### PR TITLE
Step 16E: Add governed memory API routes for DSG One

### DIFF
--- a/app/api/dsg/memory/context-pack/route.ts
+++ b/app/api/dsg/memory/context-pack/route.ts
@@ -1,0 +1,24 @@
+import { getDevMemoryContext } from '@/lib/dsg/server/memory/context';
+import { createContextPack } from '@/lib/dsg/server/memory/repository';
+import { asRecord, jsonFail, jsonOk, parseMemories, parseScope, statusForError, stringArray } from '@/lib/dsg/server/memory/route-utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const ctx = getDevMemoryContext(req, ['memory:context_pack', 'memory:read']);
+    const body = asRecord(await req.json().catch(() => null));
+    const memories = parseMemories(body.memories);
+    if (!memories.length) throw new Error('MEMORIES_REQUIRED');
+    const scope = parseScope(body.scope, 'planning');
+    const contextPack = await createContextPack(ctx, {
+      memories,
+      scope,
+      evidenceIds: stringArray(body.evidenceIds),
+      auditIds: stringArray(body.auditIds),
+    });
+    return jsonOk({ contextPack }, 201);
+  } catch (error) {
+    return jsonFail(error, statusForError(error));
+  }
+}

--- a/app/api/dsg/memory/gate/route.ts
+++ b/app/api/dsg/memory/gate/route.ts
@@ -1,0 +1,23 @@
+import { getDevMemoryContext } from '@/lib/dsg/server/memory/context';
+import { gateMemory } from '@/lib/dsg/server/memory/repository';
+import { asRecord, jsonFail, jsonOk, optionalString, parseMemories, parseScope, statusForError } from '@/lib/dsg/server/memory/route-utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const ctx = getDevMemoryContext(req, ['memory:gate', 'memory:read']);
+    const body = asRecord(await req.json().catch(() => null));
+    const memories = parseMemories(body.memories);
+    if (!memories.length) throw new Error('MEMORIES_REQUIRED');
+    const scope = parseScope(body.scope, 'planning');
+    const gate = await gateMemory(ctx, {
+      memories,
+      scope,
+      queryText: optionalString(body.queryText) ?? 'memory-gate',
+    });
+    return jsonOk({ gate });
+  } catch (error) {
+    return jsonFail(error, statusForError(error));
+  }
+}

--- a/app/api/dsg/memory/ingest/route.ts
+++ b/app/api/dsg/memory/ingest/route.ts
@@ -1,0 +1,42 @@
+import { getDevMemoryContext } from '@/lib/dsg/server/memory/context';
+import { ingestMemory } from '@/lib/dsg/server/memory/repository';
+import { asRecord, jsonFail, jsonOk, optionalString, statusForError } from '@/lib/dsg/server/memory/route-utils';
+import type { DsgMemoryKind, DsgMemorySourceType, DsgMemoryStatus, DsgMemoryTrustLevel } from '@/lib/dsg/server/memory/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const ctx = getDevMemoryContext(req, ['memory:write']);
+    const body = asRecord(await req.json().catch(() => null));
+    const rawText = optionalString(body.rawText);
+    const contentHash = optionalString(body.contentHash);
+    const sourceType = optionalString(body.sourceType) as DsgMemorySourceType | undefined;
+    const memoryKind = optionalString(body.memoryKind) as DsgMemoryKind | undefined;
+
+    if (!rawText) throw new Error('MEMORY_RAW_TEXT_REQUIRED');
+    if (!contentHash) throw new Error('MEMORY_CONTENT_HASH_REQUIRED');
+    if (!sourceType || !memoryKind) throw new Error('MEMORY_SOURCE_TYPE_AND_KIND_REQUIRED');
+
+    const memory = await ingestMemory(ctx, {
+      jobId: optionalString(body.jobId),
+      sourceType,
+      memoryKind,
+      rawText,
+      normalizedSummary: optionalString(body.normalizedSummary),
+      trustLevel: optionalString(body.trustLevel) as DsgMemoryTrustLevel | undefined,
+      status: optionalString(body.status) as DsgMemoryStatus | undefined,
+      containsSecret: body.containsSecret === true,
+      containsPii: body.containsPii === true,
+      containsLegalClaim: body.containsLegalClaim === true,
+      containsProductionClaim: body.containsProductionClaim === true,
+      sourceEvidenceId: optionalString(body.sourceEvidenceId),
+      sourceAuditId: optionalString(body.sourceAuditId),
+      contentHash,
+      metadata: asRecord(body.metadata),
+    });
+    return jsonOk({ memory }, 201);
+  } catch (error) {
+    return jsonFail(error, statusForError(error));
+  }
+}

--- a/app/api/dsg/memory/search/route.ts
+++ b/app/api/dsg/memory/search/route.ts
@@ -1,0 +1,21 @@
+import { getDevMemoryContext } from '@/lib/dsg/server/memory/context';
+import { searchMemory } from '@/lib/dsg/server/memory/repository';
+import { jsonFail, jsonOk, optionalString, statusForError } from '@/lib/dsg/server/memory/route-utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const ctx = getDevMemoryContext(req, ['memory:read']);
+    const url = new URL(req.url);
+    const limitValue = Number(url.searchParams.get('limit') ?? '20');
+    const memories = await searchMemory(ctx, {
+      query: optionalString(url.searchParams.get('q')),
+      jobId: optionalString(url.searchParams.get('jobId')),
+      limit: Number.isFinite(limitValue) ? limitValue : 20,
+    });
+    return jsonOk({ memories, count: memories.length });
+  } catch (error) {
+    return jsonFail(error, statusForError(error));
+  }
+}

--- a/docs/DSG_ONE_MEMORY_API_STEP_16E.md
+++ b/docs/DSG_ONE_MEMORY_API_STEP_16E.md
@@ -1,0 +1,83 @@
+# DSG One Governed Memory API Step 16E
+
+## Status
+
+This PR ports the governed memory repository/API route pattern from the control-plane memory work into `dsg-one-v1`.
+
+This is a development-gated memory foundation. It is not a production auth/RBAC claim.
+
+## Routes
+
+| Route | Method | Permission | Purpose |
+|---|---:|---|---|
+| `/api/dsg/memory/ingest` | POST | `memory:write` | Store a governed memory event. |
+| `/api/dsg/memory/search` | GET | `memory:read` | Search workspace-scoped memories. |
+| `/api/dsg/memory/gate` | POST | `memory:gate`, `memory:read` | Evaluate memory safety before use and record retrieval audit. |
+| `/api/dsg/memory/context-pack` | POST | `memory:context_pack`, `memory:read` | Build a deterministic context pack from allowed memory. |
+
+## Boundary
+
+Routes fail closed unless:
+
+```text
+DSG_ALLOW_DEV_AUTH_HEADERS=true
+x-dsg-workspace-id is present
+x-dsg-actor-id is present
+x-dsg-permissions includes route permission
+SUPABASE_SERVICE_ROLE_KEY is configured server-side
+```
+
+Every response includes:
+
+```json
+{
+  "productionReadyClaim": false,
+  "memoryMayOverrideEvidence": false
+}
+```
+
+Memory is context candidate only. It cannot override current evidence, audit, database state, runtime observations, or production claim gates.
+
+## Database
+
+This repo uses Supabase REST through the configured exposed schema. The migration creates `api` schema tables:
+
+```text
+api.dsg_memory_events
+api.dsg_memory_retrievals
+api.dsg_memory_context_packs
+```
+
+## Smoke
+
+```bash
+APP_URL="https://<preview-or-prod-url>" npm run smoke:memory-api
+```
+
+The smoke verifies:
+
+```text
+1. ingest returns ok=true and memory.id
+2. search returns at least one memory
+3. gate returns PASS/REVIEW/BLOCK/UNSUPPORTED
+4. context-pack returns contextHash
+5. all responses declare productionReadyClaim=false
+```
+
+## Correct claim
+
+```text
+DEV_ROUTE_SMOKE_PASS = pending until smoke passes
+PRODUCTION = false
+```
+
+Still not proven:
+
+```text
+[ ] Production auth provider binding
+[ ] Workspace membership enforcement against DSG RBAC tables
+[ ] Audit ledger hash-chain entry for every memory use
+[ ] Evidence binding route
+[ ] UI panels
+[ ] Production traffic safety
+```

--- a/docs/DSG_ONE_MEMORY_API_STEP_16E.md
+++ b/docs/DSG_ONE_MEMORY_API_STEP_16E.md
@@ -64,6 +64,12 @@ The smoke verifies:
 5. all responses declare productionReadyClaim=false
 ```
 
+## Deployment retry log
+
+```text
+2026-05-04: preview deployment retry requested after Vercel build-rate-limit block.
+```
+
 ## Correct claim
 
 ```text

--- a/lib/dsg/server/memory/context.ts
+++ b/lib/dsg/server/memory/context.ts
@@ -1,0 +1,39 @@
+export type DsgMemoryRequestContext = {
+  workspaceId: string;
+  actorId: string;
+  actorRole: string;
+  permissions: string[];
+};
+
+export function memoryBoundary() {
+  return {
+    productionReadyClaim: false,
+    claimStatus: 'DEV_ROUTE_SMOKE_ONLY',
+    memoryMayOverrideEvidence: false,
+    trustBoundary: 'development-header-context',
+    note: 'Governed memory is a context candidate only. It cannot override current evidence, audit, database state, or runtime observations.',
+  } as const;
+}
+
+export function getDevMemoryContext(req: Request, requiredPermissions: string[]): DsgMemoryRequestContext {
+  if (process.env.DSG_ALLOW_DEV_AUTH_HEADERS !== 'true') {
+    throw new Error('DSG_DEV_AUTH_HEADERS_DISABLED');
+  }
+
+  const workspaceId = req.headers.get('x-dsg-workspace-id')?.trim();
+  const actorId = req.headers.get('x-dsg-actor-id')?.trim();
+  const actorRole = req.headers.get('x-dsg-actor-role')?.trim() || 'operator';
+  const permissions = (req.headers.get('x-dsg-permissions') || '')
+    .split(',')
+    .map((permission) => permission.trim())
+    .filter(Boolean);
+
+  if (!workspaceId) throw new Error('WORKSPACE_ID_REQUIRED');
+  if (!actorId) throw new Error('ACTOR_ID_REQUIRED');
+
+  for (const permission of requiredPermissions) {
+    if (!permissions.includes(permission)) throw new Error(`MEMORY_PERMISSION_REQUIRED:${permission}`);
+  }
+
+  return { workspaceId, actorId, actorRole, permissions };
+}

--- a/lib/dsg/server/memory/repository.ts
+++ b/lib/dsg/server/memory/repository.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from 'node:crypto';
+import { supabaseRest } from '../app-builder/supabase-rest';
+import type { DsgMemoryContextPack, DsgMemoryEvent, DsgMemoryGateResult, DsgMemoryKind, DsgMemoryScope, DsgMemorySourceType, DsgMemoryStatus, DsgMemoryTrustLevel } from './types';
+import type { DsgMemoryRequestContext } from './context';
+import { buildContextText, evaluateMemoryGate, sha256 } from './route-utils';
+
+type Row = Record<string, unknown>;
+
+export type IngestMemoryInput = {
+  jobId?: string;
+  sourceType: DsgMemorySourceType;
+  memoryKind: DsgMemoryKind;
+  rawText: string;
+  normalizedSummary?: string;
+  trustLevel?: DsgMemoryTrustLevel;
+  status?: DsgMemoryStatus;
+  containsSecret?: boolean;
+  containsPii?: boolean;
+  containsLegalClaim?: boolean;
+  containsProductionClaim?: boolean;
+  sourceEvidenceId?: string;
+  sourceAuditId?: string;
+  contentHash: string;
+  metadata?: Record<string, unknown>;
+};
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function mapMemory(row: Row): DsgMemoryEvent {
+  return {
+    id: String(row.id),
+    workspaceId: String(row.workspace_id),
+    jobId: text(row.job_id),
+    actorId: String(row.actor_id),
+    actorRole: String(row.actor_role),
+    sourceType: row.source_type as DsgMemorySourceType,
+    memoryKind: row.memory_kind as DsgMemoryKind,
+    rawText: String(row.raw_text),
+    normalizedSummary: text(row.normalized_summary),
+    trustLevel: row.trust_level as DsgMemoryTrustLevel,
+    status: row.status as DsgMemoryStatus,
+    containsSecret: Boolean(row.contains_secret),
+    containsPii: Boolean(row.contains_pii),
+    containsLegalClaim: Boolean(row.contains_legal_claim),
+    containsProductionClaim: Boolean(row.contains_production_claim),
+    sourceEvidenceId: text(row.source_evidence_id),
+    sourceAuditId: text(row.source_audit_id),
+    contentHash: String(row.content_hash),
+    metadata: (row.metadata && typeof row.metadata === 'object' ? row.metadata : {}) as Record<string, unknown>,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export async function ingestMemory(ctx: DsgMemoryRequestContext, input: IngestMemoryInput): Promise<DsgMemoryEvent> {
+  const rows = await supabaseRest<Row[]>({
+    method: 'POST',
+    path: 'dsg_memory_events',
+    body: {
+      workspace_id: ctx.workspaceId,
+      job_id: input.jobId ?? null,
+      actor_id: ctx.actorId,
+      actor_role: ctx.actorRole,
+      source_type: input.sourceType,
+      memory_kind: input.memoryKind,
+      raw_text: input.rawText,
+      normalized_summary: input.normalizedSummary ?? null,
+      trust_level: input.trustLevel ?? 'user_supplied',
+      status: input.status ?? 'active',
+      contains_secret: input.containsSecret ?? false,
+      contains_pii: input.containsPii ?? false,
+      contains_legal_claim: input.containsLegalClaim ?? false,
+      contains_production_claim: input.containsProductionClaim ?? false,
+      source_evidence_id: input.sourceEvidenceId ?? null,
+      source_audit_id: input.sourceAuditId ?? null,
+      content_hash: input.contentHash,
+      metadata: input.metadata ?? {},
+    },
+  });
+  return mapMemory(rows[0]);
+}
+
+export async function searchMemory(ctx: DsgMemoryRequestContext, input: { query?: string; jobId?: string; limit?: number }): Promise<DsgMemoryEvent[]> {
+  const limit = Math.min(Math.max(input.limit ?? 20, 1), 50);
+  const filters = [`workspace_id=eq.${encodeURIComponent(ctx.workspaceId)}`, 'select=*', 'order=created_at.desc', `limit=${limit}`];
+  if (input.jobId) filters.push(`job_id=eq.${encodeURIComponent(input.jobId)}`);
+  if (input.query) filters.push(`raw_text=ilike.*${encodeURIComponent(input.query)}*`);
+  const rows = await supabaseRest<Row[]>({ path: 'dsg_memory_events', query: `?${filters.join('&')}` });
+  return rows.map(mapMemory);
+}
+
+export async function recordRetrieval(ctx: DsgMemoryRequestContext, input: { queryText: string; scope: DsgMemoryScope; gate: DsgMemoryGateResult; contextPackId?: string }): Promise<void> {
+  await supabaseRest<Row[]>({
+    method: 'POST',
+    path: 'dsg_memory_retrievals',
+    body: {
+      workspace_id: ctx.workspaceId,
+      job_id: input.scope.jobId ?? null,
+      actor_id: ctx.actorId,
+      query_text: input.queryText,
+      retrieval_scope: input.scope,
+      retrieved_memory_ids: input.gate.allowedMemoryIds,
+      blocked_memory_ids: input.gate.blockedMemoryIds,
+      review_memory_ids: input.gate.reviewMemoryIds,
+      gate_status: input.gate.status,
+      gate_reasons: input.gate.reasons,
+      context_pack_id: input.contextPackId ?? null,
+    },
+  });
+}
+
+export async function gateMemory(ctx: DsgMemoryRequestContext, input: { memories: DsgMemoryEvent[]; scope: DsgMemoryScope; queryText: string }): Promise<DsgMemoryGateResult> {
+  const gate = evaluateMemoryGate(input.memories, input.scope);
+  await recordRetrieval(ctx, { queryText: input.queryText, scope: input.scope, gate });
+  return gate;
+}
+
+export async function createContextPack(ctx: DsgMemoryRequestContext, input: { memories: DsgMemoryEvent[]; scope: DsgMemoryScope; evidenceIds?: string[]; auditIds?: string[] }): Promise<DsgMemoryContextPack> {
+  const gate = evaluateMemoryGate(input.memories, input.scope);
+  const contextText = buildContextText(input.memories, gate);
+  const contextHash = sha256(JSON.stringify({ scope: input.scope, memoryIds: gate.allowedMemoryIds, contextText }));
+  const pack: DsgMemoryContextPack = {
+    id: randomUUID(),
+    workspaceId: ctx.workspaceId,
+    jobId: input.scope.jobId,
+    actorId: ctx.actorId,
+    purpose: input.scope.purpose,
+    memoryIds: gate.allowedMemoryIds,
+    contextText,
+    contextHash,
+    gateStatus: gate.status,
+    gateReasons: gate.reasons,
+    evidenceIds: input.evidenceIds ?? [],
+    auditIds: input.auditIds ?? [],
+    createdAt: new Date().toISOString(),
+  };
+
+  await supabaseRest<Row[]>({
+    method: 'POST',
+    path: 'dsg_memory_context_packs',
+    body: {
+      id: pack.id,
+      workspace_id: pack.workspaceId,
+      job_id: pack.jobId ?? null,
+      actor_id: pack.actorId,
+      purpose: pack.purpose,
+      memory_ids: pack.memoryIds,
+      context_text: pack.contextText,
+      context_hash: pack.contextHash,
+      gate_status: pack.gateStatus,
+      gate_reasons: pack.gateReasons,
+      evidence_ids: pack.evidenceIds,
+      audit_ids: pack.auditIds,
+    },
+  });
+
+  await recordRetrieval(ctx, { queryText: `context-pack:${pack.purpose}`, scope: input.scope, gate, contextPackId: pack.id });
+  return pack;
+}

--- a/lib/dsg/server/memory/route-utils.ts
+++ b/lib/dsg/server/memory/route-utils.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { createHash } from 'node:crypto';
+import { memoryBoundary } from './context';
+import type { DsgMemoryEvent, DsgMemoryGateResult, DsgMemoryPurpose, DsgMemoryScope } from './types';
+
+const PURPOSES: DsgMemoryPurpose[] = ['planning', 'approval_review', 'runtime_execution', 'verification', 'completion_report', 'support'];
+
+export function jsonOk(payload: Record<string, unknown>, status = 200) {
+  return NextResponse.json({ ok: true, ...payload, boundary: memoryBoundary() }, { status });
+}
+
+export function jsonFail(error: unknown, status = 400) {
+  const code = error instanceof Error ? error.message : String(error || 'MEMORY_ROUTE_FAILED');
+  return NextResponse.json({ ok: false, error: { code, message: code }, boundary: memoryBoundary() }, { status });
+}
+
+export function statusForError(error: unknown): number {
+  const code = error instanceof Error ? error.message : String(error || '');
+  if (code.includes('DISABLED') || code.includes('REQUIRED') || code.includes('PERMISSION')) return 403;
+  return 400;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+export function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean);
+}
+
+export function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function parseScope(raw: unknown, fallbackPurpose: DsgMemoryPurpose): DsgMemoryScope {
+  const record = asRecord(raw);
+  const rawPurpose = optionalString(record.purpose);
+  const purpose = rawPurpose && PURPOSES.includes(rawPurpose as DsgMemoryPurpose) ? (rawPurpose as DsgMemoryPurpose) : fallbackPurpose;
+  return {
+    purpose,
+    jobId: optionalString(record.jobId),
+    requireVerifiedEvidence: record.requireVerifiedEvidence === true,
+  };
+}
+
+export function parseMemories(value: unknown): DsgMemoryEvent[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => item as DsgMemoryEvent).filter((item) => Boolean(item?.id && item.rawText));
+}
+
+export function evaluateMemoryGate(memories: DsgMemoryEvent[], scope: DsgMemoryScope): DsgMemoryGateResult {
+  const reasons: string[] = [];
+  const allowedMemoryIds: string[] = [];
+  const blockedMemoryIds: string[] = [];
+  const reviewMemoryIds: string[] = [];
+
+  for (const memory of memories) {
+    if (memory.status === 'blocked' || memory.status === 'deleted' || memory.containsSecret) {
+      blockedMemoryIds.push(memory.id);
+      reasons.push(`BLOCKED_MEMORY:${memory.id}`);
+      continue;
+    }
+    if (memory.containsProductionClaim || memory.containsLegalClaim || memory.status === 'conflicted') {
+      reviewMemoryIds.push(memory.id);
+      reasons.push(`REVIEW_MEMORY:${memory.id}`);
+      continue;
+    }
+    if (scope.requireVerifiedEvidence && memory.trustLevel !== 'verified' && memory.trustLevel !== 'observed') {
+      reviewMemoryIds.push(memory.id);
+      reasons.push(`MEMORY_NOT_VERIFIED:${memory.id}`);
+      continue;
+    }
+    allowedMemoryIds.push(memory.id);
+  }
+
+  const status = blockedMemoryIds.length ? 'BLOCK' : reviewMemoryIds.length ? 'REVIEW' : 'PASS';
+  if (!reasons.length) reasons.push('MEMORY_GATE_PASS');
+  return { status, reasons, allowedMemoryIds, blockedMemoryIds, reviewMemoryIds };
+}
+
+export function buildContextText(memories: DsgMemoryEvent[], gate: DsgMemoryGateResult): string {
+  const allowed = new Set(gate.allowedMemoryIds);
+  const lines = memories
+    .filter((memory) => allowed.has(memory.id))
+    .map((memory) => `- [${memory.memoryKind}/${memory.trustLevel}] ${memory.normalizedSummary || memory.rawText}`);
+  return lines.join('\n') || '[NO_ALLOWED_MEMORY]';
+}

--- a/lib/dsg/server/memory/types.ts
+++ b/lib/dsg/server/memory/types.ts
@@ -1,0 +1,81 @@
+export type DsgMemorySourceType =
+  | 'conversation'
+  | 'agent_step'
+  | 'approval'
+  | 'command_output'
+  | 'test_output'
+  | 'deployment_log'
+  | 'manual_note'
+  | 'system_event';
+
+export type DsgMemoryKind =
+  | 'policy'
+  | 'decision'
+  | 'preference'
+  | 'requirement'
+  | 'risk'
+  | 'command'
+  | 'evidence'
+  | 'workflow'
+  | 'project_context'
+  | 'claim'
+  | 'unknown';
+
+export type DsgMemoryTrustLevel = 'observed' | 'verified' | 'user_supplied' | 'system_generated' | 'unverified';
+export type DsgMemoryStatus = 'active' | 'stale' | 'conflicted' | 'redacted' | 'blocked' | 'deleted';
+export type DsgMemoryGateStatus = 'PASS' | 'REVIEW' | 'BLOCK' | 'UNSUPPORTED';
+export type DsgMemoryPurpose = 'planning' | 'approval_review' | 'runtime_execution' | 'verification' | 'completion_report' | 'support';
+
+export type DsgMemoryEvent = {
+  id: string;
+  workspaceId: string;
+  jobId?: string;
+  actorId: string;
+  actorRole: string;
+  sourceType: DsgMemorySourceType;
+  memoryKind: DsgMemoryKind;
+  rawText: string;
+  normalizedSummary?: string;
+  trustLevel: DsgMemoryTrustLevel;
+  status: DsgMemoryStatus;
+  containsSecret: boolean;
+  containsPii: boolean;
+  containsLegalClaim: boolean;
+  containsProductionClaim: boolean;
+  sourceEvidenceId?: string;
+  sourceAuditId?: string;
+  contentHash: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DsgMemoryScope = {
+  purpose: DsgMemoryPurpose;
+  jobId?: string;
+  requireVerifiedEvidence?: boolean;
+};
+
+export type DsgMemoryGateResult = {
+  status: DsgMemoryGateStatus;
+  reasons: string[];
+  allowedMemoryIds: string[];
+  blockedMemoryIds: string[];
+  reviewMemoryIds: string[];
+};
+
+export type DsgMemoryContextPack = {
+  id: string;
+  workspaceId: string;
+  jobId?: string;
+  actorId: string;
+  purpose: DsgMemoryPurpose;
+  memoryIds: string[];
+  contextText: string;
+  contextHash: string;
+  gateStatus: DsgMemoryGateStatus;
+  gateReasons: string[];
+  evidenceIds: string[];
+  auditIds: string[];
+  createdAt: string;
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dsg:runtime-check": "node scripts/dsg-deterministic-runtime-check.mjs",
     "dsg:typecheck": "tsc --noEmit",
     "dsg:production-flow-check": "node scripts/dsg-production-flow-check.mjs",
-    "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint"
+    "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint",
+    "smoke:memory-api": "bash scripts/dsg-memory-api-smoke.sh"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-memory-api-smoke.sh
+++ b/scripts/dsg-memory-api-smoke.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_URL="${APP_URL:-}"
+WORKSPACE_ID="${DSG_SMOKE_WORKSPACE_ID:-runtime-proof-workspace}"
+ACTOR_ID="${DSG_SMOKE_ACTOR_ID:-memory-smoke-operator}"
+ACTOR_ROLE="${DSG_SMOKE_ACTOR_ROLE:-operator}"
+
+if [ -z "$APP_URL" ]; then
+  echo "BLOCK: APP_URL is required" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PERMISSIONS="memory:write,memory:read,memory:gate,memory:context_pack"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RAW_TEXT="DSG One governed memory smoke. Memory must not override evidence. Timestamp: $NOW"
+CONTENT_HASH="$(node -e "const crypto=require('crypto'); process.stdout.write(crypto.createHash('sha256').update(process.argv[1]).digest('hex'))" "$RAW_TEXT")"
+
+request_json() {
+  local method="$1"
+  local url="$2"
+  local payload_file="${3:-}"
+  local output_file="$4"
+  local status_file="$5"
+
+  if [ -n "$payload_file" ]; then
+    curl -sS -X "$method" "$url" \
+      -H "content-type: application/json" \
+      -H "x-dsg-workspace-id: $WORKSPACE_ID" \
+      -H "x-dsg-actor-id: $ACTOR_ID" \
+      -H "x-dsg-actor-role: $ACTOR_ROLE" \
+      -H "x-dsg-permissions: $PERMISSIONS" \
+      --data-binary "@$payload_file" \
+      -o "$output_file" \
+      -w "%{http_code}" > "$status_file"
+  else
+    curl -sS -X "$method" "$url" \
+      -H "x-dsg-workspace-id: $WORKSPACE_ID" \
+      -H "x-dsg-actor-id: $ACTOR_ID" \
+      -H "x-dsg-actor-role: $ACTOR_ROLE" \
+      -H "x-dsg-permissions: $PERMISSIONS" \
+      -o "$output_file" \
+      -w "%{http_code}" > "$status_file"
+  fi
+}
+
+assert_ok_response() {
+  local label="$1"
+  local response_file="$2"
+  local status_file="$3"
+  local status
+  status="$(cat "$status_file")"
+
+  if [[ "$status" != 2* ]]; then
+    echo "BLOCK: $label returned HTTP $status" >&2
+    cat "$response_file" >&2
+    exit 1
+  fi
+
+  node - "$response_file" "$label" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const label = process.argv[3];
+const body = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (body.ok !== true) {
+  console.error(`BLOCK: ${label} did not return ok=true`);
+  console.error(JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+if (!body.boundary || body.boundary.productionReadyClaim !== false) {
+  console.error(`BLOCK: ${label} missing non-production boundary`);
+  console.error(JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+NODE
+}
+
+cat > "$TMP_DIR/ingest.json" <<JSON
+{
+  "sourceType": "manual_note",
+  "memoryKind": "policy",
+  "rawText": "$RAW_TEXT",
+  "trustLevel": "user_supplied",
+  "status": "active",
+  "containsSecret": false,
+  "containsPii": false,
+  "containsLegalClaim": false,
+  "containsProductionClaim": false,
+  "contentHash": "$CONTENT_HASH",
+  "metadata": {
+    "smoke": true,
+    "repo": "dsg-one-v1",
+    "timestamp": "$NOW"
+  }
+}
+JSON
+
+request_json POST "$APP_URL/api/dsg/memory/ingest" "$TMP_DIR/ingest.json" "$TMP_DIR/ingest.response.json" "$TMP_DIR/ingest.status"
+assert_ok_response "memory ingest" "$TMP_DIR/ingest.response.json" "$TMP_DIR/ingest.status"
+
+node - "$TMP_DIR/ingest.response.json" > "$TMP_DIR/memory.json" <<'NODE'
+const fs = require('fs');
+const body = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!body.memory || !body.memory.id) {
+  console.error('BLOCK: ingest response missing memory.id');
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify(body.memory));
+NODE
+
+SEARCH_URL="$APP_URL/api/dsg/memory/search?q=$(node -e "process.stdout.write(encodeURIComponent(process.argv[1]))" "DSG One governed memory smoke")&limit=5"
+request_json GET "$SEARCH_URL" "" "$TMP_DIR/search.response.json" "$TMP_DIR/search.status"
+assert_ok_response "memory search" "$TMP_DIR/search.response.json" "$TMP_DIR/search.status"
+
+node - "$TMP_DIR/search.response.json" <<'NODE'
+const fs = require('fs');
+const body = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!Array.isArray(body.memories) || body.memories.length < 1) {
+  console.error('BLOCK: search returned no memories');
+  console.error(JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+NODE
+
+node - "$TMP_DIR/memory.json" > "$TMP_DIR/gate.json" <<'NODE'
+const fs = require('fs');
+const memory = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+process.stdout.write(JSON.stringify({
+  queryText: 'DSG One memory smoke gate',
+  scope: { purpose: 'planning', requireVerifiedEvidence: false },
+  memories: [memory]
+}));
+NODE
+
+request_json POST "$APP_URL/api/dsg/memory/gate" "$TMP_DIR/gate.json" "$TMP_DIR/gate.response.json" "$TMP_DIR/gate.status"
+assert_ok_response "memory gate" "$TMP_DIR/gate.response.json" "$TMP_DIR/gate.status"
+
+node - "$TMP_DIR/gate.response.json" <<'NODE'
+const fs = require('fs');
+const body = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!body.gate || !['PASS', 'REVIEW', 'BLOCK', 'UNSUPPORTED'].includes(body.gate.status)) {
+  console.error('BLOCK: gate response missing valid status');
+  console.error(JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+NODE
+
+node - "$TMP_DIR/memory.json" > "$TMP_DIR/context-pack.json" <<'NODE'
+const fs = require('fs');
+const memory = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+process.stdout.write(JSON.stringify({
+  scope: { purpose: 'planning', requireVerifiedEvidence: false },
+  memories: [memory],
+  evidenceIds: [],
+  auditIds: []
+}));
+NODE
+
+request_json POST "$APP_URL/api/dsg/memory/context-pack" "$TMP_DIR/context-pack.json" "$TMP_DIR/context-pack.response.json" "$TMP_DIR/context-pack.status"
+assert_ok_response "memory context pack" "$TMP_DIR/context-pack.response.json" "$TMP_DIR/context-pack.status"
+
+node - "$TMP_DIR/context-pack.response.json" <<'NODE'
+const fs = require('fs');
+const body = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!body.contextPack || !body.contextPack.contextHash) {
+  console.error('BLOCK: context-pack response missing contextHash');
+  console.error(JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+NODE
+
+echo "PASS: DSG One governed memory API smoke completed"
+echo "NOTE: dev-gated route proof only. This is not production auth/RBAC or production claim."

--- a/supabase/migrations/20260504083000_create_dsg_one_memory_api_tables.sql
+++ b/supabase/migrations/20260504083000_create_dsg_one_memory_api_tables.sql
@@ -1,0 +1,78 @@
+create extension if not exists pgcrypto;
+create schema if not exists api;
+
+create table if not exists api.dsg_memory_events (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id text not null,
+  job_id text,
+  actor_id text not null,
+  actor_role text not null,
+  source_type text not null check (source_type in ('conversation','agent_step','approval','command_output','test_output','deployment_log','manual_note','system_event')),
+  memory_kind text not null check (memory_kind in ('policy','decision','preference','requirement','risk','command','evidence','workflow','project_context','claim','unknown')),
+  raw_text text not null check (length(trim(raw_text)) > 0),
+  normalized_summary text,
+  trust_level text not null default 'user_supplied' check (trust_level in ('observed','verified','user_supplied','system_generated','unverified')),
+  status text not null default 'active' check (status in ('active','stale','conflicted','redacted','blocked','deleted')),
+  contains_secret boolean not null default false,
+  contains_pii boolean not null default false,
+  contains_legal_claim boolean not null default false,
+  contains_production_claim boolean not null default false,
+  source_evidence_id text,
+  source_audit_id text,
+  content_hash text not null check (length(trim(content_hash)) > 0),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists dsg_memory_events_workspace_created_idx
+  on api.dsg_memory_events(workspace_id, created_at desc);
+create index if not exists dsg_memory_events_workspace_job_idx
+  on api.dsg_memory_events(workspace_id, job_id);
+create index if not exists dsg_memory_events_kind_status_idx
+  on api.dsg_memory_events(memory_kind, status);
+
+create table if not exists api.dsg_memory_retrievals (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id text not null,
+  job_id text,
+  actor_id text not null,
+  query_text text not null check (length(trim(query_text)) > 0),
+  retrieval_scope jsonb not null default '{}'::jsonb,
+  retrieved_memory_ids text[] not null default '{}'::text[],
+  blocked_memory_ids text[] not null default '{}'::text[],
+  review_memory_ids text[] not null default '{}'::text[],
+  gate_status text not null check (gate_status in ('PASS','REVIEW','BLOCK','UNSUPPORTED')),
+  gate_reasons text[] not null default '{}'::text[],
+  context_pack_id uuid,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists dsg_memory_retrievals_workspace_created_idx
+  on api.dsg_memory_retrievals(workspace_id, created_at desc);
+
+create table if not exists api.dsg_memory_context_packs (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id text not null,
+  job_id text,
+  actor_id text not null,
+  purpose text not null check (purpose in ('planning','approval_review','runtime_execution','verification','completion_report','support')),
+  memory_ids text[] not null default '{}'::text[],
+  context_text text not null check (length(trim(context_text)) > 0),
+  context_hash text not null check (length(trim(context_hash)) > 0),
+  gate_status text not null check (gate_status in ('PASS','REVIEW','BLOCK','UNSUPPORTED')),
+  gate_reasons text[] not null default '{}'::text[],
+  evidence_ids text[] not null default '{}'::text[],
+  audit_ids text[] not null default '{}'::text[],
+  created_at timestamptz not null default now()
+);
+
+create index if not exists dsg_memory_context_packs_workspace_created_idx
+  on api.dsg_memory_context_packs(workspace_id, created_at desc);
+
+grant usage on schema api to anon, authenticated, service_role;
+grant select, insert, update, delete on api.dsg_memory_events to service_role;
+grant select, insert, update, delete on api.dsg_memory_retrievals to service_role;
+grant select, insert, update, delete on api.dsg_memory_context_packs to service_role;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary

Ports the governed memory API foundation pattern from `tdealer01-crypto-dsg-control-plane` PR #495/#496 into `dsg-one-v1`.

This PR adds dev-gated governed memory routes for `dsg-one-v1` so App Builder / runtime flows can persist and retrieve bounded memory context without treating memory as evidence or production truth.

## Added

- `lib/dsg/server/memory/context.ts`
  - Parses dev-only `x-dsg-*` headers
  - Requires `DSG_ALLOW_DEV_AUTH_HEADERS=true`
  - Requires workspace, actor, and route permissions
  - Adds explicit non-production boundary
- `lib/dsg/server/memory/types.ts`
- `lib/dsg/server/memory/route-utils.ts`
- `lib/dsg/server/memory/repository.ts`
  - Uses existing `supabaseRest` helper
  - Inserts/searches governed memory events
  - Records retrievals
  - Persists deterministic context packs
- API routes:
  - `POST /api/dsg/memory/ingest`
  - `GET /api/dsg/memory/search`
  - `POST /api/dsg/memory/gate`
  - `POST /api/dsg/memory/context-pack`
- `scripts/dsg-memory-api-smoke.sh`
- `npm run smoke:memory-api`
- `supabase/migrations/20260504083000_create_dsg_one_memory_api_tables.sql`
- `docs/DSG_ONE_MEMORY_API_STEP_16E.md`

## Governance boundary

Every response declares:

```txt
productionReadyClaim=false
memoryMayOverrideEvidence=false
```

Memory is a context candidate only. It cannot override current evidence, audit, DB state, runtime observations, or production claim gates.

## Correct claim after merge

```txt
Step 16E = governed memory API foundation for dsg-one-v1
DEV_ROUTE_SMOKE_PASS = pending until smoke runs
PRODUCTION = false
```

Still not proven:

```txt
[ ] Production auth provider binding
[ ] Workspace membership enforcement against DSG RBAC tables
[ ] Audit ledger hash-chain entry for every memory use
[ ] Evidence binding route
[ ] UI panels
[ ] Production traffic safety
```

Related reference:

- control-plane PR #495: governed memory repository/API routes
- control-plane PR #496: governed memory API smoke script