### PR TITLE
Replace DSG header-role bridge with server-verified Supabase auth

### DIFF
--- a/app/api/dsg/jobs/[jobId]/audit/export/route.ts
+++ b/app/api/dsg/jobs/[jobId]/audit/export/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { createAuditExport } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'audit:export');
+  const actor = await requireVerifiedDsgActor(request.headers, 'audit:export');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as { exportHash?: string } | null;
   if (!body?.exportHash) {

--- a/app/api/dsg/jobs/[jobId]/completion/route.ts
+++ b/app/api/dsg/jobs/[jobId]/completion/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { createCompletionReport } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'replay:verify');
+  const actor = await requireVerifiedDsgActor(request.headers, 'replay:verify');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as {
     reportHash?: string;

--- a/app/api/dsg/jobs/[jobId]/deployment-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/deployment-proof/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { recordDeploymentProof } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'deployment:write');
+  const actor = await requireVerifiedDsgActor(request.headers, 'deployment:write');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as {
     environment?: string;

--- a/app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts
+++ b/app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { createEvidenceManifest } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'evidence:write');
+  const actor = await requireVerifiedDsgActor(request.headers, 'evidence:write');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as { manifestHash?: string; evidenceIds?: string[] } | null;
   if (!body?.manifestHash || !body.evidenceIds?.length) {

--- a/app/api/dsg/jobs/[jobId]/evidence/route.ts
+++ b/app/api/dsg/jobs/[jobId]/evidence/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { writeEvidence } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'evidence:write');
+  const actor = await requireVerifiedDsgActor(request.headers, 'evidence:write');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as {
     evidenceType?: string;

--- a/app/api/dsg/jobs/[jobId]/plan/route.ts
+++ b/app/api/dsg/jobs/[jobId]/plan/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { createRuntimePlan } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 import type { RuntimeTask } from '@/lib/dsg/runtime/types';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:plan');
+  const actor = await requireVerifiedDsgActor(request.headers, 'job:plan');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as { tasks?: RuntimeTask[] } | null;
   if (!body?.tasks?.length) {

--- a/app/api/dsg/jobs/[jobId]/production-flow-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/production-flow-proof/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { recordProductionFlowProof } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'production:write');
+  const actor = await requireVerifiedDsgActor(request.headers, 'production:write');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as {
     flowName?: string;

--- a/app/api/dsg/jobs/[jobId]/replay/route.ts
+++ b/app/api/dsg/jobs/[jobId]/replay/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { recordReplayProof } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'replay:verify');
+  const actor = await requireVerifiedDsgActor(request.headers, 'replay:verify');
   const { jobId } = await context.params;
   const body = (await request.json().catch(() => null)) as {
     replayHash?: string;

--- a/app/api/dsg/jobs/route.ts
+++ b/app/api/dsg/jobs/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from 'next/server';
-import { assertDsgPermission, devHeaderActor } from '@/lib/dsg/server/context';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { createRuntimeJob } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function GET(request: Request) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:read');
+  const actor = await requireVerifiedDsgActor(request.headers, 'job:read');
   return NextResponse.json({ ok: true, data: { actor, jobs: [], source: 'database-read-route-pending' } });
 }
 
 export async function POST(request: Request) {
-  const actor = assertDsgPermission(devHeaderActor(request.headers), 'job:create');
+  const actor = await requireVerifiedDsgActor(request.headers, 'job:create');
   const body = (await request.json().catch(() => null)) as { goal?: string; successCriteria?: unknown[] } | null;
   if (!body?.goal?.trim()) {
     return NextResponse.json({ ok: false, error: { code: 'DSG_GOAL_REQUIRED' } }, { status: 400 });

--- a/app/api/dsg/workspaces/route.ts
+++ b/app/api/dsg/workspaces/route.ts
@@ -1,22 +1,34 @@
 import { NextResponse } from 'next/server';
-import { devHeaderActor } from '@/lib/dsg/server/context';
+import { getBearerToken, getDsgSupabaseRpcConfig } from '@/lib/dsg/server/supabase-rpc';
 import { createWorkspace } from '@/lib/dsg/server/repository';
-import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+type SupabaseUserResponse = { id?: string; sub?: string };
+
+async function requireSupabaseUser(headers: Headers): Promise<string> {
+  const userAccessToken = getBearerToken(headers);
+  if (!userAccessToken) throw new Error('DSG_AUTH_REQUIRED');
+  const config = getDsgSupabaseRpcConfig(userAccessToken);
+  const response = await fetch(`${config.url}/auth/v1/user`, {
+    headers: { apikey: config.key, Authorization: `Bearer ${userAccessToken}` },
+    cache: 'no-store',
+  });
+  if (!response.ok) throw new Error('DSG_AUTH_REQUIRED');
+  const user = (await response.json()) as SupabaseUserResponse;
+  const actorId = user.id ?? user.sub;
+  if (!actorId) throw new Error('DSG_AUTH_REQUIRED');
+  return actorId;
+}
 
 export async function POST(request: Request) {
-  const actor = devHeaderActor(request.headers);
-  if (!actor?.actorId) {
-    return NextResponse.json({ ok: false, error: { code: 'DSG_AUTH_REQUIRED' } }, { status: 401 });
-  }
-
   const body = (await request.json().catch(() => null)) as { name?: string; slug?: string } | null;
   if (!body?.name?.trim() || !body.slug?.trim()) {
     return NextResponse.json({ ok: false, error: { code: 'DSG_WORKSPACE_INPUT_REQUIRED' } }, { status: 400 });
   }
 
   try {
+    const actorId = await requireSupabaseUser(request.headers);
     const id = await createWorkspace(
-      { actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      { actorId, userAccessToken: getBearerToken(request.headers) },
       { name: body.name, slug: body.slug },
     );
     return NextResponse.json({ ok: true, data: { id } }, { status: 201 });

--- a/docs/DSG_SUPABASE_BACKEND_WIRING.md
+++ b/docs/DSG_SUPABASE_BACKEND_WIRING.md
@@ -11,25 +11,29 @@ DSG_SUPABASE_URL=https://<project-ref>.supabase.co
 DSG_SUPABASE_SERVICE_ROLE_KEY=<server-only-service-role-key>
 ```
 
-The API caller must also provide a real user access token:
+The API caller must provide a real Supabase user access token and workspace id:
 
 ```http
 Authorization: Bearer <supabase-user-jwt>
-x-dsg-actor-id: <auth-user-id>
 x-dsg-workspace-id: <workspace-uuid>
-x-dsg-actor-role: OWNER|ADMIN|OPERATOR|AUDITOR|VIEWER
 ```
 
-Header role is still a dev bridge. Production must replace this with server-verified auth/RBAC context.
+The server verifies the JWT by calling Supabase Auth `/auth/v1/user`, then resolves the actor role from `dsg_workspace_members`. `x-dsg-actor-id` and `x-dsg-actor-role` are not trusted by default. A legacy dev bridge only works when `DSG_ALLOW_DEV_HEADER_ACTOR=true`, and must not be enabled for production.
 
 ## Wired routes
 | Route | Method | RPC | Status |
 |---|---:|---|---|
 | `/api/dsg/workspaces` | POST | `dsg_create_workspace` | wired |
 | `/api/dsg/jobs` | POST | `dsg_create_runtime_job` | wired |
+| `/api/dsg/jobs/[jobId]/plan` | POST | `dsg_create_plan` | wired |
 | `/api/dsg/jobs/[jobId]/evidence` | POST | `dsg_record_evidence` | wired |
+| `/api/dsg/jobs/[jobId]/evidence/manifest` | POST | `dsg_create_evidence_manifest` | wired |
 | `/api/dsg/jobs/[jobId]/replay` | POST | `dsg_record_replay_proof` | wired |
+| `/api/dsg/jobs/[jobId]/audit/export` | POST | `dsg_create_audit_export` | wired |
+| `/api/dsg/jobs/[jobId]/deployment-proof` | POST | `dsg_record_deployment_proof` | wired |
+| `/api/dsg/jobs/[jobId]/production-flow-proof` | POST | `dsg_record_production_flow_proof` | wired |
+| `/api/dsg/jobs/[jobId]/completion` | POST | `dsg_create_completion_report` | wired |
 | `/api/dsg/jobs` | GET | none | pending database list query |
 
 ## Truth boundary
-This wiring moves write paths from scaffold to Supabase RPC. It still does not prove production readiness. Production remains blocked until server-side auth provider verification, audit export, replay verification, deployment proof, and production user-flow proof exist.
+This wiring moves write paths from scaffold to Supabase RPC and replaces header-role trust with server verification. It still does not prove production readiness until CI/local verification, deployment proof, and production user-flow proof are observed.

--- a/lib/dsg/server/context.ts
+++ b/lib/dsg/server/context.ts
@@ -1,3 +1,5 @@
+import { getBearerToken, getDsgSupabaseRpcConfig } from './supabase-rpc';
+
 export type DsgServerActor = {
   actorId: string;
   workspaceId: string;
@@ -31,7 +33,57 @@ export function assertDsgPermission(actor: DsgServerActor | null, permission: Ds
   return actor;
 }
 
+type SupabaseUserResponse = { id?: string; sub?: string };
+type WorkspaceMemberRow = { role: DsgServerActor['role'] };
+
+export async function resolveVerifiedDsgActor(headers: Headers): Promise<DsgServerActor | null> {
+  const userAccessToken = getBearerToken(headers);
+  const workspaceId = headers.get('x-dsg-workspace-id');
+  if (!userAccessToken || !workspaceId) return null;
+
+  const config = getDsgSupabaseRpcConfig(userAccessToken);
+  const userResponse = await fetch(`${config.url}/auth/v1/user`, {
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${userAccessToken}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!userResponse.ok) return null;
+  const user = (await userResponse.json()) as SupabaseUserResponse;
+  const actorId = user.id ?? user.sub;
+  if (!actorId) return null;
+
+  const memberUrl = new URL(`${config.url}/rest/v1/dsg_workspace_members`);
+  memberUrl.searchParams.set('workspace_id', `eq.${workspaceId}`);
+  memberUrl.searchParams.set('actor_id', `eq.${actorId}`);
+  memberUrl.searchParams.set('select', 'role');
+  memberUrl.searchParams.set('limit', '1');
+
+  const memberResponse = await fetch(memberUrl, {
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  if (!memberResponse.ok) return null;
+  const rows = (await memberResponse.json()) as WorkspaceMemberRow[];
+  const role = rows[0]?.role;
+  if (!role || !Object.prototype.hasOwnProperty.call(permissionsByRole, role)) return null;
+
+  return { actorId, workspaceId, role };
+}
+
+export async function requireVerifiedDsgActor(headers: Headers, permission: DsgPermission): Promise<DsgServerActor> {
+  return assertDsgPermission(await resolveVerifiedDsgActor(headers), permission);
+}
+
 export function devHeaderActor(headers: Headers): DsgServerActor | null {
+  if (process.env.DSG_ALLOW_DEV_HEADER_ACTOR !== 'true') return null;
   const actorId = headers.get('x-dsg-actor-id');
   const workspaceId = headers.get('x-dsg-workspace-id');
   const role = headers.get('x-dsg-actor-role') as DsgServerActor['role'] | null;

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -42,6 +42,15 @@ if (missing.length) {
   process.exit(1);
 }
 
+const apiRouteFiles = required.filter((file) => file.startsWith('app/api/dsg/') && file.endsWith('/route.ts'));
+for (const file of apiRouteFiles) {
+  const source = readFileSync(join(root, file), 'utf8');
+  if (source.includes('devHeaderActor') || source.includes('x-dsg-actor-role')) {
+    console.error(`DSG deterministic runtime check failed: route uses dev actor bridge ${file}`);
+    process.exit(1);
+  }
+}
+
 const migration = readFileSync(join(root, 'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql'), 'utf8');
 const tables = [
   'dsg_runtime_jobs',


### PR DESCRIPTION
## Summary
- Add server-verified DSG actor resolver.
- Verify Supabase JWT via `/auth/v1/user`.
- Resolve workspace role from `dsg_workspace_members` instead of trusting `x-dsg-actor-role`.
- Update DSG API routes to use `requireVerifiedDsgActor`.
- Keep `devHeaderActor` disabled by default unless `DSG_ALLOW_DEV_HEADER_ACTOR=true`.
- Add deterministic guard to fail if DSG API routes use the dev actor bridge.
- Update backend wiring docs.

## Truthful status
- This removes default header-role trust from DSG API routes.
- Production readiness still requires observed CI/local verification and real deployment/user-flow evidence.
- Service role must remain server-only.

## Expected checks
- `npm run dsg:verify`

No production claim is made by this PR.