### PR TITLE
Make App Builder Agent UX claim-safe and user-first

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,8 @@
 
 import React, { useState } from 'react';
 import { 
-  ShieldCheck, Activity, Terminal, Users, BookOpen, 
-  Settings, Key, Server, Lock, Download, ChevronRight,
-  Search, Bell, FileText, CheckCircle2, AlertCircle, MessageSquare
+  ShieldCheck, Activity, Terminal, Users, Server, Lock,
+  ChevronRight, Search, Bell, FileText, AlertCircle, MessageSquare
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DashboardView } from '@/components/dashboard-view';
@@ -17,13 +16,13 @@ import { AgentPlaygroundView } from '@/components/agent-playground-view';
 type View = 'dashboard' | 'agents' | 'executions' | 'governance' | 'proof' | 'chat';
 
 export default function App() {
-  const [currentView, setCurrentView] = useState<View>('dashboard');
+  const [currentView, setCurrentView] = useState<View>('chat');
 
   const navItems = [
+    { id: 'chat', label: 'App Builder Agent', icon: MessageSquare },
     { id: 'dashboard', label: 'Mission Control', icon: Activity },
     { id: 'agents', label: 'Agents & Runtime', icon: Terminal },
-    { id: 'chat', label: 'Live Agent Chat', icon: MessageSquare },
-    { id: 'executions', label: 'Execution & Audit', icon: ShieldCheck },
+    { id: 'executions', label: 'Evidence Boundary', icon: ShieldCheck },
     { id: 'governance', label: 'Governance Policies', icon: Lock },
     { id: 'proof', label: 'Enterprise Proof', icon: FileText },
   ];
@@ -36,13 +35,12 @@ export default function App() {
       case 'executions': return <ExecutionsView />;
       case 'governance': return <GovernanceView />;
       case 'proof': return <EnterpriseProofView />;
-      default: return <DashboardView />;
+      default: return <AgentPlaygroundView />;
     }
   };
 
   return (
     <div className="flex h-screen w-full bg-slate-950 text-slate-300 font-sans">
-      {/* Sidebar */}
       <div className="w-64 border-r border-slate-800 bg-slate-950 flex flex-col">
         <div className="h-16 flex items-center px-6 border-b border-slate-800">
           <div className="flex items-center gap-2 text-indigo-400 font-bold text-lg tracking-wider">
@@ -85,15 +83,13 @@ export default function App() {
             </div>
             <div className="flex flex-col">
               <span className="text-slate-300 font-medium">Operator</span>
-              <span className="text-xs">Org: Acik Inc</span>
+              <span className="text-xs">Org scope: configured by headers</span>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        {/* Top Header */}
         <header className="h-16 border-b border-slate-800 flex items-center justify-between px-8 bg-slate-950/50 backdrop-blur-sm z-10 sticky top-0">
           <div className="flex items-center text-sm text-slate-500">
             <span>Control Plane</span>
@@ -106,23 +102,22 @@ export default function App() {
               <Search className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
               <input 
                 type="text"
-                placeholder="Search audit trail..."
-                className="bg-slate-900 border border-slate-800 rounded-full pl-9 pr-4 py-1.5 text-sm text-slate-300 focus:outline-none focus:border-indigo-500/50 w-64 placeholder:text-slate-600 transition-colors"
+                placeholder="Search is disabled until real evidence index exists..."
+                disabled
+                className="bg-slate-900 border border-slate-800 rounded-full pl-9 pr-4 py-1.5 text-sm text-slate-500 focus:outline-none w-72 placeholder:text-slate-600 transition-colors"
               />
             </div>
-            <button className="relative p-2 text-slate-400 hover:text-slate-200 transition-colors">
+            <button className="relative p-2 text-slate-500" aria-label="Notifications unavailable until evidence events exist">
               <Bell className="w-4 h-4" />
-              <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-indigo-500 rounded-full border-2 border-slate-950"></span>
             </button>
             <div className="h-8 border-l border-slate-800 mx-1"></div>
-            <div className="px-3 py-1 bg-emerald-500/10 text-emerald-400 text-xs font-semibold rounded uppercase tracking-wide border border-emerald-500/20 flex items-center gap-1.5">
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse"></span>
-              Live Environment
+            <div className="px-3 py-1 bg-amber-500/10 text-amber-200 text-xs font-semibold rounded uppercase tracking-wide border border-amber-500/20 flex items-center gap-1.5">
+              <AlertCircle className="w-3.5 h-3.5" />
+              Read-only planning layer
             </div>
           </div>
         </header>
 
-        {/* Scrollable View Area */}
         <main className="flex-1 overflow-y-auto p-8 bg-[#0a0f1c]">
           {renderView()}
         </main>

--- a/components/agent-playground-view.tsx
+++ b/components/agent-playground-view.tsx
@@ -1,289 +1,168 @@
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
-import { Send, Terminal, Loader2, PlayCircle, ShieldCheck, User } from 'lucide-react';
-import { GoogleGenAI } from '@google/genai';
-import { cn } from '@/lib/utils';
-import ReactMarkdown from 'react-markdown';
+import React, { useState } from 'react';
+import { AlertCircle, CheckCircle2, FileText, Loader2, PlayCircle, Send, ShieldCheck } from 'lucide-react';
 
-type Role = 'user' | 'model';
+type ApiResult<T> = { ok: true; data: T } | { ok: false; error: { code?: string; message?: string } };
 
-interface ChatMessage {
+type BuilderJob = {
   id: string;
-  role: Role;
-  text: string;
-  timestamp: string;
+  status: string;
+  claimStatus: string;
+  goal?: { normalizedGoal: string; goalHash: string; successCriteria: string[]; constraints: string[] };
+  prd?: { summary: string; coreFeatures: string[]; acceptanceCriteria: string[]; nonGoals: string[] };
+  proposedPlan?: {
+    steps: Array<{ id: string; title: string; phase: string; riskLevel: string; requiresApproval: boolean; allowedPaths: string[]; allowedCommands: string[]; expectedEvidence: string[] }>;
+  };
+  gateResult?: { status: string; riskLevel: string; approvalRequired: boolean; issues: Array<{ code: string; message: string; severity: string }> };
+  planHash?: string;
+  approvalHash?: string;
+};
+
+type Handoff = {
+  planHash: string;
+  approvalHash: string;
+  allowedTools: string[];
+  allowedPaths: string[];
+  allowedCommands: string[];
+  requiredSecrets: string[];
+  runtimeStatus: string;
+};
+
+function shortHash(value?: string) {
+  return value ? `${value.slice(0, 10)}…${value.slice(-6)}` : 'missing';
 }
 
-const AGENTS = [
-  {
-    id: 'ag_prod_8f9x2j',
-    name: 'Compliance Checker',
-    prompt: 'You are the Compliance Checker agent for DSG ONE. Your role is to evaluate inputs for PII leaks, rule violations, and enterprise compliance. Respond in a strict, professional tone.'
-  },
-  {
-    id: 'ag_prod_4h1x9l',
-    name: 'Customer Triage',
-    prompt: 'You are the Customer Triage agent for DSG ONE. Your role is to classify customer requests, determine urgency, and suggest routing. Be helpful, concise, and structured in your replies.'
-  },
-  {
-    id: 'ag_test_9p3m4z',
-    name: 'Finance Audit Agent',
-    prompt: 'You are the Finance Audit Agent for DSG ONE. Your role is to audit financial data, detect anomalies, and enforce ledger logic. Focus on numbers, risk analysis, and reconciliation.'
-  }
-];
-
-function createAgentGreeting(agentId: string): ChatMessage {
-  return {
-    id: `${agentId}-${Date.now().toString()}-greeting`,
-    role: 'model',
-    text: `Connected to **${AGENTS.find(a => a.id === agentId)?.name}**.\\n\\nReady to receive execution input.`,
-    timestamp: new Date().toLocaleTimeString()
-  };
+function readResult<T>(json: ApiResult<T>): T {
+  if (!json.ok) throw new Error(json.error?.message || json.error?.code || 'REQUEST_FAILED');
+  return json.data;
 }
 
 export function AgentPlaygroundView() {
-  const [messages, setMessages] = useState<ChatMessage[]>(() => [createAgentGreeting(AGENTS[0].id)]);
-  const [input, setInput] = useState('');
-  const [activeAgentId, setActiveAgentId] = useState(AGENTS[0].id);
-  const [isGenerating, setIsGenerating] = useState(false);
+  const [workspaceId, setWorkspaceId] = useState('demo-workspace');
+  const [actorId, setActorId] = useState('operator');
+  const [goal, setGoal] = useState('Build a governed full-stack app builder surface with PRD, plan, approval, and proof boundary.');
+  const [criteria, setCriteria] = useState('User sees PRD before plan\nApproval required before runtime handoff\nNo production claim without evidence ids');
+  const [constraints, setConstraints] = useState('Do not run actions before approval\nShow missing evidence instead of hiding it\nDo not claim production readiness');
+  const [job, setJob] = useState<BuilderJob | null>(null);
+  const [handoff, setHandoff] = useState<Handoff | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  
-  const bottomRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, isGenerating]);
+  async function api<T>(path: string, init?: RequestInit) {
+    const response = await fetch(path, {
+      ...init,
+      headers: {
+        'content-type': 'application/json',
+        'x-dsg-workspace-id': workspaceId.trim(),
+        'x-dsg-actor-id': actorId.trim(),
+        ...(init?.headers || {}),
+      },
+    });
+    const json = (await response.json().catch(() => ({ ok: false, error: { message: 'INVALID_JSON_RESPONSE' } }))) as ApiResult<T>;
+    if (!response.ok && json.ok) throw new Error(`HTTP_${response.status}`);
+    return readResult(json);
+  }
 
-  const activeAgent = AGENTS.find(a => a.id === activeAgentId) || AGENTS[0];
-
-  const handleAgentChange = (agentId: string) => {
-    setActiveAgentId(agentId);
-    setMessages([createAgentGreeting(agentId)]);
+  async function runStep(name: string, fn: () => Promise<void>) {
+    setBusy(name);
     setError(null);
-  };
-
-  const handleSendMessage = async () => {
-    if (!input.trim() || isGenerating) return;
-
-    const userMessageStr = input.trim();
-    setInput('');
-    setError(null);
-    setIsGenerating(true);
-
-    const newUserMessage: ChatMessage = {
-      id: Date.now().toString() + '-user',
-      role: 'user',
-      text: userMessageStr,
-      timestamp: new Date().toLocaleTimeString()
-    };
-
-    setMessages(prev => [...prev, newUserMessage]);
-
     try {
-      if (!process.env.NEXT_PUBLIC_GEMINI_API_KEY) {
-        throw new Error('Missing NEXT_PUBLIC_GEMINI_API_KEY. Please set this in the AI Studio Secrets panel.');
-      }
-
-      const ai = new GoogleGenAI({ apiKey: process.env.NEXT_PUBLIC_GEMINI_API_KEY });
-      
-      // Build history for context (excluding the first system greeting)
-      const dialogHistory = messages.slice(1).map(msg => ({
-        role: msg.role === 'model' ? 'model' : 'user',
-        parts: [{ text: msg.text }]
-      }));
-      
-      // Append new message
-      dialogHistory.push({
-        role: 'user',
-        parts: [{ text: userMessageStr }]
-      });
-
-      const response = await ai.models.generateContent({
-        model: 'gemini-3.1-pro-preview',
-        contents: dialogHistory as any,
-        config: {
-          systemInstruction: activeAgent.prompt
-        }
-      });
-
-      const responseText = response.text || 'No response generated.';
-
-      setMessages(prev => [...prev, {
-        id: Date.now().toString() + '-model',
-        role: 'model',
-        text: responseText,
-        timestamp: new Date().toLocaleTimeString()
-      }]);
-    } catch (err: any) {
-      console.error(err);
-      setError(err.message || 'An error occurred during agent execution.');
+      await fn();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'APP_BUILDER_REQUEST_FAILED');
     } finally {
-      setIsGenerating(false);
+      setBusy(null);
     }
-  };
+  }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  };
+  const createJob = () => runStep('goal', async () => {
+    setHandoff(null);
+    const data = await api<BuilderJob>('/api/dsg/app-builder/jobs', {
+      method: 'POST',
+      body: JSON.stringify({
+        goal,
+        successCriteria: criteria.split('\n').map((x) => x.trim()).filter(Boolean),
+        constraints: constraints.split('\n').map((x) => x.trim()).filter(Boolean),
+        targetStack: { frontend: 'nextjs', backend: 'next-api', database: 'none', auth: 'none', deploy: 'none' },
+      }),
+    });
+    setJob(data);
+  });
+
+  const createPlan = () => runStep('plan', async () => {
+    if (!job) throw new Error('APP_BUILDER_JOB_REQUIRED');
+    setHandoff(null);
+    setJob(await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/plan`, { method: 'POST' }));
+  });
+
+  const approvePlan = () => runStep('approval', async () => {
+    if (!job?.proposedPlan) throw new Error('APP_BUILDER_PLAN_REQUIRED');
+    setHandoff(null);
+    setJob(await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/approval`, {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'APPROVE', reason: 'Visible plan reviewed in the App Builder Agent UI.' }),
+    }));
+  });
+
+  const createHandoff = () => runStep('handoff', async () => {
+    if (!job?.approvalHash) throw new Error('APP_BUILDER_APPROVAL_REQUIRED');
+    setHandoff(await api<Handoff>(`/api/dsg/app-builder/jobs/${job.id}/runtime-handoff`, { method: 'POST' }));
+  });
+
+  const gateBlocked = job?.gateResult?.status === 'BLOCK';
+  const stages = [
+    ['Goal lock', job?.goal ? `goalHash ${shortHash(job.goal.goalHash)}` : 'waiting for user goal'],
+    ['PRD draft', job?.prd ? 'present from API response' : 'missing'],
+    ['Proposed plan', job?.proposedPlan ? `${job.proposedPlan.steps.length} steps` : 'missing'],
+    ['Gate', job?.gateResult ? `${job.gateResult.status} / ${job.gateResult.riskLevel}` : 'missing'],
+    ['Approval', job?.approvalHash ? `approvalHash ${shortHash(job.approvalHash)}` : 'missing'],
+    ['Runtime handoff', handoff ? `planHash ${shortHash(handoff.planHash)}` : 'missing'],
+  ];
 
   return (
-    <div className="space-y-6 max-w-5xl mx-auto h-[calc(100vh-8rem)] flex flex-col">
-      <div className="flex justify-between items-start shrink-0">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-100 items-center flex gap-2">
-            Live Agent Chat & Verification
-          </h1>
-          <p className="text-slate-500 mt-1">Interact with your provisioned AI agents in a controlled execution wrapper.</p>
-        </div>
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
+        <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200"><ShieldCheck className="h-4 w-4" /> App Builder Agent · governed planning</div>
+        <p className="mt-3">This screen calls the real Step 15 App Builder API. It can lock a goal, create PRD and plan, run the plan gate, record approval, and create a runtime handoff. It does not run commands, change files, deploy previews, or claim production readiness.</p>
       </div>
 
-      <div className="flex-1 min-h-0 border border-slate-800 rounded-2xl bg-slate-900 flex flex-col overflow-hidden shadow-2xl">
-        {/* Chat Header */}
-        <div className="h-16 px-6 border-b border-slate-800 bg-slate-950/50 flex items-center justify-between shrink-0">
-          <div className="flex items-center gap-4">
-            <div className="w-10 h-10 rounded-lg bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center">
-              <Terminal className="w-5 h-5 text-indigo-400" />
-            </div>
-            <div>
-              <div className="flex items-center gap-2">
-                <span className="font-semibold text-slate-200">{activeAgent.name}</span>
-                <span className="px-2 py-0.5 rounded text-[10px] font-mono font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 uppercase">
-                  Runtime Active
-                </span>
-              </div>
-              <div className="text-xs text-slate-500 font-mono mt-0.5">
-                Target: {activeAgent.id} • API Key: Bound
-              </div>
-            </div>
+      <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+        <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900 p-5">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100">Build with review before action</h1>
+            <p className="mt-1 text-sm text-slate-500">User goal → PRD → proposed plan → gate → approval → handoff.</p>
           </div>
-          <div className="flex bg-slate-900/80 p-1 rounded-lg border border-slate-800">
-            {AGENTS.map(agent => (
-              <button
-                key={agent.id}
-                onClick={() => handleAgentChange(agent.id)}
-                className={cn(
-                  "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
-                  activeAgentId === agent.id 
-                    ? "bg-slate-800 text-slate-200 shadow-sm" 
-                    : "text-slate-500 hover:text-slate-300"
-                )}
-              >
-                {agent.name}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        {/* Chat Messages */}
-        <div className="flex-1 overflow-y-auto p-6 space-y-6">
-          {messages.map((message) => (
-            <div 
-              key={message.id} 
-              className={cn(
-                "flex gap-4 max-w-[85%]",
-                message.role === 'user' ? "ml-auto flex-row-reverse" : ""
-              )}
-            >
-              <div className="shrink-0 pt-1">
-                {message.role === 'model' ? (
-                  <div className="w-8 h-8 rounded-md bg-indigo-500/20 border border-indigo-500/30 flex items-center justify-center">
-                    <ShieldCheck className="w-4 h-4 text-indigo-400" />
-                  </div>
-                ) : (
-                  <div className="w-8 h-8 rounded-md bg-slate-800 border border-slate-700 flex items-center justify-center">
-                    <User className="w-4 h-4 text-slate-400" />
-                  </div>
-                )}
-              </div>
-              <div className={cn(
-                "flex flex-col gap-1",
-                message.role === 'user' ? "items-end" : "items-start"
-              )}>
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs font-medium text-slate-400">
-                    {message.role === 'model' ? activeAgent.name : 'Operator'}
-                  </span>
-                  <span className="text-[10px] text-slate-600 font-mono">
-                    {message.timestamp}
-                  </span>
-                </div>
-                <div className={cn(
-                  "px-4 py-3 rounded-2xl text-sm leading-relaxed",
-                  message.role === 'user' 
-                    ? "bg-indigo-600/20 border border-indigo-500/30 text-slate-200 rounded-tr-sm" 
-                    : "bg-slate-800/50 border border-slate-700 text-slate-300 rounded-tl-sm markdown-body"
-                )}>
-                  {message.role === 'user' ? (
-                    <div className="whitespace-pre-wrap">{message.text}</div>
-                  ) : (
-                    <div className="prose prose-invert prose-sm max-w-none markdown-body">
-                      <ReactMarkdown>
-                        {message.text}
-                      </ReactMarkdown>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ))}
-
-          {isGenerating && (
-            <div className="flex gap-4 max-w-[85%]">
-              <div className="shrink-0 pt-1">
-                <div className="w-8 h-8 rounded-md bg-indigo-500/20 border border-indigo-500/30 flex items-center justify-center">
-                  <ShieldCheck className="w-4 h-4 text-indigo-400" />
-                </div>
-              </div>
-              <div className="flex flex-col gap-1 items-start">
-                 <div className="flex items-baseline gap-2">
-                  <span className="text-xs font-medium text-slate-400">{activeAgent.name}</span>
-                </div>
-                <div className="px-4 py-3 rounded-2xl bg-slate-800/50 border border-slate-700 rounded-tl-sm flex items-center gap-2">
-                  <Loader2 className="w-4 h-4 text-indigo-400 animate-spin" />
-                  <span className="text-sm text-slate-400 font-mono">Executing trace & policy validation...</span>
-                </div>
-              </div>
-            </div>
-          )}
-          <div ref={bottomRef} />
-        </div>
-
-        {error && (
-          <div className="mx-6 px-4 py-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-sm mb-4">
-            <span className="font-semibold">Execution Failed:</span> {error}
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-1 text-xs text-slate-400">Workspace ID<input value={workspaceId} onChange={(e) => setWorkspaceId(e.target.value)} className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none focus:border-indigo-500" /></label>
+            <label className="space-y-1 text-xs text-slate-400">Actor ID<input value={actorId} onChange={(e) => setActorId(e.target.value)} className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none focus:border-indigo-500" /></label>
           </div>
-        )}
+          <label className="space-y-2 text-xs text-slate-400">Goal<textarea rows={4} value={goal} onChange={(e) => setGoal(e.target.value)} className="w-full rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm leading-6 text-slate-200 outline-none focus:border-indigo-500" /></label>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-2 text-xs text-slate-400">Success criteria<textarea rows={4} value={criteria} onChange={(e) => setCriteria(e.target.value)} className="w-full rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm leading-6 text-slate-200 outline-none focus:border-indigo-500" /></label>
+            <label className="space-y-2 text-xs text-slate-400">Constraints<textarea rows={4} value={constraints} onChange={(e) => setConstraints(e.target.value)} className="w-full rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm leading-6 text-slate-200 outline-none focus:border-indigo-500" /></label>
+          </div>
 
-        {/* Input Area */}
-        <div className="p-4 bg-slate-950/80 border-t border-slate-800 shrink-0">
-          <div className="max-w-4xl mx-auto relative group">
-            <textarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Enter execution payload, test case, or direct message..."
-              className="w-full bg-slate-900 border border-slate-700 rounded-xl pl-4 pr-14 py-3.5 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-all resize-none min-h-[60px] max-h-48"
-              rows={1}
-            />
-            <button 
-              onClick={handleSendMessage}
-              disabled={!input.trim() || isGenerating}
-              className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:bg-slate-800 disabled:text-slate-600 text-white transition-colors"
-            >
-              {isGenerating ? <Loader2 className="w-4 h-4 animate-spin" /> : <PlayCircle className="w-4 h-4" />}
-            </button>
+          {error && <div className="rounded-xl border border-rose-500/25 bg-rose-500/10 p-4 text-sm text-rose-200"><AlertCircle className="mr-2 inline h-4 w-4" />{error}</div>}
+
+          <div className="flex flex-wrap gap-3">
+            <button onClick={createJob} disabled={!!busy || !goal.trim()} className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500 disabled:bg-slate-800 disabled:text-slate-500">{busy === 'goal' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Lock goal</button>
+            <button onClick={createPlan} disabled={!!busy || !job} className="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800 disabled:text-slate-600">{busy === 'plan' ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileText className="h-4 w-4" />} PRD + plan</button>
+            <button onClick={approvePlan} disabled={!!busy || !job?.proposedPlan || gateBlocked} className="inline-flex items-center gap-2 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm font-bold text-emerald-200 hover:bg-emerald-500/15 disabled:border-slate-800 disabled:text-slate-600">{busy === 'approval' ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />} Approve plan</button>
+            <button onClick={createHandoff} disabled={!!busy || !job?.approvalHash} className="inline-flex items-center gap-2 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-sm font-bold text-amber-100 hover:bg-amber-500/15 disabled:border-slate-800 disabled:text-slate-600">{busy === 'handoff' ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlayCircle className="h-4 w-4" />} Runtime handoff</button>
           </div>
-          <div className="text-center mt-2.5">
-            <p className="text-[10px] text-slate-600 flex items-center justify-center gap-1.5 font-mono">
-              <ShieldCheck className="w-3 h-3 text-emerald-500" />
-              Runtime decisions will trigger rule checks automatically.
-            </p>
+        </section>
+
+        <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900 p-5">
+          <div className="flex items-center justify-between gap-3"><h2 className="text-lg font-bold text-slate-100">Visible state</h2><span className="rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-400">{job?.claimStatus ?? 'NO_JOB'}</span></div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {stages.map(([label, detail]) => <div key={label} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4"><p className="font-semibold text-slate-200">{label}</p><p className="mt-1 text-xs font-mono text-slate-500">{detail}</p></div>)}
           </div>
-        </div>
+          {job?.prd && <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4"><p className="font-semibold text-slate-200">PRD</p><p className="mt-2 text-sm leading-6 text-slate-400">{job.prd.summary}</p></div>}
+          {job?.proposedPlan && <div className="space-y-3">{job.proposedPlan.steps.map((step) => <div key={step.id} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4"><p className="text-xs font-mono text-slate-500">{step.id} · {step.phase} · {step.riskLevel}{step.requiresApproval ? ' · approval required' : ''}</p><p className="mt-1 font-semibold text-slate-200">{step.title}</p><p className="mt-2 text-xs text-slate-500">Evidence: {step.expectedEvidence.join(', ') || 'missing'}</p></div>)}</div>}
+          {handoff && <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">Runtime handoff exists with planHash {shortHash(handoff.planHash)}. This is authorization data only, not execution proof.</div>}
+        </section>
       </div>
     </div>
   );

--- a/components/agents-view.tsx
+++ b/components/agents-view.tsx
@@ -1,86 +1,91 @@
 'use client';
 
 import React from 'react';
-import { Terminal, Plus, Key, Copy, MoreHorizontal } from 'lucide-react';
+import { Copy, Key, Lock, MoreHorizontal, Plus, Terminal } from 'lucide-react';
+
+const agentCapabilities = [
+  { id: 'app-builder-step-15', name: 'App Builder Planning Agent', status: 'planning-ready', scope: 'Goal, PRD, plan, gate, approval, handoff', proof: 'Step 15 API routes' },
+  { id: 'runtime-step-16', name: 'Action Runtime Executor', status: 'not-enabled', scope: 'Write files, run commands, test, build, deploy', proof: 'Missing Step 16 runtime evidence' },
+  { id: 'production-claim-gate', name: 'Production Claim Gate', status: 'blocked', scope: 'Production readiness claim', proof: 'Requires deployment + runtime proof ids' },
+];
 
 export function AgentsView() {
-  const agents = [
-    { id: 'ag_prod_8f9x2j', name: 'Compliance Checker', status: 'active', calls: '12.4k', lastRun: '2m ago' },
-    { id: 'ag_prod_4h1x9l', name: 'Customer Triage', status: 'active', calls: '8.1k', lastRun: '5m ago' },
-    { id: 'ag_test_9p3m4z', name: 'Finance Audit Agent', status: 'paused', calls: '0', lastRun: 'never' },
-  ];
-
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
-      <div className="flex justify-between items-start">
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-slate-100 items-center flex gap-2">
-            Agents & Runtime
-          </h1>
-          <p className="text-slate-500 mt-1">Manage API-key-based execution contexts and agents.</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Agents & Runtime</h1>
+          <p className="mt-1 text-slate-500">Capability inventory. Nothing here claims live execution unless runtime evidence exists.</p>
         </div>
-        <button className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition">
-          <Plus className="w-4 h-4" /> New Agent
+        <button disabled className="flex items-center gap-2 rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-slate-500">
+          <Plus className="h-4 w-4" /> New Agent disabled
         </button>
       </div>
 
-      <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
+        <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200">
+          <Lock className="h-4 w-4" /> Permission boundary
+        </div>
+        <p className="mt-3">The App Builder Agent can prepare an approved handoff. Runtime execution, API keys, shell commands, file writes, and deployment require Step 16 evidence before the UI may call them active.</p>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
         <table className="w-full text-left text-sm">
-          <thead className="bg-slate-900/50 border-b border-slate-800 text-slate-500">
+          <thead className="border-b border-slate-800 bg-slate-900/50 text-slate-500">
             <tr>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Agent Name</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Agent ID</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Status</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs text-right">Calls (30d)</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs text-right">Last Run</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs text-center">Actions</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Capability</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Scope</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Status</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider text-right">Proof</th>
+              <th className="px-6 py-4 text-center text-xs font-medium uppercase tracking-wider">Action</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
-            {agents.map((agent) => (
-              <tr key={agent.id} className="hover:bg-slate-800/20 transition-colors">
-                <td className="px-6 py-4 font-medium text-slate-200">
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded bg-slate-800 border border-slate-700 flex items-center justify-center">
-                      <Terminal className="w-4 h-4 text-indigo-400" />
+            {agentCapabilities.map((agent) => {
+              const ready = agent.status === 'planning-ready';
+              return (
+                <tr key={agent.id} className="hover:bg-slate-800/20">
+                  <td className="px-6 py-4 font-medium text-slate-200">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 items-center justify-center rounded border border-slate-700 bg-slate-800">
+                        <Terminal className="h-4 w-4 text-indigo-400" />
+                      </div>
+                      <div>
+                        <p>{agent.name}</p>
+                        <p className="mt-0.5 font-mono text-xs text-slate-500">{agent.id}</p>
+                      </div>
                     </div>
-                    {agent.name}
-                  </div>
-                </td>
-                <td className="px-6 py-4 font-mono text-emerald-400/80 text-xs">{agent.id}</td>
-                <td className="px-6 py-4">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                    agent.status === 'active' ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-slate-800 text-slate-400 border border-slate-700'
-                  }`}>
-                    {agent.status}
-                  </span>
-                </td>
-                <td className="px-6 py-4 text-right text-slate-400">{agent.calls}</td>
-                <td className="px-6 py-4 text-right text-slate-400">{agent.lastRun}</td>
-                <td className="px-6 py-4 text-center">
-                  <button className="text-slate-500 hover:text-slate-300">
-                    <MoreHorizontal className="w-5 h-5 mx-auto" />
-                  </button>
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className="px-6 py-4 text-slate-400">{agent.scope}</td>
+                  <td className="px-6 py-4">
+                    <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${ready ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400' : 'border-amber-500/20 bg-amber-500/10 text-amber-200'}`}>
+                      {agent.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-right text-xs text-slate-500">{agent.proof}</td>
+                  <td className="px-6 py-4 text-center">
+                    <button disabled className="text-slate-600">
+                      <MoreHorizontal className="mx-auto h-5 w-5" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
 
-      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
-        <h3 className="font-semibold text-slate-200 mb-2 flex items-center gap-2">
-          <Key className="w-4 h-4 text-slate-400" /> Current Runtime API Key
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+        <h3 className="mb-2 flex items-center gap-2 font-semibold text-slate-200">
+          <Key className="h-4 w-4 text-slate-400" /> Runtime API key
         </h3>
-        <p className="text-sm text-slate-500 mb-4 items-center">
-          This key provides runtime execution access. It only displays once upon generation.
-        </p>
+        <p className="mb-4 text-sm text-slate-500">No runtime key is displayed in this UI. Keys must be bound server-side and proven by Step 16 runtime evidence before execution is enabled.</p>
         <div className="flex gap-3">
-          <div className="bg-slate-950 border border-slate-800 rounded px-4 py-2 flex-1 font-mono text-slate-400 text-sm flex justify-between items-center cursor-not-allowed opacity-70">
-            dsg_rk_*********************************************
+          <div className="flex flex-1 cursor-not-allowed items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-2 font-mono text-sm text-slate-600">
+            not-bound-in-ui
           </div>
-          <button className="bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded px-4 py-2 text-slate-300 flex items-center gap-2 text-sm font-medium transition">
-             Roll Key
+          <button disabled className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-600">
+            <Copy className="h-4 w-4" /> Copy disabled
           </button>
         </div>
       </div>

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -1,103 +1,117 @@
 'use client';
 
 import React from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import { Activity, Zap, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { Activity, AlertTriangle, FileText, ShieldCheck, Terminal, Zap } from 'lucide-react';
 
-const mockChartData = [
-  { time: '00:00', val: 400 },
-  { time: '04:00', val: 300 },
-  { time: '08:00', val: 550 },
-  { time: '12:00', val: 800 },
-  { time: '16:00', val: 650 },
-  { time: '20:00', val: 900 },
-  { time: '24:00', val: 850 },
+const readinessItems = [
+  {
+    label: 'Step 15 App Builder backend',
+    value: 'Present',
+    detail: 'Goal lock, PRD, plan, gate, approval, and handoff routes exist in repo.',
+    icon: FileText,
+  },
+  {
+    label: 'Action execution proof',
+    value: 'Missing',
+    detail: 'No shell/file/deploy execution proof is claimed from this dashboard.',
+    icon: Terminal,
+  },
+  {
+    label: 'Production readiness claim',
+    value: 'Blocked',
+    detail: 'Requires CI, deployment, runtime proof ids, replay proof, and completion gate evidence.',
+    icon: AlertTriangle,
+  },
+  {
+    label: 'User protection boundary',
+    value: 'Visible',
+    detail: 'Missing evidence is shown as missing instead of converted into success metrics.',
+    icon: ShieldCheck,
+  },
+];
+
+const proofRows = [
+  ['Locked goal', 'Available after user creates App Builder job'],
+  ['PRD draft', 'Generated only after a job exists and plan is requested'],
+  ['Plan gate', 'PASS / REVIEW / BLOCK from Step 15 gate logic'],
+  ['Approval hash', 'Missing until user approves a visible plan'],
+  ['Runtime handoff', 'Authorization data only; not command execution'],
+  ['Execution evidence', 'Missing until Step 16 runtime records it'],
 ];
 
 export function DashboardView() {
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
+    <div className="mx-auto max-w-6xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-100 items-center flex gap-2">
-          Mission Control
-        </h1>
-        <p className="text-slate-500 mt-1">Live visibility into AI runtime execution and readiness.</p>
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Mission Control</h1>
+        <p className="mt-1 text-slate-500">User-safe overview of what is proven, what is missing, and what must not be claimed yet.</p>
       </div>
 
-      {/* KPIS */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        {[
-          { label: 'Total Executions', value: '42,891', diff: '+12%', status: 'text-emerald-400', icon: Zap },
-          { label: 'Policy Blocks', value: '142', diff: '+2%', status: 'text-indigo-400', icon: ShieldCheck },
-          { label: 'Avg Latency', value: '184ms', diff: '-14ms', status: 'text-emerald-400', icon: Activity },
-          { label: 'System Readiness', value: 'Green', diff: '100% Up', status: 'text-emerald-400', icon: AlertTriangle, bg: 'bg-emerald-500/10' },
-        ].map((stat, i) => {
-          const Icon = stat.icon;
+      <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
+        <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200">
+          <ShieldCheck className="h-4 w-4" /> No mock metrics
+        </div>
+        <p className="mt-3">
+          This dashboard intentionally avoids fake execution counts, fake latency, fake 100% proof rates, and fake green readiness. Use the App Builder Agent tab to create real Step 15 records. Production readiness remains blocked until runtime evidence exists.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        {readinessItems.map((item) => {
+          const Icon = item.icon;
           return (
-            <div key={i} className="bg-slate-900 border border-slate-800 rounded-xl p-5 hover:border-slate-700 transition duration-300">
-              <div className="flex justify-between items-start text-slate-400 mb-2">
-                <span className="text-sm font-medium">{stat.label}</span>
-                <Icon className={`w-4 h-4 ${stat.status}`} />
+            <div key={item.label} className="rounded-xl border border-slate-800 bg-slate-900 p-5">
+              <div className="mb-3 flex items-start justify-between gap-3 text-slate-400">
+                <span className="text-sm font-medium">{item.label}</span>
+                <Icon className="h-4 w-4 text-indigo-400" />
               </div>
-              <div className="text-2xl font-bold text-slate-200 mb-1">{stat.value}</div>
-              <div className={`text-xs ${stat.status} font-medium tracking-wide`}>{stat.diff}</div>
+              <div className="mb-2 text-2xl font-bold text-slate-200">{item.value}</div>
+              <div className="text-xs leading-5 text-slate-500">{item.detail}</div>
             </div>
           );
         })}
       </div>
 
-      {/* Chart Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2 bg-slate-900 border border-slate-800 rounded-xl p-6">
-          <div className="flex justify-between items-center mb-6">
-            <h3 className="font-semibold text-slate-200">Execution Volume (24h)</h3>
-            <div className="text-xs font-mono bg-slate-800 px-2 py-1 rounded text-slate-400">POST /api/execute</div>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="rounded-xl border border-slate-800 bg-slate-900 p-6 lg:col-span-2">
+          <div className="mb-5 flex items-center justify-between gap-3">
+            <h3 className="font-semibold text-slate-200">Builder journey</h3>
+            <div className="rounded bg-slate-800 px-2 py-1 font-mono text-xs text-slate-400">/api/dsg/app-builder/*</div>
           </div>
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={mockChartData}>
-                <defs>
-                  <linearGradient id="colorVal" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#818cf8" stopOpacity={0.3}/>
-                    <stop offset="95%" stopColor="#818cf8" stopOpacity={0}/>
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" vertical={false} />
-                <XAxis dataKey="time" stroke="#475569" fontSize={12} tickLine={false} axisLine={false} />
-                <YAxis stroke="#475569" fontSize={12} tickLine={false} axisLine={false} width={40} />
-                <Tooltip 
-                  contentStyle={{ backgroundColor: '#0f172a', borderColor: '#1e293b', color: '#f8fafc' }}
-                  itemStyle={{ color: '#818cf8' }}
-                />
-                <Area type="monotone" dataKey="val" stroke="#818cf8" strokeWidth={2} fillOpacity={1} fill="url(#colorVal)" />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
-
-        {/* Audit Status */}
-        <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 flex flex-col">
-          <h3 className="font-semibold text-slate-200 mb-4">Runtime Evidence Sync</h3>
-          
-          <div className="space-y-4 flex-1">
+          <div className="space-y-3">
             {[
-              { label: 'Ledger Match Rate', val: '100%', detail: 'Verified' },
-              { label: 'Replay Completeness', val: '100%', detail: 'Syncing' },
-              { label: 'Gate Decision Accuracy', val: '99.9%', detail: '0 False Allows' },
-              { label: 'Proof Presence', val: '100%', detail: 'Tamper Evident' },
-            ].map((item, i) => (
-              <div key={i} className="flex justify-between items-center p-3 bg-slate-950/50 rounded border border-slate-800/50">
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-slate-300">{item.label}</span>
-                  <span className="text-xs text-slate-500 mt-0.5">{item.detail}</span>
+              ['1', 'User goal', 'User describes what to build.'],
+              ['2', 'Goal lock', 'Server normalizes goal and records goalHash.'],
+              ['3', 'PRD + proposed plan', 'Server creates deterministic planning contract.'],
+              ['4', 'Gate + approval', 'Blocked plans cannot be approved. High-risk plans require approval.'],
+              ['5', 'Runtime handoff', 'Creates authorization data for Step 16. It does not execute actions.'],
+            ].map(([num, title, detail]) => (
+              <div key={num} className="grid grid-cols-[40px_1fr] gap-4 rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-indigo-500/30 bg-indigo-500/10 text-sm font-bold text-indigo-300">{num}</div>
+                <div>
+                  <p className="font-semibold text-slate-200">{title}</p>
+                  <p className="mt-1 text-sm text-slate-500">{detail}</p>
                 </div>
-                <span className="font-mono text-indigo-400 font-semibold">{item.val}</span>
               </div>
             ))}
           </div>
+        </div>
 
-          <button className="w-full mt-4 py-2 border border-slate-700 rounded-lg text-sm text-slate-300 hover:bg-slate-800 transition">
-            View Live Ledger
+        <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+          <h3 className="mb-4 font-semibold text-slate-200">Evidence ledger requirements</h3>
+          <div className="space-y-3">
+            {proofRows.map(([label, detail]) => (
+              <div key={label} className="rounded border border-slate-800/70 bg-slate-950/50 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-medium text-slate-300">{label}</span>
+                  <span className="font-mono text-xs text-slate-500">tracked</span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-slate-500">{detail}</p>
+              </div>
+            ))}
+          </div>
+          <button className="mt-4 w-full rounded-lg border border-slate-700 py-2 text-sm text-slate-300 transition hover:bg-slate-800">
+            Open App Builder Agent
           </button>
         </div>
       </div>

--- a/components/executions-view.tsx
+++ b/components/executions-view.tsx
@@ -1,83 +1,85 @@
 'use client';
 
 import React from 'react';
-import { Search, ShieldCheck, AlertCircle, Clock, ChevronRight } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Clock, Search, ShieldCheck } from 'lucide-react';
+
+const evidenceRows = [
+  { id: 'goal-lock', name: 'Goal lock record', state: 'Available through App Builder API', proof: 'goalHash' },
+  { id: 'prd-plan', name: 'PRD and proposed plan', state: 'Available after Generate PRD + plan', proof: 'proposed_plan + gate_result' },
+  { id: 'approval', name: 'Approval record', state: 'Available after user approves visible plan', proof: 'approvalHash' },
+  { id: 'handoff', name: 'Runtime handoff', state: 'Available after approval', proof: 'planHash + allowed tools' },
+  { id: 'execution', name: 'Action execution log', state: 'Missing until Step 16 runtime exists', proof: 'not claimed' },
+  { id: 'deploy', name: 'Preview or production deployment proof', state: 'Missing until deploy proof is recorded', proof: 'not claimed' },
+];
 
 export function ExecutionsView() {
-  const executions = [
-    { reqId: 'req_9281a', agent: 'Compliance Checker', status: 'Allowed', latency: '192ms', timestamp: '2026-04-18 14:22:01' },
-    { reqId: 'req_9281b', agent: 'Customer Triage', status: 'Allowed', latency: '145ms', timestamp: '2026-04-18 14:21:45' },
-    { reqId: 'req_9281c', agent: 'Compliance Checker', status: 'Blocked', latency: '89ms', timestamp: '2026-04-18 14:18:12', reason: 'Policy Violation: PII detected' },
-    { reqId: 'req_9281d', agent: 'Finance Audit Agent', status: 'Blocked', latency: '40ms', timestamp: '2026-04-18 14:15:00', reason: 'Unverified Identity' },
-    { reqId: 'req_9281e', agent: 'Customer Triage', status: 'Allowed', latency: '166ms', timestamp: '2026-04-18 14:12:33' },
-  ];
-
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
-      <div className="flex justify-between items-start">
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-slate-100 items-center flex gap-2">
-            Execution & Audit Log
-          </h1>
-          <p className="text-slate-500 mt-1">Reviewable traces, state transitions, and execution decisions.</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Execution & Evidence Boundary</h1>
+          <p className="mt-1 text-slate-500">No seeded execution rows. This view shows what proof exists or remains missing.</p>
         </div>
+      </div>
+
+      <div className="rounded-2xl border border-rose-500/25 bg-rose-500/10 p-5 text-sm leading-7 text-rose-100">
+        <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-rose-200">
+          <AlertCircle className="h-4 w-4" /> Claim boundary
+        </div>
+        <p className="mt-3">
+          Previous seeded request ids and allowed/blocked outcomes were removed because they looked like real audit events. Real executions must come from runtime evidence, audit ledger rows, deployment proof, and replay proof.
+        </p>
       </div>
 
       <div className="flex gap-4 items-center">
         <div className="relative flex-1">
-          <Search className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
-          <input 
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <input
             type="text"
-            placeholder="Filter by trace ID, agent, or policy outcome..."
-            className="w-full bg-slate-900 border border-slate-800 rounded-lg pl-10 pr-4 py-2 text-sm text-slate-300 focus:outline-none focus:border-indigo-500/50 placeholder:text-slate-600 transition-colors"
+            placeholder="Search will connect to real evidence once Step 16 runtime evidence exists..."
+            disabled
+            className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-500 outline-none placeholder:text-slate-600"
           />
         </div>
-        <select className="bg-slate-900 border border-slate-800 rounded-lg px-4 py-2 text-sm text-slate-300 focus:outline-none focus:border-indigo-500/50 appearance-none">
-          <option>All Outcomes</option>
-          <option>Allowed</option>
-          <option>Blocked</option>
-        </select>
-        <button className="bg-slate-900 border border-slate-800 rounded-lg px-4 py-2 text-sm text-slate-300 hover:bg-slate-800 transition">
-          Export Log
+        <button disabled className="rounded-lg border border-slate-800 bg-slate-900 px-4 py-2 text-sm text-slate-600">
+          Export disabled until evidence exists
         </button>
       </div>
 
-      <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
         <table className="w-full text-left text-sm">
-          <thead className="bg-slate-900/50 border-b border-slate-800 text-slate-500">
+          <thead className="border-b border-slate-800 bg-slate-900/50 text-slate-500">
             <tr>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Request ID</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Agent</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Decision</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs text-right">Latency</th>
-              <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs text-right">Timestamp (UTC)</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Evidence item</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Current state</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Proof field</th>
+              <th className="px-6 py-4 text-right text-xs font-medium uppercase tracking-wider">Claim status</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
-            {executions.map((exec) => (
-              <tr key={exec.reqId} className="hover:bg-slate-800/20 transition-colors cursor-pointer group">
-                <td className="px-6 py-4 font-mono text-slate-400 text-xs flex items-center gap-2">
-                  <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-indigo-400 transition" />
-                  {exec.reqId}
-                </td>
-                <td className="px-6 py-4 text-slate-300">{exec.agent}</td>
-                <td className="px-6 py-4">
-                  <div className="flex flex-col gap-1">
-                    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold w-fit ${
-                      exec.status === 'Allowed' ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-rose-500/10 text-rose-400 border border-rose-500/20'
-                    }`}>
-                      {exec.status === 'Allowed' ? <ShieldCheck className="w-3.5 h-3.5" /> : <AlertCircle className="w-3.5 h-3.5" />}
-                      {exec.status}
+            {evidenceRows.map((row) => {
+              const missing = row.proof === 'not claimed';
+              return (
+                <tr key={row.id} className="hover:bg-slate-800/20">
+                  <td className="px-6 py-4 font-medium text-slate-200">{row.name}</td>
+                  <td className="px-6 py-4 text-slate-400">{row.state}</td>
+                  <td className="px-6 py-4 font-mono text-xs text-slate-500">{row.proof}</td>
+                  <td className="px-6 py-4 text-right">
+                    <span className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold ${missing ? 'border-amber-500/25 bg-amber-500/10 text-amber-200' : 'border-emerald-500/25 bg-emerald-500/10 text-emerald-300'}`}>
+                      {missing ? <Clock className="h-3.5 w-3.5" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+                      {missing ? 'Missing' : 'Step 15 proof field'}
                     </span>
-                    {exec.reason && <span className="text-xs text-slate-500 font-mono mt-1">{exec.reason}</span>}
-                  </div>
-                </td>
-                <td className="px-6 py-4 text-right text-slate-400 font-mono text-xs"><Clock className="w-3 h-3 inline mr-1 text-slate-600"/>{exec.latency}</td>
-                <td className="px-6 py-4 text-right text-slate-400 font-mono text-xs">{exec.timestamp}</td>
-              </tr>
-            ))}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
+      </div>
+
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-5 text-sm leading-7 text-slate-400">
+        <div className="flex items-center gap-2 font-bold text-slate-200"><ShieldCheck className="h-4 w-4 text-indigo-400" /> Consumer-safe rule</div>
+        <p className="mt-2">If evidence is missing, the UI must say missing. It must not convert demo data into production success, uptime, latency, audit completeness, or execution counts.</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

This PR changes the main `dsg-one-v1` app surface from a generic live runtime dashboard into a user-safe App Builder Agent flow inspired by conversational app builders, while keeping DSG's truth boundary intact.

## What changed

- Default view is now **App Builder Agent**.
- Agent flow now calls the real Step 15 API path:
  - `POST /api/dsg/app-builder/jobs`
  - `POST /api/dsg/app-builder/jobs/:jobId/plan`
  - `POST /api/dsg/app-builder/jobs/:jobId/approval`
  - `POST /api/dsg/app-builder/jobs/:jobId/runtime-handoff`
- Removed browser-side Gemini execution from the agent UI.
- Removed fake dashboard metrics such as execution counts, latency, 100% proof rates, and green readiness.
- Replaced seeded audit rows with an evidence boundary table that shows missing proof honestly.
- Replaced fake agent/runtime inventory with capability states:
  - App Builder Planning Agent: planning-ready
  - Action Runtime Executor: not-enabled
  - Production Claim Gate: blocked
- Changed shell badge from `Live Environment` to `Read-only planning layer`.
- Disabled search/notifications until a real evidence index/event source exists.

## Consumer-safe truth boundary

This PR does **not** claim:

- shell command execution
- file write execution
- preview deployment
- production readiness
- runtime proof completion
- Manus clone completion

It only claims Step 15 planning and runtime handoff readiness when the real API returns those records.

## Why

The previous UI showed several values that looked like production facts without evidence backing:

- seeded execution rows
- fake request IDs
- fake 30-day call counts
- fake uptime/readiness style metrics
- `Live Environment` wording
- `Runtime Active` / `API Key: Bound` style language

This PR makes the user journey more valuable and safer: goal → PRD → proposed plan → gate → approval → handoff, with missing evidence shown as missing.