### PR TITLE
Add claim boundary to linear execution lanes doc

### DIFF
--- a/docs/linear-execution-lanes.md
+++ b/docs/linear-execution-lanes.md
@@ -32,3 +32,7 @@ npm run dsg:verify
 ```
 
 If any check fails, PR must stay blocked until fixed.
+
+## Claim boundary
+
+This document coordinates execution only. It does not claim Manus parity, production readiness, build proof completion, deploy proof completion, Auth/RBAC proof completion, or CRUD proof completion.


### PR DESCRIPTION
### Motivation
- Make the scope explicit so the document is clearly an execution coordination artifact and not a claim of Manus parity, production readiness, or any proof completion.

### Description
- Append a `## Claim boundary` section to `docs/linear-execution-lanes.md` that states the document coordinates execution only and does not claim Manus parity, production readiness, build proof completion, deploy proof completion, Auth/RBAC proof completion, or CRUD proof completion.

### Testing
- Ran `git diff --check` (pass), `npm run dsg:runtime-check` (pass), `npm run dsg:typecheck` (fail: missing `vitest` types/modules), and `npm run dsg:verify` (fail: includes the failing `dsg:typecheck`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b8a5117883288a72a95cabbdf26c)