### PR TITLE
Add AGI DSG deterministic runtime control layer

### DIFF
--- a/.dsg/WORK_LEDGER.md
+++ b/.dsg/WORK_LEDGER.md
@@ -1,0 +1,51 @@
+# Work Ledger
+
+## Goal Lock
+- Goal: Create the AGI / DSG deterministic runtime project in `tdealer01-crypto/dsg-one-v1` using the uploaded `dsg-deterministic-agent-runtime` skill and ordered Step 0-14 chat context.
+- Success criteria:
+  - No production claim without evidence, audit, replay, deployment proof, and production user-flow proof.
+  - No mock/localStorage/memory state is treated as production source-of-truth.
+  - Every governed action is planned, permissioned, audited, evidenced, and replay-verifiable.
+  - Thai consumer-protection and computer-crime/cyber compliance posture is enforced through truthful claim gates.
+  - Z3/SMT-style deterministic invariants are documented before implementation claims.
+- Workspace: agi
+- Actor: ChatGPT via GitHub connector
+- Input hash: `sha256:a655f744ac0da8788578236ae2d2051225e6acf91a35e2682df48063c8818d55`
+- Created at: 2026-05-03 Asia/Bangkok
+
+## Ordered Steps
+| Step | Status | Evidence | Notes |
+|---|---|---|---|
+| 0 Control docs | IMPLEMENTED | `.dsg/WORK_LEDGER.md`, `docs/AGI_DSG_RUNTIME_BUILD_PLAN.md` | Source-of-truth before code claims. |
+| 1 Shared types | BUILDABLE | `lib/dsg/runtime/claim-gate.ts` | Minimal runtime claim contract scaffold. |
+| 2 DB schema | PENDING | | Supabase source-of-truth required before backend persistence claims. |
+| 3 Core runtime libs | BUILDABLE | `lib/dsg/runtime/claim-gate.ts` | Claim gate only; full DAG/audit/replay still pending. |
+| 4 OpenAPI connector generator | PENDING | | Governed tool generation only. |
+| 5 API routes | PENDING | | Fail-closed route layer. |
+| 6 UI shell | BUILDABLE | `app/agi/page.tsx` | Static control page; no fake live state. |
+| 7 Repository layer | PENDING | | No DB write outside repository layer. |
+| 8 Planner + wave API | PENDING | | DAG and wave plan must be persisted. |
+| 9 Evidence + audit write | PENDING | | Required before completion claims. |
+| 10 Smoke + no-mock guard | BUILDABLE | `scripts/dsg-claim-gate-check.mjs` | Static guard; not production proof. |
+| 11 Auth/RBAC | PENDING | | Header roles cannot be production trust boundary. |
+| 12 Deployment + production flow proof | PENDING | | Required for deployable/production claims. |
+| 13 CI gates | BUILDABLE | `scripts/dsg-claim-gate-check.mjs` | Add to package scripts manually until repo write is available. |
+| 14 Route map + runbook | BUILDABLE | `docs/AGI_DSG_OPERATOR_RUNBOOK.md`, `docs/AGI_DSG_RUNTIME_ROUTE_MAP.md` | Control docs only. |
+
+## Evidence Index
+| Evidence ID | Type | Hash | Source |
+|---|---|---|---|
+| EVID-0001 | goal-lock | `sha256:a655f744ac0da8788578236ae2d2051225e6acf91a35e2682df48063c8818d55` | User request + uploaded skill + project chat context |
+
+## Audit Index
+| Entry ID | Action | Decision | Current Hash |
+|---|---|---|---|
+| AUD-0001 | initialize-ledger | PASS | `sha256:a655f744ac0da8788578236ae2d2051225e6acf91a35e2682df48063c8818d55` |
+| AUD-0002 | github-write-attempt | PASS | GitHub branch write restored and branch `agi-dsg-runtime-step-0-14` created |
+
+## Current Claim
+- BUILDABLE: yes
+- IMPLEMENTED: branch patch in progress
+- VERIFIED: no; no CI/test evidence has been observed in this session
+- DEPLOYABLE: no; no deployment proof has been observed in this session
+- PRODUCTION: no; no production user-flow proof has been observed in this session

--- a/app/agi/page.tsx
+++ b/app/agi/page.tsx
@@ -1,0 +1,54 @@
+import { evaluateDsgClaimGate } from '@/lib/dsg/runtime/claim-gate';
+
+const claim = evaluateDsgClaimGate({
+  hasEvidence: true,
+  hasAuditExport: false,
+  hasReplayProof: false,
+  hasAuthRbacProof: false,
+  hasDeploymentProof: false,
+  hasProductionFlowProof: false,
+  usesMockState: false,
+  isDevOrSmokeOnly: true,
+});
+
+export default function AgiDsgPage() {
+  return (
+    <main className="min-h-screen px-6 py-10">
+      <section className="mx-auto max-w-4xl space-y-6">
+        <div className="rounded-3xl border p-8">
+          <p className="text-sm uppercase tracking-widest opacity-70">AGI DSG Control Plane</p>
+          <h1 className="mt-4 text-4xl font-semibold">Deterministic runtime governance</h1>
+          <p className="mt-4 text-lg opacity-80">
+            Current page is a truthful control surface. It shows the claim gate state and does not report production readiness.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm opacity-70">Claim level</p>
+            <p className="mt-2 text-3xl font-semibold">{claim.level}</p>
+          </div>
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm opacity-70">Production claim</p>
+            <p className="mt-2 text-3xl font-semibold">Blocked</p>
+          </div>
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm opacity-70">DB source</p>
+            <p className="mt-2 text-3xl font-semibold">Pending</p>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border p-6">
+          <h2 className="text-2xl font-semibold">Active blocks</h2>
+          <ul className="mt-4 grid gap-2 md:grid-cols-2">
+            {claim.blocks.map((block) => (
+              <li key={block} className="rounded-xl border px-4 py-3 font-mono text-sm">
+                {block}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/docs/AGI_DSG_OPERATOR_RUNBOOK.md
+++ b/docs/AGI_DSG_OPERATOR_RUNBOOK.md
@@ -1,0 +1,47 @@
+# AGI DSG Operator Runbook
+
+## Operator Principle
+The operator controls the runtime. The model never claims production success by itself. Every high-risk or external mutation must be visible, permissioned, auditable, and reversible where possible.
+
+## Before Running Any AGI/DSG Flow
+1. Confirm the active workspace.
+2. Confirm authenticated actor and server-side role.
+3. Confirm the goal lock and input hash.
+4. Confirm tool registry and connector risk levels.
+5. Confirm no production claim is enabled from mock/dev/smoke data.
+
+## Stop Conditions
+Stop or block the job immediately when:
+- Evidence is missing.
+- Audit export is missing.
+- Replay proof is missing.
+- Deployment proof is missing for deployability claims.
+- Production user-flow proof is missing for production claims.
+- The runtime source-of-truth is memory, localStorage, fixture, test data, or mock data.
+- A role or permission is supplied only by client headers.
+- An external system returns inconsistent, stale, unauthorized, or unverifiable data.
+
+## Claim Decision Table
+| Situation | Allowed Claim |
+|---|---|
+| Files exist but no tests | Implemented only |
+| Tests pass but no deployment proof | Verified only |
+| Deployment URL verified but no real user flow | Deployable only |
+| Real user flow exists but no audit/replay | Blocked |
+| Evidence + audit + replay + deployment + auth/RBAC + real user flow pass | Production claim allowed |
+
+## Incident Handling
+- Record the job id, actor id, workspace id, route, tool name, risk level, decision, and evidence ids.
+- Freeze further production claims for the affected workspace.
+- Export the audit ledger.
+- Re-run replay verification.
+- Do not overwrite evidence. Append a corrective evidence item.
+
+## Local Check
+Run:
+
+```bash
+node scripts/dsg-claim-gate-check.mjs
+```
+
+This static check only verifies that required guard files exist and that the repository does not contain obvious production claims without proof markers. It is not a replacement for typecheck, tests, deployment verification, or production proof.

--- a/docs/AGI_DSG_RUNTIME_BUILD_PLAN.md
+++ b/docs/AGI_DSG_RUNTIME_BUILD_PLAN.md
@@ -1,0 +1,49 @@
+# AGI DSG Deterministic Runtime Build Plan
+
+## Purpose
+This file is the build-control document for the `agi` project inside `tdealer01-crypto/dsg-one-v1`.
+
+The system must not claim completion, deployability, or production readiness from chat text, demos, mock state, or intention. Claims are allowed only when evidence exists in the repository and can be checked by scripts, CI, audit logs, and replay proof.
+
+## Claim Levels
+| Claim | Meaning | Required Evidence |
+|---|---|---|
+| BUILDABLE | Design and file plan exist | Work ledger, route map, invariant spec |
+| IMPLEMENTED | Files exist in repo | Commit/PR contains files |
+| VERIFIED | Tests/checks pass | CI or local logs for typecheck, tests, claim gate |
+| DEPLOYABLE | Deployment proof passes | Deployment URL verification and environment proof |
+| PRODUCTION | Real production user-flow proof passes | Auth/RBAC, evidence, audit, replay, deployment, and real user-flow proof |
+
+## Non-Negotiable Gates
+- No evidence item -> completion must be blocked.
+- No audit export -> completion must be blocked.
+- No replay proof -> completion must be blocked.
+- Mock/local/memory state -> production claim must be blocked.
+- Dev/test/smoke-only environment -> production claim must be blocked.
+- Header-supplied role -> cannot be a production trust boundary.
+- External mutation -> must go through a governed executor and audit path.
+
+## Ordered Build Sequence
+1. Control docs and ledger.
+2. Shared TypeScript claim/status types.
+3. Supabase schema for runtime jobs, events, evidence, audit, replay, auth/RBAC, deployment proofs.
+4. Deterministic runtime libs: stable JSON, hash, DAG, wave plan, gate checks.
+5. OpenAPI-to-governed-tool generator.
+6. Fail-closed API routes.
+7. Control Plane UI shell that renders backend state only.
+8. Repository layer for all DB access.
+9. Planner and wave APIs.
+10. Evidence and audit write APIs.
+11. Smoke flow and no-mock guard.
+12. Server-side Auth/RBAC.
+13. Deployment evidence and production flow proof.
+14. CI gates, route map, operator runbook.
+
+## Thai Law Truthfulness Posture
+This project must avoid misleading consumer or business claims. Product pages, UI, API responses, logs, and reports must not state `production-ready`, `verified`, `secure`, `compliant`, or `deployed` unless the matching proof exists.
+
+## Z3 / SMT Deterministic Posture
+The repo includes a formal invariant draft in `formal/dsg-claim-gate-invariants.smt2`. It is a specification artifact. It is not a proof result until an SMT solver run is attached as evidence.
+
+## Current Build Boundary
+This patch is a truthful starting layer: ledger, route map, runbook, claim gate, basic UI entry, and local static claim-gate check. It does not implement the full runtime database, API executor, or production deployment proof yet.

--- a/docs/AGI_DSG_RUNTIME_ROUTE_MAP.md
+++ b/docs/AGI_DSG_RUNTIME_ROUTE_MAP.md
@@ -1,0 +1,28 @@
+# AGI DSG Runtime Route Map
+
+## Purpose
+Map intended runtime surfaces before production implementation. A route is not production-valid until it is backed by server-side auth, repository persistence, audit, evidence, and replay checks.
+
+## UI Routes
+| Route | Purpose | Current Status | Production Claim |
+|---|---|---:|---:|
+| `/agi` | AGI/DSG control overview and claim gate explanation | Static buildable page | No |
+
+## Planned API Routes
+| Route | Method | Permission | Purpose | Required Tables |
+|---|---:|---|---|---|
+| `/api/dsg/jobs` | GET/POST | `job:read`, `job:create` | list/create runtime jobs | `dsg_runtime_jobs` |
+| `/api/dsg/jobs/[jobId]` | GET | `job:read` | read job state | `dsg_runtime_jobs`, `dsg_runtime_events` |
+| `/api/dsg/jobs/[jobId]/plan` | POST | `job:plan` | create deterministic DAG/wave plan | `dsg_task_plans`, `dsg_wave_plans` |
+| `/api/dsg/jobs/[jobId]/controls` | POST | `job:control` | pause/resume/kill | `dsg_runtime_events`, `dsg_audit_ledger` |
+| `/api/dsg/jobs/[jobId]/approvals` | POST | `approval:write` | approve/reject high-risk steps | `dsg_approvals` |
+| `/api/dsg/jobs/[jobId]/evidence` | GET/POST | `evidence:read/write` | read/write evidence items | `dsg_evidence_items` |
+| `/api/dsg/jobs/[jobId]/audit/export` | POST | `audit:export` | export audit ledger | `dsg_audit_exports` |
+| `/api/dsg/jobs/[jobId]/replay` | POST | `replay:verify` | verify replay proof | `dsg_replay_proofs` |
+| `/api/dsg/jobs/[jobId]/completion` | POST | `job:complete` | claim completion only after gates pass | all proof tables |
+| `/api/dsg/connectors/openapi/import` | POST | `connector:create` | import OpenAPI as governed tools | `dsg_connectors`, `dsg_tool_registry` |
+| `/api/dsg/deployment-proofs` | POST | `deployment:write` | record deployment evidence | `dsg_deployment_proofs` |
+| `/api/dsg/production-flow-proofs` | POST | `production:write` | record real user-flow proof | `dsg_production_flow_proofs` |
+
+## Fail-Closed Rule
+Every planned API route must reject when any required context is missing: authenticated actor, workspace membership, permission, persisted job, evidence path, audit path, or replay path.

--- a/formal/dsg-claim-gate-invariants.smt2
+++ b/formal/dsg-claim-gate-invariants.smt2
@@ -1,0 +1,56 @@
+; DSG claim gate invariants
+; This is a specification artifact. It is not a solver result until a Z3/SMT run is attached as evidence.
+
+(set-logic QF_Bool)
+
+(declare-const evidence Bool)
+(declare-const auditExport Bool)
+(declare-const replayProof Bool)
+(declare-const authRbacProof Bool)
+(declare-const deploymentProof Bool)
+(declare-const productionFlowProof Bool)
+(declare-const mockState Bool)
+(declare-const devOrSmokeOnly Bool)
+
+(declare-const claimCompleted Bool)
+(declare-const claimVerified Bool)
+(declare-const claimDeployable Bool)
+(declare-const claimProduction Bool)
+
+; Completion requires evidence, audit export, and replay proof.
+(assert (= claimCompleted (and evidence auditExport replayProof)))
+
+; Verified requires completion and auth/RBAC proof.
+(assert (= claimVerified (and claimCompleted authRbacProof)))
+
+; Deployable requires verified state and deployment proof.
+(assert (= claimDeployable (and claimVerified deploymentProof)))
+
+; Production requires deployable state, real production user-flow proof, and no mock/dev-only source.
+(assert (= claimProduction (and claimDeployable productionFlowProof (not mockState) (not devOrSmokeOnly))))
+
+; Safety checks: these bad states must be unsatisfiable.
+(push)
+(assert (and claimCompleted (not evidence)))
+(check-sat)
+(pop)
+
+(push)
+(assert (and claimCompleted (not auditExport)))
+(check-sat)
+(pop)
+
+(push)
+(assert (and claimCompleted (not replayProof)))
+(check-sat)
+(pop)
+
+(push)
+(assert (and claimProduction mockState))
+(check-sat)
+(pop)
+
+(push)
+(assert (and claimProduction devOrSmokeOnly))
+(check-sat)
+(pop)

--- a/lib/dsg/runtime/claim-gate.ts
+++ b/lib/dsg/runtime/claim-gate.ts
@@ -1,0 +1,81 @@
+export type DsgClaimLevel = 'BUILDABLE' | 'IMPLEMENTED' | 'VERIFIED' | 'DEPLOYABLE' | 'PRODUCTION';
+
+export type DsgClaimGateInput = {
+  hasEvidence: boolean;
+  hasAuditExport: boolean;
+  hasReplayProof: boolean;
+  hasAuthRbacProof: boolean;
+  hasDeploymentProof: boolean;
+  hasProductionFlowProof: boolean;
+  usesMockState: boolean;
+  isDevOrSmokeOnly: boolean;
+};
+
+export type DsgClaimGateResult = {
+  allowed: boolean;
+  level: DsgClaimLevel;
+  blocks: string[];
+};
+
+const BLOCKS = {
+  evidence: 'NO_EVIDENCE',
+  audit: 'NO_AUDIT_EXPORT',
+  replay: 'NO_REPLAY_PROOF',
+  auth: 'NO_AUTH_RBAC_PROOF',
+  deployment: 'NO_DEPLOYMENT_PROOF',
+  productionFlow: 'NO_PRODUCTION_FLOW_PROOF',
+  mock: 'MOCK_STATE_BLOCKS_PRODUCTION',
+  smoke: 'DEV_OR_SMOKE_ONLY_BLOCKS_PRODUCTION',
+} as const;
+
+export function evaluateDsgClaimGate(input: DsgClaimGateInput): DsgClaimGateResult {
+  const blocks: string[] = [];
+
+  const completed = input.hasEvidence && input.hasAuditExport && input.hasReplayProof;
+  if (!input.hasEvidence) blocks.push(BLOCKS.evidence);
+  if (!input.hasAuditExport) blocks.push(BLOCKS.audit);
+  if (!input.hasReplayProof) blocks.push(BLOCKS.replay);
+
+  const verified = completed && input.hasAuthRbacProof;
+  if (!input.hasAuthRbacProof) blocks.push(BLOCKS.auth);
+
+  const deployable = verified && input.hasDeploymentProof;
+  if (!input.hasDeploymentProof) blocks.push(BLOCKS.deployment);
+
+  const production =
+    deployable &&
+    input.hasProductionFlowProof &&
+    !input.usesMockState &&
+    !input.isDevOrSmokeOnly;
+
+  if (!input.hasProductionFlowProof) blocks.push(BLOCKS.productionFlow);
+  if (input.usesMockState) blocks.push(BLOCKS.mock);
+  if (input.isDevOrSmokeOnly) blocks.push(BLOCKS.smoke);
+
+  if (production) {
+    return { allowed: true, level: 'PRODUCTION', blocks: [] };
+  }
+
+  if (deployable) {
+    return { allowed: true, level: 'DEPLOYABLE', blocks };
+  }
+
+  if (verified) {
+    return { allowed: true, level: 'VERIFIED', blocks };
+  }
+
+  if (completed) {
+    return { allowed: true, level: 'IMPLEMENTED', blocks };
+  }
+
+  return { allowed: true, level: 'BUILDABLE', blocks };
+}
+
+export function assertNoProductionClaim(input: DsgClaimGateInput): void {
+  const result = evaluateDsgClaimGate(input);
+  if (result.level === 'PRODUCTION') return;
+
+  throw new Error(
+    `Production claim blocked. Current level=${result.level}; blocks=${result.blocks.join(',')}`,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "clean": "next clean"
+    "clean": "next clean",
+    "dsg:claim-gate": "node scripts/dsg-claim-gate-check.mjs",
+    "dsg:verify": "npm run dsg:claim-gate && npm run lint"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-claim-gate-check.mjs
+++ b/scripts/dsg-claim-gate-check.mjs
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const requiredFiles = [
+  '.dsg/WORK_LEDGER.md',
+  'docs/AGI_DSG_RUNTIME_BUILD_PLAN.md',
+  'docs/AGI_DSG_RUNTIME_ROUTE_MAP.md',
+  'docs/AGI_DSG_OPERATOR_RUNBOOK.md',
+  'formal/dsg-claim-gate-invariants.smt2',
+  'lib/dsg/runtime/claim-gate.ts',
+  'app/agi/page.tsx',
+];
+
+const missing = requiredFiles.filter((file) => !existsSync(join(root, file)));
+if (missing.length > 0) {
+  console.error('DSG claim gate failed: missing files');
+  for (const file of missing) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+const ledger = readFileSync(join(root, '.dsg/WORK_LEDGER.md'), 'utf8');
+const requiredPhrases = [
+  'PRODUCTION: no',
+  'DEPLOYABLE: no',
+  'VERIFIED: no',
+  'No production claim without evidence',
+];
+
+const phraseMissing = requiredPhrases.filter((phrase) => !ledger.includes(phrase));
+if (phraseMissing.length > 0) {
+  console.error('DSG claim gate failed: ledger is missing truthful claim markers');
+  for (const phrase of phraseMissing) console.error(`- ${phrase}`);
+  process.exit(1);
+}
+
+console.log('DSG claim gate passed: guard files exist and production claim remains blocked.');


### PR DESCRIPTION
## Summary
- Add AGI/DSG work ledger and truthful claim boundary docs.
- Add route map, operator runbook, and SMT/Z3-style invariant specification.
- Add TypeScript claim gate and `/agi` control page.
- Add static claim gate check script and package scripts.

## Truthful status
- This PR does not claim production readiness.
- VERIFIED is still blocked until CI/test logs exist.
- DEPLOYABLE is still blocked until deployment proof exists.
- PRODUCTION is still blocked until auth/RBAC, evidence, audit export, replay proof, deployment proof, and real production flow proof exist.

## Files
- `.dsg/WORK_LEDGER.md`
- `docs/AGI_DSG_RUNTIME_BUILD_PLAN.md`
- `docs/AGI_DSG_RUNTIME_ROUTE_MAP.md`
- `docs/AGI_DSG_OPERATOR_RUNBOOK.md`
- `formal/dsg-claim-gate-invariants.smt2`
- `lib/dsg/runtime/claim-gate.ts`
- `app/agi/page.tsx`
- `scripts/dsg-claim-gate-check.mjs`
- `package.json`

## Checks not run by ChatGPT
No local or CI execution evidence is available in this session.