### PR TITLE
Wire DSG deployment and production flow proof gates

### DIFF
--- a/app/api/dsg/jobs/[jobId]/deployment-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/deployment-proof/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { recordDeploymentProof } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'deployment:write');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    environment?: string;
+    deploymentUrl?: string;
+    proofHash?: string;
+    status?: 'PASS' | 'BLOCK' | 'FAILED';
+    details?: Record<string, unknown>;
+  } | null;
+
+  if (!body?.environment || !body.deploymentUrl || !body.proofHash || !body.status) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_DEPLOYMENT_PROOF_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await recordDeploymentProof(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      {
+        jobId,
+        environment: body.environment,
+        deploymentUrl: body.deploymentUrl,
+        proofHash: body.proofHash,
+        status: body.status,
+        details: body.details,
+      },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_DEPLOYMENT_PROOF_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/[jobId]/production-flow-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/production-flow-proof/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { recordProductionFlowProof } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = assertDsgPermission(devHeaderActor(request.headers), 'production:write');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    flowName?: string;
+    proofHash?: string;
+    status?: 'PASS' | 'BLOCK' | 'FAILED';
+    details?: Record<string, unknown>;
+  } | null;
+
+  if (!body?.flowName || !body.proofHash || !body.status) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_PRODUCTION_FLOW_PROOF_REQUIRED' } }, { status: 400 });
+  }
+
+  try {
+    const data = await recordProductionFlowProof(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { jobId, flowName: body.flowName, proofHash: body.proofHash, status: body.status, details: body.details },
+    );
+    return NextResponse.json({ ok: true, data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_PRODUCTION_FLOW_PROOF_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/lib/dsg/server/repository.ts
+++ b/lib/dsg/server/repository.ts
@@ -144,6 +144,43 @@ export async function recordReplayProof(
   return { id };
 }
 
+export async function recordDeploymentProof(
+  context: DsgRepositoryContext,
+  input: { jobId: string; environment: string; deploymentUrl: string; proofHash: string; status: 'PASS' | 'BLOCK' | 'FAILED'; details?: Record<string, unknown> },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.environment || !input.deploymentUrl || !input.proofHash) throw new Error('DSG_DEPLOYMENT_PROOF_REQUIRED');
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_record_deployment_proof', {
+    p_job_id: input.jobId,
+    p_environment: input.environment,
+    p_deployment_url: input.deploymentUrl,
+    p_proof_hash: input.proofHash,
+    p_status: input.status,
+    p_details: input.details ?? {},
+  });
+
+  return { id };
+}
+
+export async function recordProductionFlowProof(
+  context: DsgRepositoryContext,
+  input: { jobId: string; flowName: string; proofHash: string; status: 'PASS' | 'BLOCK' | 'FAILED'; details?: Record<string, unknown> },
+): Promise<{ id: string }> {
+  assertRepositoryContext(context);
+  if (!input.jobId || !input.flowName || !input.proofHash) throw new Error('DSG_PRODUCTION_FLOW_PROOF_REQUIRED');
+
+  const id = await callDsgRpc<string>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_record_production_flow_proof', {
+    p_job_id: input.jobId,
+    p_flow_name: input.flowName,
+    p_proof_hash: input.proofHash,
+    p_status: input.status,
+    p_details: input.details ?? {},
+  });
+
+  return { id };
+}
+
 export async function createCompletionReport(
   context: DsgRepositoryContext,
   input: {

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -8,6 +8,7 @@ const required = [
   'supabase/migrations/20260502175200_harden_dsg_runtime_functions_step_2.sql',
   'supabase/migrations/20260502181720_add_dsg_runtime_policies_and_rpc.sql',
   'supabase/migrations/20260502183649_add_dsg_plan_audit_completion_rpc.sql',
+  'supabase/migrations/20260502184542_add_dsg_deployment_production_flow_rpc.sql',
   'lib/dsg/runtime/stable-json.ts',
   'lib/dsg/runtime/hash.ts',
   'lib/dsg/runtime/planner.ts',
@@ -27,6 +28,8 @@ const required = [
   'app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts',
   'app/api/dsg/jobs/[jobId]/audit/export/route.ts',
   'app/api/dsg/jobs/[jobId]/replay/route.ts',
+  'app/api/dsg/jobs/[jobId]/deployment-proof/route.ts',
+  'app/api/dsg/jobs/[jobId]/production-flow-proof/route.ts',
   'app/api/dsg/jobs/[jobId]/completion/route.ts',
   'app/api/dsg/verify/route.ts',
   'docs/DSG_SUPABASE_BACKEND_WIRING.md',
@@ -72,6 +75,15 @@ const completionRpcSource = readFileSync(join(root, 'supabase/migrations/2026050
 const completionRpcNames = ['dsg_create_plan', 'dsg_create_evidence_manifest', 'dsg_create_audit_export', 'dsg_create_completion_report'];
 for (const rpcName of completionRpcNames) {
   if (!completionRpcSource.includes(rpcName)) {
+    console.error(`DSG deterministic runtime check failed: migration missing ${rpcName}`);
+    process.exit(1);
+  }
+}
+
+const deploymentRpcSource = readFileSync(join(root, 'supabase/migrations/20260502184542_add_dsg_deployment_production_flow_rpc.sql'), 'utf8');
+const deploymentRpcNames = ['dsg_record_deployment_proof', 'dsg_record_production_flow_proof'];
+for (const rpcName of deploymentRpcNames) {
+  if (!deploymentRpcSource.includes(rpcName)) {
     console.error(`DSG deterministic runtime check failed: migration missing ${rpcName}`);
     process.exit(1);
   }

--- a/supabase/migrations/20260502184542_add_dsg_deployment_production_flow_rpc.sql
+++ b/supabase/migrations/20260502184542_add_dsg_deployment_production_flow_rpc.sql
@@ -1,0 +1,74 @@
+create or replace function public.dsg_record_deployment_proof(
+  p_job_id uuid,
+  p_environment text,
+  p_deployment_url text,
+  p_proof_hash text,
+  p_status text,
+  p_details jsonb default '{}'::jsonb
+)
+returns uuid
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_proof_id uuid;
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'deployment:write') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_proof_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_DEPLOYMENT_PROOF_HASH'; end if;
+  if p_status not in ('PASS','BLOCK','FAILED') then raise exception 'DSG_INVALID_DEPLOYMENT_STATUS'; end if;
+  if p_environment is null or length(trim(p_environment)) = 0 then raise exception 'DSG_ENVIRONMENT_REQUIRED'; end if;
+  if p_deployment_url is null or p_deployment_url !~ '^https://.+' then raise exception 'DSG_HTTPS_DEPLOYMENT_URL_REQUIRED'; end if;
+
+  insert into public.dsg_deployment_proofs(job_id, workspace_id, environment, deployment_url, proof_hash, status, checked_by, details)
+  values (p_job_id, v_workspace_id, p_environment, p_deployment_url, p_proof_hash, p_status, v_actor, coalesce(p_details, '{}'::jsonb))
+  returning id into v_proof_id;
+
+  insert into public.dsg_runtime_events(job_id, workspace_id, event_type, message, actor_id, payload)
+  values (p_job_id, v_workspace_id, 'DEPLOYMENT_PROOF_RECORDED', 'Deployment proof recorded', v_actor,
+    jsonb_build_object('deploymentProofId', v_proof_id, 'environment', p_environment, 'status', p_status));
+
+  return v_proof_id;
+end;
+$$;
+
+create or replace function public.dsg_record_production_flow_proof(
+  p_job_id uuid,
+  p_flow_name text,
+  p_proof_hash text,
+  p_status text,
+  p_details jsonb default '{}'::jsonb
+)
+returns uuid
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor text := public.dsg_current_actor_id();
+  v_workspace_id uuid;
+  v_proof_id uuid;
+begin
+  select workspace_id into v_workspace_id from public.dsg_runtime_jobs where id = p_job_id;
+  if v_workspace_id is null then raise exception 'DSG_JOB_NOT_FOUND'; end if;
+  if not public.dsg_has_permission(v_workspace_id, 'production:write') then raise exception 'DSG_PERMISSION_DENIED'; end if;
+  if p_proof_hash !~ '^sha256:[a-f0-9]{64}$' then raise exception 'DSG_INVALID_PRODUCTION_FLOW_PROOF_HASH'; end if;
+  if p_status not in ('PASS','BLOCK','FAILED') then raise exception 'DSG_INVALID_PRODUCTION_FLOW_STATUS'; end if;
+  if p_flow_name is null or length(trim(p_flow_name)) = 0 then raise exception 'DSG_FLOW_NAME_REQUIRED'; end if;
+
+  insert into public.dsg_production_flow_proofs(job_id, workspace_id, flow_name, proof_hash, status, checked_by, details)
+  values (p_job_id, v_workspace_id, p_flow_name, p_proof_hash, p_status, v_actor, coalesce(p_details, '{}'::jsonb))
+  returning id into v_proof_id;
+
+  insert into public.dsg_runtime_events(job_id, workspace_id, event_type, message, actor_id, payload)
+  values (p_job_id, v_workspace_id, 'PRODUCTION_FLOW_PROOF_RECORDED', 'Production flow proof recorded', v_actor,
+    jsonb_build_object('productionFlowProofId', v_proof_id, 'flowName', p_flow_name, 'status', p_status));
+
+  return v_proof_id;
+end;
+$$;
+
+revoke execute on function public.dsg_record_deployment_proof(uuid, text, text, text, text, jsonb) from anon;
+revoke execute on function public.dsg_record_production_flow_proof(uuid, text, text, text, jsonb) from anon;


### PR DESCRIPTION
## Summary
- Add Supabase migration source for deployment proof and production flow proof RPCs already applied to dev.
- Wire repository methods to record deployment and production flow proofs.
- Add API routes for deployment proof and production flow proof.
- Extend deterministic runtime check coverage.

## Supabase evidence
Applied migration in dev project `dsg-control-plane-dev`:
- `20260502184542_add_dsg_deployment_production_flow_rpc`

## Truthful status
- Deployment and production-flow proof storage paths are now wired.
- Production can still only be claimed if completion receives PASS deployment and production-flow proof IDs plus all prior gates.
- Header actor/role remains a dev bridge until replaced by server-verified auth/RBAC.

## Expected checks
- `npm run dsg:verify`

No production claim is made by this PR.