### PR TITLE
Normalize DSG memory dev auth env flag

### DIFF
--- a/lib/dsg/server/memory/context.ts
+++ b/lib/dsg/server/memory/context.ts
@@ -5,6 +5,10 @@ export type DsgMemoryRequestContext = {
   permissions: string[];
 };
 
+function isDevHeaderGateEnabled(): boolean {
+  return process.env.DSG_ALLOW_DEV_AUTH_HEADERS?.trim().toLowerCase() === 'true';
+}
+
 export function memoryBoundary() {
   return {
     productionReadyClaim: false,
@@ -16,7 +20,7 @@ export function memoryBoundary() {
 }
 
 export function getDevMemoryContext(req: Request, requiredPermissions: string[]): DsgMemoryRequestContext {
-  if (process.env.DSG_ALLOW_DEV_AUTH_HEADERS !== 'true') {
+  if (!isDevHeaderGateEnabled()) {
     throw new Error('DSG_DEV_AUTH_HEADERS_DISABLED');
   }
 


### PR DESCRIPTION
## Summary

Normalizes `DSG_ALLOW_DEV_AUTH_HEADERS` before checking it in the governed memory dev-header gate.

Before:

```ts
process.env.DSG_ALLOW_DEV_AUTH_HEADERS !== 'true'
```

After:

```ts
process.env.DSG_ALLOW_DEV_AUTH_HEADERS?.trim().toLowerCase() === 'true'
```

## Why

The memory smoke route is still correctly dev-gated, but this avoids false negatives when the value is present with whitespace or case differences from Vercel env input.

## Boundary

This does not remove the gate and does not claim production auth/RBAC. The route remains bounded as:

```txt
claimStatus=DEV_ROUTE_SMOKE_ONLY
productionReadyClaim=false
memoryMayOverrideEvidence=false
```
