### PR TITLE
Complete DSG deterministic runtime layers 2-14

### DIFF
--- a/.github/workflows/dsg-verify.yml
+++ b/.github/workflows/dsg-verify.yml
@@ -1,0 +1,19 @@
+name: DSG Verify
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run dsg:verify

--- a/app/api/dsg/jobs/route.ts
+++ b/app/api/dsg/jobs/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+
+export async function GET(request: Request) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:read');
+  return NextResponse.json({ ok: true, data: { actor, jobs: [], source: 'database-required' } });
+}
+
+export async function POST(request: Request) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:create');
+  const body = (await request.json().catch(() => null)) as { goal?: string } | null;
+  if (!body?.goal?.trim()) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_GOAL_REQUIRED' } }, { status: 400 });
+  }
+  return NextResponse.json(
+    { ok: false, error: { code: 'DSG_REPOSITORY_NOT_CONNECTED', actor } },
+    { status: 501 },
+  );
+}

--- a/app/api/dsg/verify/route.ts
+++ b/app/api/dsg/verify/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { evaluateDsgClaimGate } from '@/lib/dsg/runtime/claim-gate';
+
+export async function GET() {
+  const claim = evaluateDsgClaimGate({
+    hasEvidence: false,
+    hasAuditExport: false,
+    hasReplayProof: false,
+    hasAuthRbacProof: false,
+    hasDeploymentProof: false,
+    hasProductionFlowProof: false,
+    usesMockState: false,
+    isDevOrSmokeOnly: true,
+  });
+
+  return NextResponse.json({ ok: true, data: { claim, production: false } });
+}

--- a/docs/DSG_STEP_2_14_COMPLETION_MAP.md
+++ b/docs/DSG_STEP_2_14_COMPLETION_MAP.md
@@ -1,0 +1,36 @@
+# DSG Step 2-14 Completion Map
+
+## Scope
+This document maps the current repository implementation to the planned DSG runtime steps. It is a route and evidence map, not a production claim.
+
+## Status by Step
+| Step | Repo Artifact | Runtime Status | Claim Boundary |
+|---|---|---|---|
+| 2 Database schema | `supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql` | Source file present; already applied to dev Supabase in operator session | Not production |
+| 2 Function hardening | `supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql` | Source file present; already applied to dev Supabase in operator session | Not production |
+| 3 Runtime core | `lib/dsg/runtime/*` | Deterministic JSON, hashing, planner, audit, evidence, replay, completion, no-mock guard | Build-time verifiable |
+| 4 OpenAPI connector | `lib/dsg/connectors/openapi.ts` | Converts OpenAPI paths into governed tool definitions | Executor still pending |
+| 5 API routes | `app/api/dsg/jobs/route.ts`, `app/api/dsg/verify/route.ts` | Fail-closed scaffold | Persistence not connected |
+| 6 UI shell | `app/agi/page.tsx` | Truthful control page | No fake live data |
+| 7 Repository layer | `lib/dsg/server/repository.ts` | Boundary exists; fails closed until Supabase client is wired | No mock persistence |
+| 8 Planner | `lib/dsg/runtime/planner.ts` | DAG + wave plan + hash | Deterministic local logic |
+| 9 Evidence/Audit | `lib/dsg/runtime/evidence.ts`, `lib/dsg/runtime/audit.ts` | Manifest and hash-chain logic | DB write routes pending |
+| 10 Smoke/no-mock | `scripts/dsg-deterministic-runtime-check.mjs`, `lib/dsg/runtime/no-mock-guard.ts` | Static guard | Smoke is not production proof |
+| 11 Auth/RBAC | `lib/dsg/server/context.ts` | Permission guard scaffold | Header actor is dev-only until server auth provider is wired |
+| 12 Deployment proof | DB tables + completion gate fields | Data model ready | No deployment proof yet |
+| 13 CI gates | `.github/workflows/dsg-verify.yml`, package scripts | CI configured | Passing CI must be observed |
+| 14 Route map/runbook | docs files | Operator map present | No production claim |
+
+## Required Commands
+```bash
+npm run dsg:claim-gate
+npm run dsg:runtime-check
+npm run dsg:typecheck
+npm run dsg:verify
+```
+
+## Current Truthful Claim
+- IMPLEMENTED: repository artifacts exist after merge.
+- VERIFIED: only after CI or local command output passes.
+- DEPLOYABLE: blocked until deployment evidence exists.
+- PRODUCTION: blocked until auth/RBAC, evidence, audit export, replay, deployment proof, and production user-flow proof all pass.

--- a/lib/dsg/connectors/openapi.ts
+++ b/lib/dsg/connectors/openapi.ts
@@ -1,0 +1,61 @@
+import { sha256Json } from '../runtime/hash';
+import type { RiskLevel } from '../runtime/types';
+
+export type OpenApiOperation = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  parameters?: unknown[];
+  requestBody?: unknown;
+};
+
+export type OpenApiDocument = {
+  openapi?: string;
+  swagger?: string;
+  info?: { title?: string; version?: string };
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+};
+
+export type GovernedTool = {
+  name: string;
+  method: string;
+  path: string;
+  description: string;
+  riskLevel: RiskLevel;
+  requiresApproval: boolean;
+  schemaHash: string;
+};
+
+const mutationMethods = new Set(['post', 'put', 'patch', 'delete']);
+
+export function classifyOperationRisk(method: string, operation: OpenApiOperation): RiskLevel {
+  const text = `${method} ${operation.operationId ?? ''} ${operation.summary ?? ''} ${operation.description ?? ''}`.toLowerCase();
+  if (text.includes('delete') || text.includes('payment') || text.includes('transfer')) return 'CRITICAL';
+  if (mutationMethods.has(method.toLowerCase())) return 'HIGH';
+  return 'MEDIUM';
+}
+
+export function openApiToGovernedTools(document: OpenApiDocument): GovernedTool[] {
+  const paths = document.paths ?? {};
+  const tools: GovernedTool[] = [];
+
+  for (const path of Object.keys(paths).sort()) {
+    const operations = paths[path];
+    for (const method of Object.keys(operations).sort()) {
+      const operation = operations[method];
+      const riskLevel = classifyOperationRisk(method, operation);
+      const name = operation.operationId ?? `${method}_${path.replace(/[^a-zA-Z0-9]+/g, '_')}`.replace(/^_+|_+$/g, '');
+      tools.push({
+        name,
+        method: method.toUpperCase(),
+        path,
+        description: operation.summary ?? operation.description ?? name,
+        riskLevel,
+        requiresApproval: riskLevel === 'HIGH' || riskLevel === 'CRITICAL',
+        schemaHash: sha256Json({ method, path, operation }),
+      });
+    }
+  }
+
+  return tools;
+}

--- a/lib/dsg/runtime/audit.ts
+++ b/lib/dsg/runtime/audit.ts
@@ -1,0 +1,73 @@
+import { sha256Json } from './hash';
+import type { GateStatus } from './types';
+
+export type AuditLedgerEntry = {
+  id: string;
+  previousHash?: string;
+  currentHash: string;
+  actorId: string;
+  action: string;
+  decision: GateStatus;
+  evidenceIds: string[];
+  payload: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type CreateAuditLedgerEntryInput = {
+  id: string;
+  previousHash?: string;
+  actorId: string;
+  action: string;
+  decision: GateStatus;
+  evidenceIds?: string[];
+  payload?: Record<string, unknown>;
+  createdAt?: string;
+};
+
+export function createAuditLedgerEntry(input: CreateAuditLedgerEntryInput): AuditLedgerEntry {
+  const entryWithoutHash = {
+    id: input.id,
+    previousHash: input.previousHash,
+    actorId: input.actorId,
+    action: input.action,
+    decision: input.decision,
+    evidenceIds: [...(input.evidenceIds ?? [])].sort(),
+    payload: input.payload ?? {},
+    createdAt: input.createdAt ?? new Date(0).toISOString(),
+  };
+
+  return {
+    ...entryWithoutHash,
+    currentHash: sha256Json(entryWithoutHash),
+  };
+}
+
+export function verifyAuditHashChain(entries: AuditLedgerEntry[]): { ok: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const sorted = [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+
+  for (let index = 0; index < sorted.length; index += 1) {
+    const entry = sorted[index];
+    const expectedPrevious = index === 0 ? undefined : sorted[index - 1].currentHash;
+    if (entry.previousHash !== expectedPrevious) {
+      errors.push(`AUDIT_PREVIOUS_HASH_MISMATCH:${entry.id}`);
+    }
+
+    const recomputed = createAuditLedgerEntry({
+      id: entry.id,
+      previousHash: entry.previousHash,
+      actorId: entry.actorId,
+      action: entry.action,
+      decision: entry.decision,
+      evidenceIds: entry.evidenceIds,
+      payload: entry.payload,
+      createdAt: entry.createdAt,
+    });
+
+    if (recomputed.currentHash !== entry.currentHash) {
+      errors.push(`AUDIT_CURRENT_HASH_MISMATCH:${entry.id}`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/lib/dsg/runtime/completion.ts
+++ b/lib/dsg/runtime/completion.ts
@@ -1,0 +1,40 @@
+import { sha256Json } from './hash';
+import type { DsgClaimGateInput, DsgClaimGateResult } from './claim-gate';
+import { evaluateDsgClaimGate } from './claim-gate';
+
+export type CompletionReport = {
+  id: string;
+  claim: DsgClaimGateResult;
+  reportHash: string;
+  evidenceManifestId?: string;
+  auditExportId?: string;
+  replayProofId?: string;
+  deploymentProofId?: string;
+  productionFlowProofId?: string;
+  createdAt: string;
+};
+
+export function createCompletionReport(input: {
+  id: string;
+  gate: DsgClaimGateInput;
+  evidenceManifestId?: string;
+  auditExportId?: string;
+  replayProofId?: string;
+  deploymentProofId?: string;
+  productionFlowProofId?: string;
+  createdAt?: string;
+}): CompletionReport {
+  const claim = evaluateDsgClaimGate(input.gate);
+  const createdAt = input.createdAt ?? new Date(0).toISOString();
+  const payload = {
+    id: input.id,
+    claim,
+    evidenceManifestId: input.evidenceManifestId,
+    auditExportId: input.auditExportId,
+    replayProofId: input.replayProofId,
+    deploymentProofId: input.deploymentProofId,
+    productionFlowProofId: input.productionFlowProofId,
+    createdAt,
+  };
+  return { ...payload, reportHash: sha256Json(payload) };
+}

--- a/lib/dsg/runtime/evidence.ts
+++ b/lib/dsg/runtime/evidence.ts
@@ -1,0 +1,35 @@
+import { sha256Json } from './hash';
+import type { EvidenceItem } from './types';
+
+export type EvidenceManifest = {
+  id: string;
+  evidenceIds: string[];
+  manifestHash: string;
+  status: 'DRAFT' | 'COMPLETE' | 'BLOCKED';
+  createdBy: string;
+  createdAt: string;
+};
+
+export function createEvidenceManifest(input: {
+  id: string;
+  evidence: EvidenceItem[];
+  createdBy: string;
+  createdAt?: string;
+}): EvidenceManifest {
+  const evidenceIds = input.evidence.map((item) => item.id).sort();
+  const contentHashes = input.evidence.map((item) => item.contentHash).sort();
+  const allHashesValid = contentHashes.every((hash) => /^sha256:[a-f0-9]{64}$/.test(hash));
+
+  return {
+    id: input.id,
+    evidenceIds,
+    status: input.evidence.length > 0 && allHashesValid ? 'COMPLETE' : 'BLOCKED',
+    createdBy: input.createdBy,
+    createdAt: input.createdAt ?? new Date(0).toISOString(),
+    manifestHash: sha256Json({ evidenceIds, contentHashes }),
+  };
+}
+
+export function isEvidenceComplete(manifest: EvidenceManifest): boolean {
+  return manifest.status === 'COMPLETE' && manifest.evidenceIds.length > 0;
+}

--- a/lib/dsg/runtime/hash.ts
+++ b/lib/dsg/runtime/hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto';
+import { stableJsonStringify } from './stable-json';
+
+export function sha256Text(input: string): string {
+  return `sha256:${createHash('sha256').update(input, 'utf8').digest('hex')}`;
+}
+
+export function sha256Json(input: unknown): string {
+  return sha256Text(stableJsonStringify(input));
+}
+
+export function assertHash(value: string): void {
+  if (!/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw new Error(`Invalid DSG hash: ${value}`);
+  }
+}

--- a/lib/dsg/runtime/no-mock-guard.ts
+++ b/lib/dsg/runtime/no-mock-guard.ts
@@ -1,0 +1,15 @@
+export type NoMockGuardInput = {
+  environment: 'development' | 'test' | 'preview' | 'production';
+  sourceOfTruth: 'database' | 'external_verified' | 'memory' | 'localStorage' | 'fixture' | 'mock';
+  hasDeploymentProof: boolean;
+  hasProductionFlowProof: boolean;
+};
+
+export function checkNoMockProductionGuard(input: NoMockGuardInput): { ok: boolean; blocks: string[] } {
+  const blocks: string[] = [];
+  if (input.environment !== 'production') blocks.push('ENVIRONMENT_NOT_PRODUCTION');
+  if (['memory', 'localStorage', 'fixture', 'mock'].includes(input.sourceOfTruth)) blocks.push('SOURCE_OF_TRUTH_NOT_REAL');
+  if (!input.hasDeploymentProof) blocks.push('NO_DEPLOYMENT_PROOF');
+  if (!input.hasProductionFlowProof) blocks.push('NO_PRODUCTION_FLOW_PROOF');
+  return { ok: blocks.length === 0, blocks };
+}

--- a/lib/dsg/runtime/planner.ts
+++ b/lib/dsg/runtime/planner.ts
@@ -1,0 +1,88 @@
+import { sha256Json } from './hash';
+import type { RiskLevel, RuntimeDependencyEdge, RuntimePlan, RuntimeTask, RuntimeWave } from './types';
+
+const riskRank: Record<RiskLevel, number> = { LOW: 0, MEDIUM: 1, HIGH: 2, CRITICAL: 3 };
+const riskOrder: RiskLevel[] = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+
+function maxRisk(tasks: RuntimeTask[]): RiskLevel {
+  return tasks.reduce<RiskLevel>((highest, task) =>
+    riskRank[task.riskLevel] > riskRank[highest] ? task.riskLevel : highest,
+  'LOW');
+}
+
+export function buildDependencyEdges(tasks: RuntimeTask[]): RuntimeDependencyEdge[] {
+  const ids = new Set(tasks.map((task) => task.id));
+  const edges: RuntimeDependencyEdge[] = [];
+  for (const task of tasks) {
+    for (const dependency of task.dependsOn) {
+      if (!ids.has(dependency)) throw new Error(`Unknown dependency ${dependency} for task ${task.id}`);
+      if (dependency === task.id) throw new Error(`Task ${task.id} cannot depend on itself`);
+      edges.push({ from: dependency, to: task.id });
+    }
+  }
+  return edges.sort((a, b) => `${a.from}:${a.to}`.localeCompare(`${b.from}:${b.to}`));
+}
+
+export function buildWaves(tasks: RuntimeTask[]): RuntimeWave[] {
+  const byId = new Map(tasks.map((task) => [task.id, task] as const));
+  const remaining = new Set(byId.keys());
+  const completed = new Set<string>();
+  const waves: RuntimeWave[] = [];
+
+  while (remaining.size > 0) {
+    const ready = [...remaining]
+      .map((id) => byId.get(id)!)
+      .filter((task) => task.dependsOn.every((dependency) => completed.has(dependency)))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    if (ready.length === 0) throw new Error('Dependency cycle detected');
+
+    const waveRisk = maxRisk(ready);
+    waves.push({
+      id: `wave-${waves.length + 1}`,
+      index: waves.length,
+      taskIds: ready.map((task) => task.id),
+      riskLevel: waveRisk,
+      requiresApproval: ready.some((task) => task.requiresApproval || riskRank[task.riskLevel] >= riskRank.HIGH),
+    });
+
+    for (const task of ready) {
+      completed.add(task.id);
+      remaining.delete(task.id);
+    }
+  }
+
+  return waves;
+}
+
+export function createRuntimePlan(tasks: RuntimeTask[]): RuntimePlan {
+  if (tasks.length === 0) throw new Error('Cannot create plan without tasks');
+  const ids = new Set<string>();
+  for (const task of tasks) {
+    if (!task.id.trim()) throw new Error('Task id is required');
+    if (ids.has(task.id)) throw new Error(`Duplicate task id ${task.id}`);
+    ids.add(task.id);
+  }
+
+  const normalizedTasks = tasks
+    .map((task) => ({ ...task, dependsOn: [...task.dependsOn].sort() }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const edges = buildDependencyEdges(normalizedTasks);
+  const waves = buildWaves(normalizedTasks);
+
+  return {
+    tasks: normalizedTasks,
+    edges,
+    waves,
+    planHash: sha256Json({ tasks: normalizedTasks, edges }),
+    waveHash: sha256Json({ waves }),
+  };
+}
+
+export function compareRisk(a: RiskLevel, b: RiskLevel): number {
+  return riskRank[a] - riskRank[b];
+}
+
+export function riskFromRank(rank: number): RiskLevel {
+  return riskOrder[Math.max(0, Math.min(rank, riskOrder.length - 1))];
+}

--- a/lib/dsg/runtime/replay.ts
+++ b/lib/dsg/runtime/replay.ts
@@ -1,0 +1,34 @@
+import { sha256Json } from './hash';
+import { verifyAuditHashChain, type AuditLedgerEntry } from './audit';
+import { isEvidenceComplete, type EvidenceManifest } from './evidence';
+
+export type ReplayProof = {
+  replayHash: string;
+  status: 'PASS' | 'BLOCK' | 'FAILED';
+  errors: string[];
+};
+
+export function verifyReplay(input: {
+  planHash: string;
+  waveHash: string;
+  evidenceManifest: EvidenceManifest;
+  auditEntries: AuditLedgerEntry[];
+}): ReplayProof {
+  const errors: string[] = [];
+  const audit = verifyAuditHashChain(input.auditEntries);
+  if (!audit.ok) errors.push(...audit.errors);
+  if (!isEvidenceComplete(input.evidenceManifest)) errors.push('EVIDENCE_MANIFEST_INCOMPLETE');
+  if (!input.planHash.startsWith('sha256:')) errors.push('PLAN_HASH_INVALID');
+  if (!input.waveHash.startsWith('sha256:')) errors.push('WAVE_HASH_INVALID');
+
+  return {
+    replayHash: sha256Json({
+      planHash: input.planHash,
+      waveHash: input.waveHash,
+      manifestHash: input.evidenceManifest.manifestHash,
+      auditHashes: input.auditEntries.map((entry) => entry.currentHash),
+    }),
+    status: errors.length === 0 ? 'PASS' : 'BLOCK',
+    errors,
+  };
+}

--- a/lib/dsg/runtime/stable-json.ts
+++ b/lib/dsg/runtime/stable-json.ts
@@ -1,0 +1,23 @@
+export function normalizeForStableJson(value: unknown): unknown {
+  if (value === null) return null;
+  if (Array.isArray(value)) return value.map((item) => normalizeForStableJson(item));
+  if (typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(input).sort()) {
+      const item = input[key];
+      if (typeof item !== 'undefined') output[key] = normalizeForStableJson(item);
+    }
+    return output;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Non-finite numbers cannot be encoded deterministically');
+    return value;
+  }
+  if (typeof value === 'bigint') return value.toString();
+  return value;
+}
+
+export function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStableJson(value));
+}

--- a/lib/dsg/runtime/types.ts
+++ b/lib/dsg/runtime/types.ts
@@ -1,0 +1,57 @@
+export type RuntimeJobStatus =
+  | 'QUEUED'
+  | 'GOAL_LOCKED'
+  | 'INSPECTING'
+  | 'PLANNING'
+  | 'WAITING_PERMISSION'
+  | 'WAITING_APPROVAL'
+  | 'RUNNING'
+  | 'VERIFYING'
+  | 'PASSED'
+  | 'BLOCKED'
+  | 'FAILED'
+  | 'KILLED'
+  | 'COMPLETED'
+  | 'RESET';
+
+export type GateStatus = 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
+export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export type RuntimeTask = {
+  id: string;
+  title: string;
+  dependsOn: string[];
+  riskLevel: RiskLevel;
+  toolName?: string;
+  requiresApproval?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+export type RuntimeDependencyEdge = {
+  from: string;
+  to: string;
+};
+
+export type RuntimeWave = {
+  id: string;
+  index: number;
+  taskIds: string[];
+  riskLevel: RiskLevel;
+  requiresApproval: boolean;
+};
+
+export type RuntimePlan = {
+  tasks: RuntimeTask[];
+  edges: RuntimeDependencyEdge[];
+  waves: RuntimeWave[];
+  planHash: string;
+  waveHash: string;
+};
+
+export type EvidenceItem = {
+  id: string;
+  evidenceType: string;
+  contentHash: string;
+  summary: string;
+  uri?: string;
+};

--- a/lib/dsg/server/context.ts
+++ b/lib/dsg/server/context.ts
@@ -1,0 +1,41 @@
+export type DsgServerActor = {
+  actorId: string;
+  workspaceId: string;
+  role: 'OWNER' | 'ADMIN' | 'OPERATOR' | 'AUDITOR' | 'VIEWER';
+};
+
+export type DsgPermission =
+  | 'job:read'
+  | 'job:create'
+  | 'job:plan'
+  | 'job:control'
+  | 'approval:write'
+  | 'evidence:write'
+  | 'audit:export'
+  | 'replay:verify'
+  | 'deployment:write'
+  | 'production:write';
+
+const permissionsByRole: Record<DsgServerActor['role'], DsgPermission[]> = {
+  OWNER: ['job:read', 'job:create', 'job:plan', 'job:control', 'approval:write', 'evidence:write', 'audit:export', 'replay:verify', 'deployment:write', 'production:write'],
+  ADMIN: ['job:read', 'job:create', 'job:plan', 'job:control', 'approval:write', 'evidence:write', 'audit:export', 'replay:verify', 'deployment:write'],
+  OPERATOR: ['job:read', 'job:create', 'job:plan', 'job:control', 'approval:write', 'evidence:write', 'replay:verify'],
+  AUDITOR: ['job:read', 'audit:export', 'replay:verify'],
+  VIEWER: ['job:read'],
+};
+
+export function assertDsgPermission(actor: DsgServerActor | null, permission: DsgPermission): DsgServerActor {
+  if (!actor) throw new Error('DSG_AUTH_REQUIRED');
+  if (!actor.actorId || !actor.workspaceId) throw new Error('DSG_CONTEXT_REQUIRED');
+  if (!permissionsByRole[actor.role]?.includes(permission)) throw new Error('DSG_PERMISSION_DENIED');
+  return actor;
+}
+
+export function devHeaderActor(headers: Headers): DsgServerActor | null {
+  const actorId = headers.get('x-dsg-actor-id');
+  const workspaceId = headers.get('x-dsg-workspace-id');
+  const role = headers.get('x-dsg-actor-role') as DsgServerActor['role'] | null;
+  if (!actorId || !workspaceId || !role) return null;
+  if (!Object.prototype.hasOwnProperty.call(permissionsByRole, role)) return null;
+  return { actorId, workspaceId, role };
+}

--- a/lib/dsg/server/repository.ts
+++ b/lib/dsg/server/repository.ts
@@ -1,0 +1,41 @@
+import type { RuntimeTask } from '../runtime/types';
+
+export type DsgRepositoryContext = {
+  workspaceId: string;
+  actorId: string;
+};
+
+export type DsgRuntimeJobRecord = {
+  id: string;
+  workspaceId: string;
+  goal: string;
+  status: string;
+  createdBy: string;
+  createdAt: string;
+};
+
+const repositoryNotice = 'DSG_REPOSITORY_REQUIRES_SUPABASE_CLIENT';
+
+export function assertRepositoryContext(context: DsgRepositoryContext): void {
+  if (!context.workspaceId) throw new Error('DSG_WORKSPACE_REQUIRED');
+  if (!context.actorId) throw new Error('DSG_ACTOR_REQUIRED');
+}
+
+export async function createRuntimeJob(context: DsgRepositoryContext, input: { goal: string }): Promise<DsgRuntimeJobRecord> {
+  assertRepositoryContext(context);
+  if (!input.goal.trim()) throw new Error('DSG_GOAL_REQUIRED');
+  throw new Error(repositoryNotice);
+}
+
+export async function createRuntimePlan(context: DsgRepositoryContext, input: { jobId: string; tasks: RuntimeTask[] }): Promise<never> {
+  assertRepositoryContext(context);
+  if (!input.jobId) throw new Error('DSG_JOB_REQUIRED');
+  if (input.tasks.length === 0) throw new Error('DSG_TASKS_REQUIRED');
+  throw new Error(repositoryNotice);
+}
+
+export async function writeEvidence(context: DsgRepositoryContext, input: { jobId: string; contentHash: string; summary: string }): Promise<never> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.contentHash || !input.summary) throw new Error('DSG_EVIDENCE_REQUIRED');
+  throw new Error(repositoryNotice);
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "clean": "next clean",
     "dsg:claim-gate": "node scripts/dsg-claim-gate-check.mjs",
-    "dsg:verify": "npm run dsg:claim-gate && npm run lint"
+    "dsg:runtime-check": "node scripts/dsg-deterministic-runtime-check.mjs",
+    "dsg:typecheck": "tsc --noEmit",
+    "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const required = [
+  'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql',
+  'supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql',
+  'lib/dsg/runtime/stable-json.ts',
+  'lib/dsg/runtime/hash.ts',
+  'lib/dsg/runtime/planner.ts',
+  'lib/dsg/runtime/audit.ts',
+  'lib/dsg/runtime/evidence.ts',
+  'lib/dsg/runtime/replay.ts',
+  'lib/dsg/runtime/completion.ts',
+  'lib/dsg/runtime/no-mock-guard.ts',
+  'lib/dsg/connectors/openapi.ts',
+  'lib/dsg/server/context.ts',
+  'lib/dsg/server/repository.ts',
+  'app/api/dsg/jobs/route.ts',
+  'app/api/dsg/verify/route.ts',
+];
+
+const missing = required.filter((file) => !existsSync(join(root, file)));
+if (missing.length) {
+  console.error('DSG deterministic runtime check failed: missing files');
+  for (const file of missing) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+const migration = readFileSync(join(root, 'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql'), 'utf8');
+const tables = [
+  'dsg_runtime_jobs',
+  'dsg_task_plans',
+  'dsg_wave_plans',
+  'dsg_evidence_items',
+  'dsg_audit_ledger',
+  'dsg_replay_proofs',
+  'dsg_completion_reports',
+  'dsg_deployment_proofs',
+  'dsg_production_flow_proofs',
+];
+
+for (const table of tables) {
+  if (!migration.includes(table)) {
+    console.error(`DSG deterministic runtime check failed: migration missing ${table}`);
+    process.exit(1);
+  }
+}
+
+const combined = required.map((file) => readFileSync(join(root, file), 'utf8')).join('\n---DSG---\n');
+const digest = createHash('sha256').update(combined, 'utf8').digest('hex');
+console.log(`DSG deterministic runtime check passed sha256:${digest}`);

--- a/supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql
+++ b/supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql
@@ -1,0 +1,256 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.dsg_workspaces (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists public.dsg_workspace_members (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  actor_id text not null,
+  role text not null check (role in ('OWNER','ADMIN','OPERATOR','AUDITOR','VIEWER')),
+  created_at timestamptz not null default now(),
+  unique (workspace_id, actor_id)
+);
+
+create table if not exists public.dsg_runtime_jobs (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  goal text not null,
+  success_criteria jsonb not null default '[]'::jsonb,
+  status text not null default 'QUEUED' check (status in ('QUEUED','GOAL_LOCKED','INSPECTING','PLANNING','WAITING_PERMISSION','WAITING_APPROVAL','RUNNING','VERIFYING','PASSED','BLOCKED','FAILED','KILLED','COMPLETED','RESET')),
+  risk_level text not null default 'LOW' check (risk_level in ('LOW','MEDIUM','HIGH','CRITICAL')),
+  current_wave_id text,
+  current_step_id text,
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  input_lock_id uuid,
+  completion_report_id uuid,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists public.dsg_input_locks (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  input_hash text not null,
+  canonical_input jsonb not null,
+  locked_by text not null,
+  created_at timestamptz not null default now(),
+  unique (job_id)
+);
+
+create table if not exists public.dsg_task_plans (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  plan_hash text not null,
+  tasks jsonb not null default '[]'::jsonb,
+  dependency_edges jsonb not null default '[]'::jsonb,
+  status text not null default 'DRAFT' check (status in ('DRAFT','READY','BLOCKED','APPROVED','REJECTED')),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  unique (job_id, plan_hash)
+);
+
+create table if not exists public.dsg_wave_plans (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  task_plan_id uuid not null references public.dsg_task_plans(id) on delete cascade,
+  wave_hash text not null,
+  waves jsonb not null default '[]'::jsonb,
+  current_wave_index integer not null default 0,
+  status text not null default 'READY' check (status in ('READY','RUNNING','BLOCKED','PASSED','FAILED')),
+  created_at timestamptz not null default now(),
+  unique (job_id, wave_hash)
+);
+
+create table if not exists public.dsg_runtime_events (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  event_type text not null,
+  message text not null,
+  actor_id text not null,
+  risk_level text not null default 'LOW' check (risk_level in ('LOW','MEDIUM','HIGH','CRITICAL')),
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dsg_approvals (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  step_id text not null,
+  requested_by text not null,
+  decided_by text,
+  decision text not null default 'PENDING' check (decision in ('PENDING','APPROVED','REJECTED','EXPIRED')),
+  reason text,
+  created_at timestamptz not null default now(),
+  decided_at timestamptz
+);
+
+create table if not exists public.dsg_evidence_items (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  evidence_type text not null,
+  uri text,
+  content_hash text not null,
+  summary text not null,
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (job_id, content_hash)
+);
+
+create table if not exists public.dsg_evidence_manifests (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  manifest_hash text not null,
+  evidence_ids uuid[] not null default array[]::uuid[],
+  status text not null default 'DRAFT' check (status in ('DRAFT','COMPLETE','BLOCKED')),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  unique (job_id, manifest_hash)
+);
+
+create table if not exists public.dsg_audit_ledger (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.dsg_runtime_jobs(id) on delete set null,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  actor_id text not null,
+  action text not null,
+  decision text not null check (decision in ('PASS','BLOCK','REVIEW','UNSUPPORTED')),
+  previous_hash text,
+  current_hash text not null,
+  evidence_ids uuid[] not null default array[]::uuid[],
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (workspace_id, current_hash)
+);
+
+create table if not exists public.dsg_audit_exports (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  export_hash text not null,
+  ledger_entry_ids uuid[] not null default array[]::uuid[],
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  unique (job_id, export_hash)
+);
+
+create table if not exists public.dsg_replay_proofs (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  replay_hash text not null,
+  status text not null check (status in ('PASS','BLOCK','FAILED')),
+  checked_by text not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (job_id, replay_hash)
+);
+
+create table if not exists public.dsg_completion_reports (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null unique references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  claim_status text not null check (claim_status in ('BUILDABLE','IMPLEMENTED','VERIFIED','DEPLOYABLE','PRODUCTION','BLOCKED')),
+  evidence_manifest_id uuid references public.dsg_evidence_manifests(id) on delete restrict,
+  audit_export_id uuid references public.dsg_audit_exports(id) on delete restrict,
+  replay_proof_id uuid references public.dsg_replay_proofs(id) on delete restrict,
+  block_reasons text[] not null default array[]::text[],
+  report_hash text not null,
+  created_by text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dsg_connectors (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  provider text not null,
+  name text not null,
+  risk_level text not null default 'MEDIUM' check (risk_level in ('LOW','MEDIUM','HIGH','CRITICAL')),
+  auth_type text not null default 'NONE',
+  config jsonb not null default '{}'::jsonb,
+  active boolean not null default false,
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.dsg_tool_registry (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  connector_id uuid references public.dsg_connectors(id) on delete cascade,
+  tool_name text not null,
+  description text not null,
+  method text,
+  path text,
+  risk_level text not null default 'MEDIUM' check (risk_level in ('LOW','MEDIUM','HIGH','CRITICAL')),
+  requires_approval boolean not null default true,
+  schema jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (workspace_id, tool_name)
+);
+
+create table if not exists public.dsg_deployment_proofs (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  environment text not null,
+  deployment_url text not null,
+  proof_hash text not null,
+  status text not null check (status in ('PASS','BLOCK','FAILED')),
+  checked_by text not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dsg_production_flow_proofs (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.dsg_runtime_jobs(id) on delete cascade,
+  workspace_id uuid not null references public.dsg_workspaces(id) on delete cascade,
+  flow_name text not null,
+  proof_hash text not null,
+  status text not null check (status in ('PASS','BLOCK','FAILED')),
+  checked_by text not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_dsg_runtime_jobs_workspace on public.dsg_runtime_jobs(workspace_id, created_at desc);
+create index if not exists idx_dsg_runtime_events_job on public.dsg_runtime_events(job_id, created_at desc);
+create index if not exists idx_dsg_audit_ledger_workspace on public.dsg_audit_ledger(workspace_id, created_at desc);
+create index if not exists idx_dsg_evidence_items_job on public.dsg_evidence_items(job_id, created_at desc);
+create index if not exists idx_dsg_tool_registry_workspace on public.dsg_tool_registry(workspace_id, tool_name);
+
+alter table public.dsg_workspaces enable row level security;
+alter table public.dsg_workspace_members enable row level security;
+alter table public.dsg_runtime_jobs enable row level security;
+alter table public.dsg_input_locks enable row level security;
+alter table public.dsg_task_plans enable row level security;
+alter table public.dsg_wave_plans enable row level security;
+alter table public.dsg_runtime_events enable row level security;
+alter table public.dsg_approvals enable row level security;
+alter table public.dsg_evidence_items enable row level security;
+alter table public.dsg_evidence_manifests enable row level security;
+alter table public.dsg_audit_ledger enable row level security;
+alter table public.dsg_audit_exports enable row level security;
+alter table public.dsg_replay_proofs enable row level security;
+alter table public.dsg_completion_reports enable row level security;
+alter table public.dsg_connectors enable row level security;
+alter table public.dsg_tool_registry enable row level security;
+alter table public.dsg_deployment_proofs enable row level security;
+alter table public.dsg_production_flow_proofs enable row level security;

--- a/supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql
+++ b/supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql
@@ -1,0 +1,62 @@
+create or replace function public.dsg_touch_updated_at()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create or replace function public.dsg_current_actor_id()
+returns text
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  select coalesce(auth.uid()::text, current_setting('request.jwt.claim.sub', true), current_setting('request.jwt.claims', true)::jsonb->>'sub')
+$$;
+
+create or replace function public.dsg_is_workspace_member(target_workspace_id uuid)
+returns boolean
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.dsg_workspace_members m
+    where m.workspace_id = target_workspace_id
+      and m.actor_id = public.dsg_current_actor_id()
+  )
+$$;
+
+create or replace function public.dsg_compute_audit_hash(
+  previous_hash text,
+  actor_id text,
+  action text,
+  decision text,
+  payload jsonb
+)
+returns text
+language sql
+immutable
+set search_path = public, extensions, pg_temp
+as $$
+  select 'sha256:' || encode(digest(coalesce(previous_hash, '') || '|' || actor_id || '|' || action || '|' || decision || '|' || payload::text, 'sha256'), 'hex')
+$$;
+
+revoke execute on function public.dsg_touch_updated_at() from anon, authenticated;
+revoke execute on function public.dsg_current_actor_id() from anon;
+revoke execute on function public.dsg_is_workspace_member(uuid) from anon;
+revoke execute on function public.dsg_compute_audit_hash(text, text, text, text, jsonb) from anon;
+
+drop trigger if exists trg_dsg_workspaces_touch on public.dsg_workspaces;
+create trigger trg_dsg_workspaces_touch before update on public.dsg_workspaces for each row execute function public.dsg_touch_updated_at();
+
+drop trigger if exists trg_dsg_runtime_jobs_touch on public.dsg_runtime_jobs;
+create trigger trg_dsg_runtime_jobs_touch before update on public.dsg_runtime_jobs for each row execute function public.dsg_touch_updated_at();
+
+drop trigger if exists trg_dsg_connectors_touch on public.dsg_connectors;
+create trigger trg_dsg_connectors_touch before update on public.dsg_connectors for each row execute function public.dsg_touch_updated_at();


### PR DESCRIPTION
## Summary
- Add Supabase migration source files for DSG runtime tables and function hardening.
- Add deterministic runtime core: stable JSON, SHA-256 hashing, DAG/wave planner, audit hash chain, evidence manifest, replay verifier, completion report, no-mock guard.
- Add OpenAPI governed tool scaffold.
- Add server permission guard and repository boundary scaffold.
- Add fail-closed DSG API route scaffolds.
- Add deterministic runtime verification script, package scripts, and GitHub Actions workflow.
- Add Step 2-14 completion map.

## Truthful status
- Step 2 schema was applied in Supabase dev project `dsg-control-plane-dev` during the operator session.
- This PR adds source artifacts for Steps 2-14, but does not claim production readiness.
- Repository persistence is intentionally fail-closed until Supabase client wiring is added.
- Header actor context remains dev-only until server-side auth/RBAC provider is wired.
- Production remains blocked until evidence, audit export, replay proof, deployment proof, auth/RBAC proof, and production user-flow proof exist.

## Checks expected
- `npm run dsg:claim-gate`
- `npm run dsg:runtime-check`
- `npm run dsg:typecheck`
- `npm run lint`
- `npm run dsg:verify`

## Notes
CI evidence is required before calling this VERIFIED. Deployment and production claims remain blocked.