### PR TITLE
Layer 3: Add DSG production flow proof check

### DIFF
--- a/docs/DSG_LAYER_3_PRODUCTION_FLOW_PROOF.md
+++ b/docs/DSG_LAYER_3_PRODUCTION_FLOW_PROOF.md
@@ -1,0 +1,38 @@
+# DSG Layer 3: Production Flow Proof
+
+## Purpose
+Layer 3 adds a read-only production flow proof check for `dsg-one-v1`.
+
+## Command
+
+```bash
+DSG_ONE_V1_PRODUCTION_URL=https://<production-url> npm run dsg:production-flow-check
+```
+
+## What it proves
+The script performs a real HTTPS GET request to the supplied production URL and records deterministic hashes for the response body and proof payload.
+
+## Output
+
+```txt
+DSG production flow check passed
+url=<url>
+status=200
+bodyHash=sha256:<hash>
+proofHash=sha256:<hash>
+startedAt=<iso-time>
+completedAt=<iso-time>
+```
+
+## Truth boundary
+This layer is read-only. It does not insert runtime proof rows, seed data, mutate Supabase, or claim production readiness by itself.
+
+A full production claim still requires:
+
+```txt
+1. production deployment READY
+2. CI verification success
+3. production flow proof output
+4. runtime proof recording
+5. completion gate with proof ids
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dsg:claim-gate": "node scripts/dsg-claim-gate-check.mjs",
     "dsg:runtime-check": "node scripts/dsg-deterministic-runtime-check.mjs",
     "dsg:typecheck": "tsc --noEmit",
+    "dsg:production-flow-check": "node scripts/dsg-production-flow-check.mjs",
     "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint"
   },
   "dependencies": {

--- a/scripts/dsg-deterministic-runtime-check.mjs
+++ b/scripts/dsg-deterministic-runtime-check.mjs
@@ -21,6 +21,7 @@ const required = [
   'lib/dsg/server/context.ts',
   'lib/dsg/server/repository.ts',
   'lib/dsg/server/supabase-rpc.ts',
+  'scripts/dsg-production-flow-check.mjs',
   'app/api/dsg/workspaces/route.ts',
   'app/api/dsg/jobs/route.ts',
   'app/api/dsg/jobs/[jobId]/route.ts',
@@ -34,6 +35,7 @@ const required = [
   'app/api/dsg/jobs/[jobId]/completion/route.ts',
   'app/api/dsg/verify/route.ts',
   'docs/DSG_SUPABASE_BACKEND_WIRING.md',
+  'docs/DSG_LAYER_3_PRODUCTION_FLOW_PROOF.md',
 ];
 
 const missing = required.filter((file) => !existsSync(join(root, file)));
@@ -66,6 +68,20 @@ const repositorySource = readFileSync(join(root, 'lib/dsg/server/repository.ts')
 for (const name of ['listRuntimeJobs', 'getRuntimeJob', 'getRuntimeJobTimeline']) {
   if (!repositorySource.includes(name)) {
     console.error(`DSG deterministic runtime check failed: missing read repository method ${name}`);
+    process.exit(1);
+  }
+}
+
+const packageSource = readFileSync(join(root, 'package.json'), 'utf8');
+if (!packageSource.includes('dsg:production-flow-check')) {
+  console.error('DSG deterministic runtime check failed: production flow check script is missing from package.json');
+  process.exit(1);
+}
+
+const productionFlowSource = readFileSync(join(root, 'scripts/dsg-production-flow-check.mjs'), 'utf8');
+for (const requiredText of ['DSG_ONE_V1_PRODUCTION_URL', 'https://', 'proofHash=sha256:']) {
+  if (!productionFlowSource.includes(requiredText)) {
+    console.error(`DSG deterministic runtime check failed: production flow script missing ${requiredText}`);
     process.exit(1);
   }
 }

--- a/scripts/dsg-production-flow-check.mjs
+++ b/scripts/dsg-production-flow-check.mjs
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+
+const productionUrl = process.env.DSG_ONE_V1_PRODUCTION_URL;
+
+if (!productionUrl) {
+  console.error('DSG production flow check failed: DSG_ONE_V1_PRODUCTION_URL is required');
+  process.exit(1);
+}
+
+if (!productionUrl.startsWith('https://')) {
+  console.error('DSG production flow check failed: production URL must use https');
+  process.exit(1);
+}
+
+const startedAt = new Date().toISOString();
+const response = await fetch(productionUrl, {
+  method: 'GET',
+  headers: {
+    Accept: 'text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8',
+    'User-Agent': 'dsg-production-flow-check/1.0',
+  },
+  cache: 'no-store',
+});
+
+const body = await response.text();
+const completedAt = new Date().toISOString();
+const bodyHash = createHash('sha256').update(body, 'utf8').digest('hex');
+const proofHash = createHash('sha256')
+  .update(JSON.stringify({ productionUrl, status: response.status, ok: response.ok, bodyHash, startedAt, completedAt }), 'utf8')
+  .digest('hex');
+
+if (!response.ok) {
+  console.error(`DSG production flow check failed: status ${response.status}`);
+  console.error(`proofHash=sha256:${proofHash}`);
+  process.exit(1);
+}
+
+console.log('DSG production flow check passed');
+console.log(`url=${productionUrl}`);
+console.log(`status=${response.status}`);
+console.log(`bodyHash=sha256:${bodyHash}`);
+console.log(`proofHash=sha256:${proofHash}`);
+console.log(`startedAt=${startedAt}`);
+console.log(`completedAt=${completedAt}`);


### PR DESCRIPTION
## Layer
Layer 3: Production Flow Proof

## Summary
- Add read-only production flow proof script.
- Add `npm run dsg:production-flow-check`.
- Add Layer 3 documentation and deterministic guard coverage.

## Truth boundary
- This layer adds the proof mechanism only.
- The proof check requires `DSG_ONE_V1_PRODUCTION_URL` and should be run intentionally against a known production URL.
- It does not seed data, mutate Supabase, or claim production readiness.

## Expected checks
- DSG Verify workflow
- Vercel preview/build check

No production claim is made by this PR.