### PR TITLE
Layer 2: Add DSG read API from Supabase source of truth

### DIFF
--- a/app/api/dsg/jobs/[jobId]/route.ts
+++ b/app/api/dsg/jobs/[jobId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getRuntimeJobTimeline } from '@/lib/dsg/server/repository';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+
+export async function GET(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = await requireVerifiedDsgActor(request.headers, 'job:read');
+  const { jobId } = await context.params;
+
+  try {
+    const data = await getRuntimeJobTimeline(
+      { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) },
+      jobId,
+    );
+    return NextResponse.json({ ok: true, data, source: 'supabase' });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_GET_JOB_FAILED' } },
+      { status: 403 },
+    );
+  }
+}

--- a/app/api/dsg/jobs/route.ts
+++ b/app/api/dsg/jobs/route.ts
@@ -1,11 +1,24 @@
 import { NextResponse } from 'next/server';
 import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
-import { createRuntimeJob } from '@/lib/dsg/server/repository';
+import { createRuntimeJob, listRuntimeJobs } from '@/lib/dsg/server/repository';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
 
 export async function GET(request: Request) {
   const actor = await requireVerifiedDsgActor(request.headers, 'job:read');
-  return NextResponse.json({ ok: true, data: { actor, jobs: [], source: 'database-read-route-pending' } });
+
+  try {
+    const jobs = await listRuntimeJobs({
+      workspaceId: actor.workspaceId,
+      actorId: actor.actorId,
+      userAccessToken: getBearerToken(request.headers),
+    });
+    return NextResponse.json({ ok: true, data: { jobs, source: 'supabase' } });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_LIST_JOBS_FAILED' } },
+      { status: 403 },
+    );
+  }
 }
 
 export async function POST(request: Request) {

--- a/docs/DSG_LAYER_2_READ_API.md
+++ b/docs/DSG_LAYER_2_READ_API.md
@@ -1,0 +1,30 @@
+# DSG Layer 2: Read API
+
+## Purpose
+Layer 2 adds read-only runtime visibility from the Supabase source-of-truth.
+
+## Routes
+
+```txt
+GET /api/dsg/jobs
+GET /api/dsg/jobs/[jobId]
+```
+
+## Data source
+The routes read from Supabase server-side after server-verified DSG actor resolution.
+
+## Included timeline tables
+
+```txt
+dsg_runtime_events
+dsg_evidence_items
+dsg_evidence_manifests
+dsg_audit_exports
+dsg_replay_proofs
+dsg_deployment_proofs
+dsg_production_flow_proofs
+dsg_completion_reports
+```
+
+## Truth boundary
+This layer is read-only. It must not seed jobs, insert mock proof rows, or claim production state.

--- a/lib/dsg/server/repository.ts
+++ b/lib/dsg/server/repository.ts
@@ -1,6 +1,6 @@
 import { createRuntimePlan as buildRuntimePlan } from '../runtime/planner';
 import type { RuntimeTask } from '../runtime/types';
-import { callDsgRpc, getDsgSupabaseRpcConfig } from './supabase-rpc';
+import { callDsgRpc, getDsgSupabaseRpcConfig, readDsgRest } from './supabase-rpc';
 
 export type DsgRepositoryContext = {
   workspaceId: string;
@@ -13,14 +13,106 @@ export type DsgRuntimeJobRecord = {
   workspaceId: string;
   goal: string;
   status: string;
+  riskLevel?: string;
+  currentWaveId?: string | null;
+  currentStepId?: string | null;
+  completionReportId?: string | null;
   createdBy: string;
   createdAt: string;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type DsgJobRow = {
+  id: string;
+  workspace_id: string;
+  goal: string;
+  status: string;
+  risk_level: string;
+  current_wave_id: string | null;
+  current_step_id: string | null;
+  completion_report_id: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  metadata: Record<string, unknown>;
 };
 
 export function assertRepositoryContext(context: DsgRepositoryContext): void {
   if (!context.workspaceId) throw new Error('DSG_WORKSPACE_REQUIRED');
   if (!context.actorId) throw new Error('DSG_ACTOR_REQUIRED');
   if (!context.userAccessToken) throw new Error('DSG_USER_ACCESS_TOKEN_REQUIRED');
+}
+
+function mapJob(row: DsgJobRow): DsgRuntimeJobRecord {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    goal: row.goal,
+    status: row.status,
+    riskLevel: row.risk_level,
+    currentWaveId: row.current_wave_id,
+    currentStepId: row.current_step_id,
+    completionReportId: row.completion_report_id,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    metadata: row.metadata,
+  };
+}
+
+export async function listRuntimeJobs(context: DsgRepositoryContext): Promise<DsgRuntimeJobRecord[]> {
+  assertRepositoryContext(context);
+  const rows = await readDsgRest<DsgJobRow[]>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_runtime_jobs', {
+    workspace_id: `eq.${context.workspaceId}`,
+    select: 'id,workspace_id,goal,status,risk_level,current_wave_id,current_step_id,completion_report_id,created_by,created_at,updated_at,metadata',
+    order: 'created_at.desc',
+    limit: '50',
+  });
+  return rows.map(mapJob);
+}
+
+export async function getRuntimeJob(context: DsgRepositoryContext, jobId: string): Promise<DsgRuntimeJobRecord> {
+  assertRepositoryContext(context);
+  if (!jobId) throw new Error('DSG_JOB_REQUIRED');
+  const rows = await readDsgRest<DsgJobRow[]>(getDsgSupabaseRpcConfig(context.userAccessToken), 'dsg_runtime_jobs', {
+    id: `eq.${jobId}`,
+    workspace_id: `eq.${context.workspaceId}`,
+    select: 'id,workspace_id,goal,status,risk_level,current_wave_id,current_step_id,completion_report_id,created_by,created_at,updated_at,metadata',
+    limit: '1',
+  });
+  const row = rows[0];
+  if (!row) throw new Error('DSG_JOB_NOT_FOUND');
+  return mapJob(row);
+}
+
+export async function getRuntimeJobTimeline(context: DsgRepositoryContext, jobId: string): Promise<{
+  job: DsgRuntimeJobRecord;
+  events: unknown[];
+  evidenceItems: unknown[];
+  evidenceManifests: unknown[];
+  auditExports: unknown[];
+  replayProofs: unknown[];
+  deploymentProofs: unknown[];
+  productionFlowProofs: unknown[];
+  completionReports: unknown[];
+}> {
+  const job = await getRuntimeJob(context, jobId);
+  const config = getDsgSupabaseRpcConfig(context.userAccessToken);
+  const base = { job_id: `eq.${jobId}`, workspace_id: `eq.${context.workspaceId}` };
+
+  const [events, evidenceItems, evidenceManifests, auditExports, replayProofs, deploymentProofs, productionFlowProofs, completionReports] = await Promise.all([
+    readDsgRest<unknown[]>(config, 'dsg_runtime_events', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_evidence_items', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_evidence_manifests', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_audit_exports', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_replay_proofs', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_deployment_proofs', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_production_flow_proofs', { ...base, select: '*', order: 'created_at.asc' }),
+    readDsgRest<unknown[]>(config, 'dsg_completion_reports', { ...base, select: '*', order: 'created_at.asc' }),
+  ]);
+
+  return { job, events, evidenceItems, evidenceManifests, auditExports, replayProofs, deploymentProofs, productionFlowProofs, completionReports };
 }
 
 export async function createWorkspace(

--- a/lib/dsg/server/supabase-rpc.ts
+++ b/lib/dsg/server/supabase-rpc.ts
@@ -21,6 +21,10 @@ export function getDsgSupabaseRpcConfig(userAccessToken?: string): DsgSupabaseRp
   return { url: url.replace(/\/$/, ''), key, userAccessToken };
 }
 
+function parseJsonBody<T>(text: string): T | DsgRpcError | null {
+  return text ? (JSON.parse(text) as T | DsgRpcError) : null;
+}
+
 export async function callDsgRpc<T>(
   config: DsgSupabaseRpcConfig,
   functionName: string,
@@ -38,12 +42,40 @@ export async function callDsgRpc<T>(
     cache: 'no-store',
   });
 
-  const text = await response.text();
-  const payload = text ? (JSON.parse(text) as T | DsgRpcError) : null;
+  const payload = parseJsonBody<T>(await response.text());
 
   if (!response.ok) {
     const error = payload as DsgRpcError | null;
     throw new Error(error?.message ?? `DSG_RPC_${response.status}`);
+  }
+
+  return payload as T;
+}
+
+export async function readDsgRest<T>(
+  config: DsgSupabaseRpcConfig,
+  tableName: string,
+  searchParams: Record<string, string>,
+): Promise<T> {
+  const url = new URL(`${config.url}/rest/v1/${tableName}`);
+  for (const [key, value] of Object.entries(searchParams)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  const payload = parseJsonBody<T>(await response.text());
+
+  if (!response.ok) {
+    const error = payload as DsgRpcError | null;
+    throw new Error(error?.message ?? `DSG_REST_${response.status}`);
   }
 
   return payload as T;

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -23,6 +23,7 @@ const required = [
   'lib/dsg/server/supabase-rpc.ts',
   'app/api/dsg/workspaces/route.ts',
   'app/api/dsg/jobs/route.ts',
+  'app/api/dsg/jobs/[jobId]/route.ts',
   'app/api/dsg/jobs/[jobId]/plan/route.ts',
   'app/api/dsg/jobs/[jobId]/evidence/route.ts',
   'app/api/dsg/jobs/[jobId]/evidence/manifest/route.ts',
@@ -55,6 +56,18 @@ const rpcClientSource = readFileSync(join(root, 'lib/dsg/server/supabase-rpc.ts'
 if (!rpcClientSource.includes('DSG_ONE_V1_SUPABASE_URL') || !rpcClientSource.includes('DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY')) {
   console.error('DSG deterministic runtime check failed: repo-scoped Supabase env names are missing');
   process.exit(1);
+}
+if (!rpcClientSource.includes('readDsgRest')) {
+  console.error('DSG deterministic runtime check failed: Supabase read helper is missing');
+  process.exit(1);
+}
+
+const repositorySource = readFileSync(join(root, 'lib/dsg/server/repository.ts'), 'utf8');
+for (const name of ['listRuntimeJobs', 'getRuntimeJob', 'getRuntimeJobTimeline']) {
+  if (!repositorySource.includes(name)) {
+    console.error(`DSG deterministic runtime check failed: missing read repository method ${name}`);
+    process.exit(1);
+  }
 }
 
 const envDoc = readFileSync(join(root, '.env.example'), 'utf8');


### PR DESCRIPTION
## Layer
Layer 2: Read API

## Summary
- Add Supabase REST read helper for server-side DSG read paths.
- Add repository methods for listing jobs and reading full job timeline/detail.
- Replace placeholder `GET /api/dsg/jobs` with a Supabase-backed read.
- Add `GET /api/dsg/jobs/[jobId]` for job timeline visibility.
- Extend deterministic runtime check coverage.
- Add Layer 2 read API documentation.

## Truth boundary
- Read-only layer.
- No seed data.
- No mock proof rows.
- No production claim.

## Expected checks
- DSG Verify workflow
- Vercel preview/build check

No production claim is made by this PR.