### PR TITLE
Wire DSG backend routes to Supabase RPC

### DIFF
--- a/app/api/dsg/jobs/[jobId]/evidence/route.ts
+++ b/app/api/dsg/jobs/[jobId]/evidence/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { writeEvidence } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'evidence:write');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    evidenceType?: string;
+    contentHash?: string;
+    summary?: string;
+    uri?: string;
+    metadata?: Record<string, unknown>;
+  } | null;
+
+  if (!body?.evidenceType || !body.contentHash || !body.summary) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_EVIDENCE_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await writeEvidence(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      {
+        jobId,
+        evidenceType: body.evidenceType,
+        contentHash: body.contentHash,
+        summary: body.summary,
+        uri: body.uri,
+        metadata: body.metadata,
+      },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_WRITE_EVIDENCE_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/[jobId]/replay/route.ts
+++ b/app/api/dsg/jobs/[jobId]/replay/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { recordReplayProof } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'replay:verify');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    replayHash?: string;
+    status?: 'PASS' | 'BLOCK' | 'FAILED';
+    details?: Record<string, unknown>;
+  } | null;
+
+  if (!body?.replayHash || !body.status) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_REPLAY_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await recordReplayProof(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { jobId, replayHash: body.replayHash, status: body.status, details: body.details },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_RECORD_REPLAY_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/route.ts
+++ b/app/api/dsg/jobs/route.ts
@@ -1,19 +1,30 @@
 import { NextResponse } from 'next/server';
 import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { createRuntimeJob } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function GET(request: Request) {
   const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:read');
-  return NextResponse.json({ ok: true, data: { actor, jobs: [], source: 'database-required' } });
+  return NextResponse.json({ ok: true, data: { actor, jobs: [], source: 'database-read-route-pending' } });
 }
 
 export async function POST(request: Request) {
   const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:create');
-  const body = (await request.json().catch(() => null)) as { goal?: string } | null;
+  const body = (await request.json().catch(() => null)) as { goal?: string; successCriteria?: unknown[] } | null;
   if (!body?.goal?.trim()) {
     return NextResponse.json({ ok: false, error: { code: 'DSG_GOAL_REQUIRED' } }, { status: 400 });
   }
-  return NextResponse.json(
-    { ok: false, error: { code: 'DSG_REPOSITORY_NOT_CONNECTED', actor } },
-    { status: 501 },
-  );
+
+  try {
+    const data = await createRuntimeJob(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { goal: body.goal, successCriteria: body.successCriteria },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_CREATE_JOB_FAILED' } },
+      { status: 403 },
+    );
+  }
 }

--- a/app/api/dsg/workspaces/route.ts
+++ b/app/api/dsg/workspaces/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { devHeaderActor } from '@/lib/dsg/server/context';
+import { createWorkspace } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request) {
+  const actor = devHeaderActor(request.headers);
+  if (!actor?.actorId) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_AUTH_REQUIRED' } }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { name?: string; slug?: string } | null;
+  if (!body?.name?.trim() || !body.slug?.trim()) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_WORKSPACE_INPUT_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const id = await createWorkspace(
+      { actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { name: body.name, slug: body.slug },
+    );
+    return NextResponse.json({ ok: true, data: { id } }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_CREATE_WORKSPACE_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/docs/DSG_SUPABASE_BACKEND_WIRING.md
+++ b/docs/DSG_SUPABASE_BACKEND_WIRING.md
@@ -1,0 +1,35 @@
+# DSG Supabase Backend Wiring
+
+## Purpose
+This document lists the runtime environment variables and backend routes needed for the DSG backend to call Supabase RPC as the database source-of-truth.
+
+## Required server environment
+Do not expose service-role values to the browser.
+
+```bash
+DSG_SUPABASE_URL=https://<project-ref>.supabase.co
+DSG_SUPABASE_SERVICE_ROLE_KEY=<server-only-service-role-key>
+```
+
+The API caller must also provide a real user access token:
+
+```http
+Authorization: Bearer <supabase-user-jwt>
+x-dsg-actor-id: <auth-user-id>
+x-dsg-workspace-id: <workspace-uuid>
+x-dsg-actor-role: OWNER|ADMIN|OPERATOR|AUDITOR|VIEWER
+```
+
+Header role is still a dev bridge. Production must replace this with server-verified auth/RBAC context.
+
+## Wired routes
+| Route | Method | RPC | Status |
+|---|---:|---|---|
+| `/api/dsg/workspaces` | POST | `dsg_create_workspace` | wired |
+| `/api/dsg/jobs` | POST | `dsg_create_runtime_job` | wired |
+| `/api/dsg/jobs/[jobId]/evidence` | POST | `dsg_record_evidence` | wired |
+| `/api/dsg/jobs/[jobId]/replay` | POST | `dsg_record_replay_proof` | wired |
+| `/api/dsg/jobs` | GET | none | pending database list query |
+
+## Truth boundary
+This wiring moves write paths from scaffold to Supabase RPC. It still does not prove production readiness. Production remains blocked until server-side auth provider verification, audit export, replay verification, deployment proof, and production user-flow proof exist.

--- a/lib/dsg/server/repository.ts
+++ b/lib/dsg/server/repository.ts
@@ -1,8 +1,10 @@
 import type { RuntimeTask } from '../runtime/types';
+import { callDsgRpc, getDsgSupabaseRpcConfig } from './supabase-rpc';
 
 export type DsgRepositoryContext = {
   workspaceId: string;
   actorId: string;
+  userAccessToken?: string;
 };
 
 export type DsgRuntimeJobRecord = {
@@ -14,28 +16,81 @@ export type DsgRuntimeJobRecord = {
   createdAt: string;
 };
 
-const repositoryNotice = 'DSG_REPOSITORY_REQUIRES_SUPABASE_CLIENT';
-
 export function assertRepositoryContext(context: DsgRepositoryContext): void {
   if (!context.workspaceId) throw new Error('DSG_WORKSPACE_REQUIRED');
   if (!context.actorId) throw new Error('DSG_ACTOR_REQUIRED');
+  if (!context.userAccessToken) throw new Error('DSG_USER_ACCESS_TOKEN_REQUIRED');
 }
 
-export async function createRuntimeJob(context: DsgRepositoryContext, input: { goal: string }): Promise<DsgRuntimeJobRecord> {
+export async function createWorkspace(
+  context: Omit<DsgRepositoryContext, 'workspaceId'>,
+  input: { name: string; slug: string },
+): Promise<string> {
+  if (!context.actorId) throw new Error('DSG_ACTOR_REQUIRED');
+  if (!context.userAccessToken) throw new Error('DSG_USER_ACCESS_TOKEN_REQUIRED');
+  if (!input.name.trim() || !input.slug.trim()) throw new Error('DSG_WORKSPACE_INPUT_REQUIRED');
+
+  return callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_create_workspace', {
+    p_name: input.name,
+    p_slug: input.slug,
+  });
+}
+
+export async function createRuntimeJob(
+  context: DsgRepositoryContext,
+  input: { goal: string; successCriteria?: unknown[] },
+): Promise<{ id: string }> {
   assertRepositoryContext(context);
   if (!input.goal.trim()) throw new Error('DSG_GOAL_REQUIRED');
-  throw new Error(repositoryNotice);
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_create_runtime_job', {
+    p_workspace_id: context.workspaceId,
+    p_goal: input.goal,
+    p_success_criteria: input.successCriteria ?? [],
+  });
+
+  return { id };
 }
 
 export async function createRuntimePlan(context: DsgRepositoryContext, input: { jobId: string; tasks: RuntimeTask[] }): Promise<never> {
   assertRepositoryContext(context);
   if (!input.jobId) throw new Error('DSG_JOB_REQUIRED');
   if (input.tasks.length === 0) throw new Error('DSG_TASKS_REQUIRED');
-  throw new Error(repositoryNotice);
+  throw new Error('DSG_PLAN_RPC_NOT_IMPLEMENTED');
 }
 
-export async function writeEvidence(context: DsgRepositoryContext, input: { jobId: string; contentHash: string; summary: string }): Promise<never> {
+export async function writeEvidence(
+  context: DsgRepositoryContext,
+  input: { jobId: string; evidenceType: string; contentHash: string; summary: string; uri?: string; metadata?: Record<string, unknown> },
+): Promise<{ id: string }> {
   assertRepositoryContext(context);
   if (!input.jobId || !input.contentHash || !input.summary) throw new Error('DSG_EVIDENCE_REQUIRED');
-  throw new Error(repositoryNotice);
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_record_evidence', {
+    p_job_id: input.jobId,
+    p_evidence_type: input.evidenceType,
+    p_content_hash: input.contentHash,
+    p_summary: input.summary,
+    p_uri: input.uri ?? null,
+    p_metadata: input.metadata ?? {},
+  });
+
+  return { id };
+}
+
+export async function recordReplayProof(
+  context: DsgRepositoryContext,
+  input: { jobId: string; replayHash: string; status: 'PASS' | 'BLOCK' | 'FAILED'; details?: Record<string, unknown> },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.replayHash) throw new Error('DSG_REPLAY_REQUIRED');
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_record_replay_proof', {
+    p_job_id: input.jobId,
+    p_replay_hash: input.replayHash,
+    p_status: input.status,
+    p_details: input.details ?? {},
+  });
+
+  return { id };
 }

--- a/lib/dsg/server/supabase-rpc.ts
+++ b/lib/dsg/server/supabase-rpc.ts
@@ -1,0 +1,56 @@
+export type DsgSupabaseRpcConfig = {
+  url: string;
+  key: string;
+  userAccessToken?: string;
+};
+
+export type DsgRpcError = {
+  message?: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+};
+
+export function getDsgSupabaseRpcConfig(userAccessToken?: string): DsgSupabaseRpcConfig {
+  const url = process.env.DSG_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const key = process.env.DSG_SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) throw new Error('DSG_SUPABASE_URL_REQUIRED');
+  if (!key) throw new Error('DSG_SUPABASE_SERVICE_ROLE_KEY_REQUIRED');
+
+  return { url: url.replace(/\/$/, ''), key, userAccessToken };
+}
+
+export async function callDsgRpc<T>(
+  config: DsgSupabaseRpcConfig,
+  functionName: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${config.url}/rest/v1/rpc/${functionName}`, {
+    method: 'POST',
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.userAccessToken ?? config.key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  const payload = text ? (JSON.parse(text) as T | DsgRpcError) : null;
+
+  if (!response.ok) {
+    const error = payload as DsgRpcError | null;
+    throw new Error(error?.message ?? `DSG_RPC_${response.status}`);
+  }
+
+  return payload as T;
+}
+
+export function getBearerToken(headers: Headers): string | undefined {
+  const value = headers.get('authorization');
+  if (!value?.toLowerCase().startsWith('bearer ')) return undefined;
+  return value.slice('bearer '.length).trim();
+}

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -6,6 +6,7 @@ const root = process.cwd();
 const required = [
   'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql',
   'supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql',
+  'supabase/migrations/20260502181720_add_dsg_runtime_policies_and_rpc.sql',
   'lib/dsg/runtime/stable-json.ts',
   'lib/dsg/runtime/hash.ts',
   'lib/dsg/runtime/planner.ts',
@@ -17,8 +18,13 @@ const required = [
   'lib/dsg/connectors/openapi.ts',
   'lib/dsg/server/context.ts',
   'lib/dsg/server/repository.ts',
+  'lib/dsg/server/supabase-rpc.ts',
+  'app/api/dsg/workspaces/route.ts',
   'app/api/dsg/jobs/route.ts',
+  'app/api/dsg/jobs/[jobId]/evidence/route.ts',
+  'app/api/dsg/jobs/[jobId]/replay/route.ts',
   'app/api/dsg/verify/route.ts',
+  'docs/DSG_SUPABASE_BACKEND_WIRING.md',
 ];
 
 const missing = required.filter((file) => !existsSync(join(root, file)));
@@ -44,6 +50,15 @@ const tables = [
 for (const table of tables) {
   if (!migration.includes(table)) {
     console.error(`DSG deterministic runtime check failed: migration missing ${table}`);
+    process.exit(1);
+  }
+}
+
+const rpcSource = readFileSync(join(root, 'supabase/migrations/20260502181720_add_dsg_runtime_policies_and_rpc.sql'), 'utf8');
+const rpcNames = ['dsg_create_workspace', 'dsg_create_runtime_job', 'dsg_record_evidence', 'dsg_record_replay_proof'];
+for (const rpcName of rpcNames) {
+  if (!rpcSource.includes(rpcName)) {
+    console.error(`DSG deterministic runtime check failed: migration missing ${rpcName}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Add server-side Supabase RPC client using server-only env values.
- Wire repository create workspace/job/evidence/replay operations to Supabase RPC.
- Wire API routes for workspace creation, job creation, evidence write, and replay proof write.
- Add backend wiring docs and extend deterministic runtime check coverage.

## Truthful status
- This moves selected backend write paths from scaffold to Supabase RPC.
- It still requires real Supabase user JWTs and server env values at runtime.
- Header actor/role remains a dev bridge and must be replaced by server-verified auth/RBAC before production.
- Plan persistence, audit export, deployment proof, and production flow proof are still not production-complete.

## Required env
- `DSG_SUPABASE_URL`
- `DSG_SUPABASE_SERVICE_ROLE_KEY`

## Expected checks
- `npm run dsg:verify`

No production claim is made by this PR.