### PR TITLE
Improve DSG verify workflow diagnostics

### DIFF
--- a/.github/workflows/dsg-verify.yml
+++ b/.github/workflows/dsg-verify.yml
@@ -1,10 +1,14 @@
 name: DSG Verify
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   verify:
@@ -15,5 +19,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - run: node --version
+      - run: npm --version
       - run: npm ci
+      - run: npm run dsg:claim-gate
+      - run: npm run dsg:runtime-check
+      - run: npm run dsg:typecheck
+      - run: npm run lint
       - run: npm run dsg:verify


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` so DSG verification can be manually triggered.
- Split `dsg:verify` into visible claim-gate, deterministic runtime, typecheck, lint, and final verify steps.
- Keep this independent from Vercel deployment status so CI evidence can be inspected separately.

## Truthful status
- This does not prove verification by itself.
- Verification is only proven after a workflow run or local log passes.

## Expected next check
- Run DSG Verify workflow or inspect status on merge commit.