### PR TITLE
DSG-5: implement real GitHub Git Trees/Commits writer

### DIFF
--- a/lib/dsg/app-builder/github-writer.ts
+++ b/lib/dsg/app-builder/github-writer.ts
@@ -1,17 +1,138 @@
+import { createHash } from 'node:crypto';
 import type { FileTree } from './file-tree';
 
 export type GitHubWriteResult = {
   branch: string;
   commitSha: string;
   treeHash: string;
+  baseCommitSha: string;
+  githubTreeSha: string;
 };
+
+const GITHUB_API = 'https://api.github.com';
 
 export async function writeTreeToGithubBranch(
   branch: string,
   tree: FileTree,
 ): Promise<GitHubWriteResult> {
-  if (!branch) throw new Error('DSG_BRANCH_REQUIRED');
-  if (!tree.treeHash || tree.files.length === 0) throw new Error('DSG_FILE_TREE_REQUIRED');
+  if (typeof branch !== 'string' || branch.trim().length === 0) throw new Error('DSG_BRANCH_REQUIRED');
+  if (!tree?.treeHash || !Array.isArray(tree.files) || tree.files.length === 0) throw new Error('DSG_FILE_TREE_REQUIRED');
 
-  throw new Error('DSG_GITHUB_WRITER_NOT_WIRED_REAL_GITHUB_API_REQUIRED');
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('DSG_GITHUB_TOKEN_REQUIRED');
+
+  const repo = process.env.DSG_TARGET_REPO ?? process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error('DSG_GITHUB_REPO_REQUIRED');
+  const repoMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(repo);
+  if (!repoMatch) throw new Error('DSG_GITHUB_REPO_INVALID');
+  const [, owner, name] = repoMatch;
+
+  validateTree(tree);
+
+  const baseRef = process.env.DSG_GITHUB_BASE_REF || 'main';
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+
+  const baseRefResp = await githubRequest<{ object: { sha: string } }>(`${GITHUB_API}/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(baseRef)}`, { headers });
+  const baseCommitSha = baseRefResp.object.sha;
+
+  const baseCommit = await githubRequest<{ tree: { sha: string } }>(`${GITHUB_API}/repos/${owner}/${name}/git/commits/${baseCommitSha}`, { headers });
+
+  let targetCommitSha = baseCommitSha;
+  try {
+    const targetRefResp = await githubRequest<{ object: { sha: string } }>(`${GITHUB_API}/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(branch)}`, { headers });
+    targetCommitSha = targetRefResp.object.sha;
+  } catch (error) {
+    if (!(error instanceof GitHubApiError) || error.status !== 404) throw error;
+    await githubRequest(`${GITHUB_API}/repos/${owner}/${name}/git/refs`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: baseCommitSha }),
+    });
+  }
+
+  const treeEntries: Array<{ path: string; mode: '100644'; type: 'blob'; sha: string }> = [];
+  for (const file of tree.files) {
+    const blobResp = await githubRequest<{ sha: string }>(`${GITHUB_API}/repos/${owner}/${name}/git/blobs`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ content: file.content, encoding: 'utf-8' }),
+    });
+    treeEntries.push({ path: file.path, mode: '100644', type: 'blob', sha: blobResp.sha });
+  }
+
+  const newTree = await githubRequest<{ sha: string }>(`${GITHUB_API}/repos/${owner}/${name}/git/trees`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ base_tree: baseCommit.tree.sha, tree: treeEntries }),
+  });
+
+  const commitResp = await githubRequest<{ sha: string }>(`${GITHUB_API}/repos/${owner}/${name}/git/commits`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      message: `DSG app builder update (${tree.treeHash.slice(0, 12)})`,
+      tree: newTree.sha,
+      parents: [targetCommitSha],
+    }),
+  });
+
+  await githubRequest(`${GITHUB_API}/repos/${owner}/${name}/git/refs/heads/${encodeURIComponent(branch)}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ sha: commitResp.sha, force: false }),
+  });
+
+  if (commitResp.sha.startsWith('sim_')) throw new Error('DSG_GITHUB_COMMIT_SHA_INVALID');
+
+  return { branch, commitSha: commitResp.sha, treeHash: tree.treeHash, baseCommitSha, githubTreeSha: newTree.sha };
+}
+
+function validateTree(tree: FileTree): void {
+  const seen = new Set<string>();
+  for (const file of tree.files) {
+    if (!file || typeof file.path !== 'string' || typeof file.content !== 'string' || typeof file.fileHash !== 'string') {
+      throw new Error('DSG_FILE_TREE_FILE_INVALID');
+    }
+    const path = normalizePath(file.path);
+    if (seen.has(path)) throw new Error('DSG_DUPLICATE_PATH_BLOCKED');
+    seen.add(path);
+    const expected = sha(`${path}\n${file.content}`);
+    if (file.fileHash !== expected) throw new Error('DSG_FILE_HASH_MISMATCH_BLOCKED');
+  }
+}
+
+function normalizePath(input: string): string {
+  if (input.includes('..')) throw new Error('DSG_PATH_TRAVERSAL_BLOCKED');
+  const p = input.replace(/^\/+/, '');
+  const n = p.toLowerCase();
+  if ((n === '.env' || n.endsWith('/.env')) && !n.endsWith('.env.example')) throw new Error('DSG_DOTENV_BLOCKED');
+  return p;
+}
+
+const sha = (x: string) => createHash('sha256').update(x).digest('hex');
+
+class GitHubApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'GitHubApiError';
+    this.status = status;
+  }
+}
+
+async function githubRequest<T = unknown>(url: string, init: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new GitHubApiError(response.status, `DSG_GITHUB_API_ERROR_${response.status}:${text}`);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return await response.json() as T;
 }

--- a/tests/dsg/github-writer.test.ts
+++ b/tests/dsg/github-writer.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildDeterministicFileTree } from '@/lib/dsg/app-builder/file-tree';
+import { writeTreeToGithubBranch } from '@/lib/dsg/app-builder/github-writer';
+
+describe('github writer', () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...env };
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.DSG_TARGET_REPO;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.DSG_GITHUB_BASE_REF;
+  });
+
+  it('blocks missing token', async () => {
+    process.env.DSG_TARGET_REPO = 'acme/repo';
+    const tree = buildDeterministicFileTree([{ path: 'a.txt', content: 'x' }]);
+    await expect(writeTreeToGithubBranch('feature', tree)).rejects.toThrow('DSG_GITHUB_TOKEN_REQUIRED');
+  });
+
+  it('blocks missing repo', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    const tree = buildDeterministicFileTree([{ path: 'a.txt', content: 'x' }]);
+    await expect(writeTreeToGithubBranch('feature', tree)).rejects.toThrow('DSG_GITHUB_REPO_REQUIRED');
+  });
+
+  it('blocks empty tree', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    process.env.DSG_TARGET_REPO = 'acme/repo';
+    await expect(writeTreeToGithubBranch('feature', { files: [], treeHash: '' })).rejects.toThrow('DSG_FILE_TREE_REQUIRED');
+  });
+
+  it('blocks unsafe path', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    process.env.DSG_TARGET_REPO = 'acme/repo';
+    const tree = buildDeterministicFileTree([{ path: '.env.example', content: 'x' }]);
+    tree.files[0].path = '../evil.txt';
+    await expect(writeTreeToGithubBranch('feature', tree)).rejects.toThrow('DSG_PATH_TRAVERSAL_BLOCKED');
+  });
+
+  it('returns real github commit sha and deterministic call order', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    process.env.DSG_TARGET_REPO = 'acme/repo';
+    process.env.DSG_GITHUB_BASE_REF = 'main';
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(okJson({ object: { sha: 'base-ref-sha' } }))
+      .mockResolvedValueOnce(okJson({ tree: { sha: 'base-tree-sha' } }))
+      .mockResolvedValueOnce(okJson({ object: { sha: 'branch-head-sha' } }))
+      .mockResolvedValueOnce(okJson({ sha: 'blob-sha-1' }))
+      .mockResolvedValueOnce(okJson({ sha: 'new-tree-sha' }))
+      .mockResolvedValueOnce(okJson({ sha: 'real-commit-sha-123' }))
+      .mockResolvedValueOnce(okNoContent());
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const tree = buildDeterministicFileTree([{ path: 'a.txt', content: 'hello' }]);
+    const result = await writeTreeToGithubBranch('feature-dsg', tree);
+
+    expect(result.commitSha).toBe('real-commit-sha-123');
+    expect(result.commitSha.startsWith('sim_')).toBe(false);
+
+    const urls = fetchMock.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(urls).toEqual([
+      'https://api.github.com/repos/acme/repo/git/ref/heads/main',
+      'https://api.github.com/repos/acme/repo/git/commits/base-ref-sha',
+      'https://api.github.com/repos/acme/repo/git/ref/heads/feature-dsg',
+      'https://api.github.com/repos/acme/repo/git/blobs',
+      'https://api.github.com/repos/acme/repo/git/trees',
+      'https://api.github.com/repos/acme/repo/git/commits',
+      'https://api.github.com/repos/acme/repo/git/refs/heads/feature-dsg',
+    ]);
+  });
+});
+
+function okJson(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+function okNoContent(): Response {
+  return {
+    ok: true,
+    status: 204,
+    json: async () => ({}),
+    text: async () => '',
+  } as Response;
+}


### PR DESCRIPTION
### Motivation
- Replace the fail-closed scaffold with a real GitHub Git Database API writer implemented with `fetch` so commits and trees are real GitHub objects. 
- Enforce fail-closed validations for credentials, repository, branch, tree shape, file hashes and unsafe paths to prevent accidental or malicious writes. 
- Produce a deterministic, auditable write flow that maps to GitHub endpoints for blobs/trees/commits/refs and returns real GitHub SHAs. 

### Description
- Implemented the Git Database API flow in `lib/dsg/app-builder/github-writer.ts` including GET base ref, GET base commit/tree, GET or create target ref, POST blobs, POST trees (with `base_tree`), POST commits and PATCH branch ref. 
- Added strict environment validation for `GITHUB_TOKEN`, `DSG_TARGET_REPO`/`GITHUB_REPOSITORY` and `DSG_GITHUB_BASE_REF` (default `main`), input validation for `branch` and `FileTree`, duplicate-path/path-traversal/.env protections, and deterministic per-file hash verification matching `file-tree.ts`. 
- Return contract updated to `{ branch, commitSha, treeHash, baseCommitSha, githubTreeSha }` and explicitly block any commit SHA prefixed with `sim_`. 
- Added mocked-fetch unit tests at `tests/dsg/github-writer.test.ts` that cover missing token/repo/tree, unsafe path, and a success path asserting returned commit SHA equals the GitHub response and that the API call order is deterministic. 
- Files changed: `lib/dsg/app-builder/github-writer.ts` and `tests/dsg/github-writer.test.ts`. 

### Testing
- `git diff --check` ran and passed. 
- `npm run dsg:runtime-check` ran and passed (`DSG deterministic runtime check passed`). 
- `npm run dsg:typecheck` was run and failed due to missing `vitest` type declarations in the workspace (existing test typings issue, not introduced by this change). 
- `npm run dsg:verify` was run and failed at the `dsg:typecheck` step for the same `vitest` declaration issue. 

Claim boundary: DSG-5 implements real GitHub Git Trees/Commits writer path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e1ebeb3083288087af8ccbbaa5b7)