### PR TITLE
Wire DSG plan audit and completion RPC flow

### DIFF
--- a/app/api/dsg/jobs/[jobId]/audit/export/route.ts
+++ b/app/api/dsg/jobs/[jobId]/audit/export/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { createAuditExport } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'audit:export');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as { exportHash?: string } | null;
+  if (!body?.exportHash) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_AUDIT_EXPORT_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await createAuditExport(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { jobId, exportHash: body.exportHash },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_AUDIT_EXPORT_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/[jobId]/completion/route.ts
+++ b/app/api/dsg/jobs/[jobId]/completion/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { createCompletionReport } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'replay:verify');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    reportHash?: string;
+    evidenceManifestId?: string;
+    auditExportId?: string;
+    replayProofId?: string;
+    deploymentProofId?: string | null;
+    productionFlowProofId?: string | null;
+    usesMockState?: boolean;
+    isDevOrSmokeOnly?: boolean;
+  } | null;
+
+  if (!body?.reportHash || !body.evidenceManifestId || !body.auditExportId || !body.replayProofId) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_COMPLETION_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await createCompletionReport(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      {
+        jobId,
+        reportHash: body.reportHash,
+        evidenceManifestId: body.evidenceManifestId,
+        auditExportId: body.auditExportId,
+        replayProofId: body.replayProofId,
+        deploymentProofId: body.deploymentProofId,
+        productionFlowProofId: body.productionFlowProofId,
+        usesMockState: body.usesMockState,
+        isDevOrSmokeOnly: body.isDevOrSmokeOnly,
+      },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_COMPLETION_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts
+++ b/app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { createEvidenceManifest } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'evidence:write');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as { manifestHash?: string; evidenceIds?: string[] } | null;
+  if (!body?.manifestHash || !body.evidenceIds?.length) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_MANIFEST_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await createEvidenceManifest(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { jobId, manifestHash: body.manifestHash, evidenceIds: body.evidenceIds },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_MANIFEST_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/[jobId]/plan/route.ts
+++ b/app/api/dsg/jobs/[jobId]/plan/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { createRuntimePlan } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+import type { RuntimeTask } from '@/lib/dsg/runtime/types';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:plan');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as { tasks?: RuntimeTask[] } | null;
+  if (!body?.tasks?.length) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_TASKS_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await createRuntimePlan(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { jobId, tasks: body.tasks },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_PLAN_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/lib/dsg/server/repository.ts
+++ b/lib/dsg/server/repository.ts
@@ -1,3 +1,4 @@
+import { createRuntimePlan as buildRuntimePlan } from '../runtime/planner';
 import type { RuntimeTask } from '../runtime/types';
 import { callDsgRpc, getDsgSupabaseRpcConfig } from './supabase-rpc';
 
@@ -52,11 +53,28 @@ export async function createRuntimeJob(
   return { id };
 }
 
-export async function createRuntimePlan(context: DsgRepositoryContext, input: { jobId: string; tasks: RuntimeTask[] }): Promise<never> {
+export async function createRuntimePlan(
+  context: DsgRepositoryContext,
+  input: { jobId: string; tasks: RuntimeTask[] },
+): Promise<{ taskPlanId: string; wavePlanId: string; planHash: string; waveHash: string }> {
   assertRepositoryContext(context);
   if (!input.jobId) throw new Error('DSG_JOB_REQUIRED');
-  if (input.tasks.length === 0) throw new Error('DSG_TASKS_REQUIRED');
-  throw new Error('DSG_PLAN_RPC_NOT_IMPLEMENTED');
+  const plan = buildRuntimePlan(input.tasks);
+
+  const data = await callDsgRpc<{ taskPlanId: string; wavePlanId: string }>(
+    getDsgSupabaseRpcConfig(context.userAccessToken),
+    'dsg_create_plan',
+    {
+      p_job_id: input.jobId,
+      p_plan_hash: plan.planHash,
+      p_tasks: plan.tasks,
+      p_dependency_edges: plan.edges,
+      p_wave_hash: plan.waveHash,
+      p_waves: plan.waves,
+    },
+  );
+
+  return { ...data, planHash: plan.planHash, waveHash: plan.waveHash };
 }
 
 export async function writeEvidence(
@@ -78,6 +96,37 @@ export async function writeEvidence(
   return { id };
 }
 
+export async function createEvidenceManifest(
+  context: DsgRepositoryContext,
+  input: { jobId: string; manifestHash: string; evidenceIds: string[] },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.manifestHash || input.evidenceIds.length === 0) throw new Error('DSG_MANIFEST_REQUIRED');
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_create_evidence_manifest', {
+    p_job_id: input.jobId,
+    p_manifest_hash: input.manifestHash,
+    p_evidence_ids: input.evidenceIds,
+  });
+
+  return { id };
+}
+
+export async function createAuditExport(
+  context: DsgRepositoryContext,
+  input: { jobId: string; exportHash: string },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.exportHash) throw new Error('DSG_AUDIT_EXPORT_REQUIRED');
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_create_audit_export', {
+    p_job_id: input.jobId,
+    p_export_hash: input.exportHash,
+  });
+
+  return { id };
+}
+
 export async function recordReplayProof(
   context: DsgRepositoryContext,
   input: { jobId: string; replayHash: string; status: 'PASS' | 'BLOCK' | 'FAILED'; details?: Record<string, unknown> },
@@ -90,6 +139,40 @@ export async function recordReplayProof(
     p_replay_hash: input.replayHash,
     p_status: input.status,
     p_details: input.details ?? {},
+  });
+
+  return { id };
+}
+
+export async function createCompletionReport(
+  context: DsgRepositoryContext,
+  input: {
+    jobId: string;
+    reportHash: string;
+    evidenceManifestId: string;
+    auditExportId: string;
+    replayProofId: string;
+    deploymentProofId?: string | null;
+    productionFlowProofId?: string | null;
+    usesMockState?: boolean;
+    isDevOrSmokeOnly?: boolean;
+  },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.reportHash || !input.evidenceManifestId || !input.auditExportId || !input.replayProofId) {
+    throw new Error('DSG_COMPLETION_REQUIRED');
+  }
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_create_completion_report', {
+    p_job_id: input.jobId,
+    p_report_hash: input.reportHash,
+    p_evidence_manifest_id: input.evidenceManifestId,
+    p_audit_export_id: input.auditExportId,
+    p_replay_proof_id: input.replayProofId,
+    p_deployment_proof_id: input.deploymentProofId ?? null,
+    p_production_flow_proof_id: input.productionFlowProofId ?? null,
+    p_uses_mock_state: input.usesMockState ?? false,
+    p_is_dev_or_smoke_only: input.isDevOrSmokeOnly ?? true,
   });
 
   return { id };

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -7,6 +7,7 @@ const required = [
   'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql',
   'supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql',
   'supabase/migrations/20260502181720_add_dsg_runtime_policies_and_rpc.sql',
+  'supabase/migrations/20260502183649_add_dsg_plan_audit_completion_rpc.sql',
   'lib/dsg/runtime/stable-json.ts',
   'lib/dsg/runtime/hash.ts',
   'lib/dsg/runtime/planner.ts',
@@ -21,8 +22,12 @@ const required = [
   'lib/dsg/server/supabase-rpc.ts',
   'app/api/dsg/workspaces/route.ts',
   'app/api/dsg/jobs/route.ts',
+  'app/api/dsg/jobs/[jobId]/plan/route.ts',
   'app/api/dsg/jobs/[jobId]/evidence/route.ts',
+  'app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts',
+  'app/api/dsg/jobs/[jobId]/audit/export/route.ts',
   'app/api/dsg/jobs/[jobId]/replay/route.ts',
+  'app/api/dsg/jobs/[jobId]/completion/route.ts',
   'app/api/dsg/verify/route.ts',
   'docs/DSG_SUPABASE_BACKEND_WIRING.md',
 ];
@@ -58,6 +63,15 @@ const rpcSource = readFileSync(join(root, 'supabase/migrations/20260502181720_ad
 const rpcNames = ['dsg_create_workspace', 'dsg_create_runtime_job', 'dsg_record_evidence', 'dsg_record_replay_proof'];
 for (const rpcName of rpcNames) {
   if (!rpcSource.includes(rpcName)) {
+    console.error(`DSG deterministic runtime check failed: migration missing ${rpcName}`);
+    process.exit(1);
+  }
+}
+
+const completionRpcSource = readFileSync(join(root, 'supabase/migrations/20260502183649_add_dsg_plan_audit_completion_rpc.sql'), 'utf8');
+const completionRpcNames = ['dsg_create_plan', 'dsg_create_evidence_manifest', 'dsg_create_audit_export', 'dsg_create_completion_report'];
+for (const rpcName of completionRpcNames) {
+  if (!completionRpcSource.includes(rpcName)) {
     console.error(`DSG deterministic runtime check failed: migration missing ${rpcName}`);
     process.exit(1);
   }

--- a/supabase/migrations/20260502183649_add_dsg_plan_audit_completion_rpc.sql
+++ b/supabase/migrations/20260502183649_add_dsg_plan_audit_completion_rpc.sql
@@ -1,0 +1,190 @@
+create or replace function public.dsg_create_plan(
+  p_job_id uuid,
+  p_plan_hash text,
+  p_tasks jsonb,
+  p_dependency_edges jsonb,
+  p_wave_hash text,
+  p_waves jsonb
+)
+returns jsonb
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_task_plan_id uuid;
+  v_wave_plan_id uuid;
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'job:plan') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_plan_hash !~ '^sha256:[a-f0-9]{64}$' or p_wave_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_PLAN_HASH'; end if;
+  if jsonb_typeof(p_tasks) <> 'array' or jsonb_array_length(p_tasks) = 0 then raise exception 'DSG_TASKS_REQUIRED'; end if;
+
+  insert into public.dsg_task_plans(job_id, workspace_id, plan_hash, tasks, dependency_edges, status, created_by)
+  values (p_job_id, v_workspace_id, p_plan_hash, p_tasks, coalesce(p_dependency_edges, '[]'::jsonb), 'READY', v_actor)
+  returning id into v_task_plan_id;
+
+  insert into public.dsg_wave_plans(job_id, workspace_id, task_plan_id, wave_hash, waves, status)
+  values (p_job_id, v_workspace_id, v_task_plan_id, p_wave_hash, coalesce(p_waves, '[]'::jsonb), 'READY')
+  returning id into v_wave_plan_id;
+
+  update public.dsg_runtime_jobs set status = 'WAITING_APPROVAL', current_wave_id = 'wave-1' where id = p_job_id;
+
+  insert into public.dsg_runtime_events(job_id, workspace_id, event_type, message, actor_id, payload)
+  values (p_job_id, v_workspace_id, 'PLAN_CREATED', 'Runtime plan created', v_actor,
+    jsonb_build_object('taskPlanId', v_task_plan_id, 'wavePlanId', v_wave_plan_id, 'planHash', p_plan_hash, 'waveHash', p_wave_hash));
+
+  return jsonb_build_object('taskPlanId', v_task_plan_id, 'wavePlanId', v_wave_plan_id);
+end;
+$$;
+
+create or replace function public.dsg_create_evidence_manifest(
+  p_job_id uuid,
+  p_manifest_hash text,
+  p_evidence_ids uuid[]
+)
+returns uuid
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_manifest_id uuid;
+  v_missing_count integer;
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'evidence:write') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_manifest_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_MANIFEST_HASH'; end if;
+
+  select count(*) into v_missing_count
+  from unnest(coalesce(p_evidence_ids, array[]::uuid[])) as e(id)
+  where not exists (
+    select 1 from public.dsg_evidence_items item
+    where item.id = e.id and item.job_id = p_job_id and item.workspace_id = v_workspace_id
+  );
+
+  if v_missing_count > 0 or cardinality(coalesce(p_evidence_ids, array[]::uuid[])) = 0 then
+    raise exception 'DSG_EVIDENCE_INCOMPLETE';
+  end if;
+
+  insert into public.dsg_evidence_manifests(job_id, workspace_id, manifest_hash, evidence_ids, status, created_by)
+  values (p_job_id, v_workspace_id, p_manifest_hash, p_evidence_ids, 'COMPLETE', v_actor)
+  returning id into v_manifest_id;
+
+  return v_manifest_id;
+end;
+$$;
+
+create or replace function public.dsg_create_audit_export(
+  p_job_id uuid,
+  p_export_hash text
+)
+returns uuid
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_export_id uuid;
+  v_entry_ids uuid[];
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'audit:export') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_export_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_AUDIT_EXPORT_HASH'; end if;
+
+  select coalesce(array_agg(id order by created_at asc), array[]::uuid[]) into v_entry_ids
+  from public.dsg_audit_ledger
+  where job_id = p_job_id and workspace_id = v_workspace_id;
+
+  if cardinality(v_entry_ids) = 0 then raise exception 'DSG_AUDIT_EMPTY'; end if;
+
+  insert into public.dsg_audit_exports(job_id, workspace_id, export_hash, ledger_entry_ids, created_by)
+  values (p_job_id, v_workspace_id, p_export_hash, v_entry_ids, v_actor)
+  returning id into v_export_id;
+
+  return v_export_id;
+end;
+$$;
+
+create or replace function public.dsg_create_completion_report(
+  p_job_id uuid,
+  p_report_hash text,
+  p_evidence_manifest_id uuid,
+  p_audit_export_id uuid,
+  p_replay_proof_id uuid,
+  p_deployment_proof_id uuid default null,
+  p_production_flow_proof_id uuid default null,
+  p_uses_mock_state boolean default false,
+  p_is_dev_or_smoke_only boolean default true
+)
+returns uuid
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_report_id uuid;
+  v_replay_status text;
+  v_has_deployment boolean;
+  v_has_production_flow boolean;
+  v_gate jsonb;
+  v_claim_status text;
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'replay:verify') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_report_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_REPORT_HASH'; end if;
+
+  if not exists (select 1 from public.dsg_evidence_manifests where id = p_evidence_manifest_id and job_id = p_job_id and status = 'COMPLETE') then
+    raise exception 'DSG_EVIDENCE_MANIFEST_REQUIRED';
+  end if;
+  if not exists (select 1 from public.dsg_audit_exports where id = p_audit_export_id and job_id = p_job_id) then
+    raise exception 'DSG_AUDIT_EXPORT_REQUIRED';
+  end if;
+
+  select status into v_replay_status from public.dsg_replay_proofs where id = p_replay_proof_id and job_id = p_job_id;
+  if v_replay_status is distinct from 'PASS' then raise exception 'DSG_REPLAY_PASS_REQUIRED'; end if;
+
+  v_has_deployment := p_deployment_proof_id is not null and exists (
+    select 1 from public.dsg_deployment_proofs where id = p_deployment_proof_id and job_id = p_job_id and status = 'PASS'
+  );
+  v_has_production_flow := p_production_flow_proof_id is not null and exists (
+    select 1 from public.dsg_production_flow_proofs where id = p_production_flow_proof_id and job_id = p_job_id and status = 'PASS'
+  );
+
+  v_gate := public.dsg_claim_gate(true, true, true, true, v_has_deployment, v_has_production_flow, p_uses_mock_state, p_is_dev_or_smoke_only);
+
+  if (v_gate->>'production')::boolean then v_claim_status := 'PRODUCTION';
+  elsif (v_gate->>'deployable')::boolean then v_claim_status := 'DEPLOYABLE';
+  elsif (v_gate->>'verified')::boolean then v_claim_status := 'VERIFIED';
+  else v_claim_status := 'BLOCKED';
+  end if;
+
+  insert into public.dsg_completion_reports(
+    job_id, workspace_id, claim_status, evidence_manifest_id, audit_export_id, replay_proof_id,
+    block_reasons, report_hash, created_by
+  ) values (
+    p_job_id, v_workspace_id, v_claim_status, p_evidence_manifest_id, p_audit_export_id, p_replay_proof_id,
+    coalesce(array(select jsonb_array_elements_text(v_gate->'blocks')), array[]::text[]), p_report_hash, v_actor
+  ) returning id into v_report_id;
+
+  update public.dsg_runtime_jobs
+  set status = case when v_claim_status in ('VERIFIED','DEPLOYABLE','PRODUCTION') then 'COMPLETED' else 'BLOCKED' end,
+      completion_report_id = v_report_id
+  where id = p_job_id;
+
+  return v_report_id;
+end;
+$$;
+
+revoke execute on function public.dsg_create_plan(uuid, text, jsonb, jsonb, text, jsonb) from anon;
+revoke execute on function public.dsg_create_evidence_manifest(uuid, text, uuid[]) from anon;
+revoke execute on function public.dsg_create_audit_export(uuid, text) from anon;
+revoke execute on function public.dsg_create_completion_report(uuid, text, uuid, uuid, uuid, uuid, uuid, boolean, boolean) from anon;


### PR DESCRIPTION
## Summary
- Add Supabase migration source for plan, evidence manifest, audit export, and completion report RPCs already applied to dev.
- Wire repository methods to call `dsg_create_plan`, `dsg_create_evidence_manifest`, `dsg_create_audit_export`, and `dsg_create_completion_report`.
- Add API routes for plan, evidence manifest, audit export, and completion.
- Extend deterministic runtime check coverage.

## Supabase evidence
Applied migration in dev project `dsg-control-plane-dev`:
- `20260502183649_add_dsg_plan_audit_completion_rpc`

## Truthful status
- This makes the core flow more complete: create job -> plan -> evidence manifest -> audit export -> replay proof -> completion report.
- Completion still blocks unless evidence manifest, audit export, and PASS replay proof exist.
- Production remains blocked without deployment proof and production flow proof.
- Header actor/role remains a dev bridge until replaced by server-verified auth/RBAC.

## Expected checks
- `npm run dsg:verify`

No production claim is made by this PR.