### PR TITLE
Isolate DSG Supabase env for dsg-one-v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,18 @@ GEMINI_API_KEY="MY_GEMINI_API_KEY"
 # AI Studio automatically injects this at runtime with the Cloud Run service URL.
 # Used for self-referential links, OAuth callbacks, and API endpoints.
 APP_URL="MY_APP_URL"
+
+# dsg-one-v1 Supabase environment isolation
+# Do not reuse Supabase env values from another repository or Vercel project.
+# This repo must use its own project-scoped variables.
+
+# Public browser-safe values for this repo only.
+NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_URL=""
+NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_PUBLISHABLE_KEY=""
+
+# Server-only values for this repo only. Never expose in client code.
+DSG_ONE_V1_SUPABASE_URL=""
+DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY=""
+
+# Optional local-only compatibility bridge. Do not enable for production.
+DSG_ALLOW_DEV_HEADER_ACTOR="false"

--- a/docs/DSG_SUPABASE_BACKEND_WIRING.md
+++ b/docs/DSG_SUPABASE_BACKEND_WIRING.md
@@ -4,11 +4,18 @@
 This document lists the runtime environment variables and backend routes needed for the DSG backend to call Supabase RPC as the database source-of-truth.
 
 ## Required server environment
-Do not expose service-role values to the browser.
+Do not expose service-role values to the browser. This repo must use repo-scoped names so it does not collide with another repository or Vercel project.
 
 ```bash
-DSG_SUPABASE_URL=https://<project-ref>.supabase.co
-DSG_SUPABASE_SERVICE_ROLE_KEY=<server-only-service-role-key>
+DSG_ONE_V1_SUPABASE_URL=https://<project-ref>.supabase.co
+DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY=<server-only-service-role-key>
+```
+
+Optional public values can use the same repo prefix:
+
+```bash
+NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_URL=https://<project-ref>.supabase.co
+NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
 ```
 
 The API caller must provide a real Supabase user access token and workspace id:
@@ -19,6 +26,9 @@ x-dsg-workspace-id: <workspace-uuid>
 ```
 
 The server verifies the JWT by calling Supabase Auth `/auth/v1/user`, then resolves the actor role from `dsg_workspace_members`. `x-dsg-actor-id` and `x-dsg-actor-role` are not trusted by default. A legacy dev bridge only works when `DSG_ALLOW_DEV_HEADER_ACTOR=true`, and must not be enabled for production.
+
+## Vercel isolation rule
+Set these variables only on the Vercel project for `tdealer01-crypto/dsg-one-v1`. Do not copy generic `SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, or shared `SUPABASE_SERVICE_ROLE_KEY` values from another repo.
 
 ## Wired routes
 | Route | Method | RPC | Status |
@@ -36,4 +46,4 @@ The server verifies the JWT by calling Supabase Auth `/auth/v1/user`, then resol
 | `/api/dsg/jobs` | GET | none | pending database list query |
 
 ## Truth boundary
-This wiring moves write paths from scaffold to Supabase RPC and replaces header-role trust with server verification. It still does not prove production readiness until CI/local verification, deployment proof, and production user-flow proof are observed.
+This wiring moves write paths from scaffold to Supabase RPC, replaces header-role trust with server verification, and now requires repo-scoped Supabase env names. It still does not prove production readiness until CI/local verification, deployment proof, and production user-flow proof are observed.

--- a/lib/dsg/server/supabase-rpc.ts
+++ b/lib/dsg/server/supabase-rpc.ts
@@ -12,11 +12,11 @@ export type DsgRpcError = {
 };
 
 export function getDsgSupabaseRpcConfig(userAccessToken?: string): DsgSupabaseRpcConfig {
-  const url = process.env.DSG_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
-  const key = process.env.DSG_SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = process.env.DSG_ONE_V1_SUPABASE_URL;
+  const key = process.env.DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY;
 
-  if (!url) throw new Error('DSG_SUPABASE_URL_REQUIRED');
-  if (!key) throw new Error('DSG_SUPABASE_SERVICE_ROLE_KEY_REQUIRED');
+  if (!url) throw new Error('DSG_ONE_V1_SUPABASE_URL_REQUIRED');
+  if (!key) throw new Error('DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY_REQUIRED');
 
   return { url: url.replace(/\/$/, ''), key, userAccessToken };
 }

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -51,6 +51,20 @@ for (const file of apiRouteFiles) {
   }
 }
 
+const rpcClientSource = readFileSync(join(root, 'lib/dsg/server/supabase-rpc.ts'), 'utf8');
+if (!rpcClientSource.includes('DSG_ONE_V1_SUPABASE_URL') || !rpcClientSource.includes('DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY')) {
+  console.error('DSG deterministic runtime check failed: repo-scoped Supabase env names are missing');
+  process.exit(1);
+}
+
+const envDoc = readFileSync(join(root, '.env.example'), 'utf8');
+for (const name of ['NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_URL', 'NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_PUBLISHABLE_KEY', 'DSG_ONE_V1_SUPABASE_URL', 'DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY']) {
+  if (!envDoc.includes(name)) {
+    console.error(`DSG deterministic runtime check failed: .env.example missing ${name}`);
+    process.exit(1);
+  }
+}
+
 const migration = readFileSync(join(root, 'supabase/migrations/20260502174934_create_dsg_runtime_core_step_2.sql'), 'utf8');
 const tables = [
   'dsg_runtime_jobs',


### PR DESCRIPTION
## Summary
- Require repo-scoped Supabase env names for `dsg-one-v1`.
- Remove fallback to generic/shared Supabase env names from the server RPC client.
- Update `.env.example` and backend wiring docs.
- Extend deterministic runtime check to ensure repo-scoped env names exist.

## Required Vercel env for this repo only
- `DSG_ONE_V1_SUPABASE_URL`
- `DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY`
- Optional public values:
  - `NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_URL`
  - `NEXT_PUBLIC_DSG_ONE_V1_SUPABASE_PUBLISHABLE_KEY`

## Truthful status
This prevents accidental reuse of another repo's Supabase env names. It does not set Vercel secrets by itself and does not claim deployment success.