### PR TITLE
DSG-8: Implement Auth/RBAC proof probe (server-side)

### DIFF
--- a/app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts
@@ -1,17 +1,58 @@
 import { NextResponse } from 'next/server';
 import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
+import { recordReplayProof, writeEvidence } from '@/lib/dsg/server/repository';
+import { runAuthRbacProof } from '@/lib/dsg/runtime/auth-rbac-proof';
 
-export async function POST(request: Request) {
-  await requireVerifiedDsgActor(request.headers, 'production:write');
+export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
+  const actor = await requireVerifiedDsgActor(request.headers, 'replay:verify');
+  const { jobId } = await context.params;
+  const body = (await request.json().catch(() => null)) as {
+    previewUrl?: string;
+    routes?: Array<{ path: string; kind: 'public' | 'protected' | 'admin' }>;
+    authRequired?: boolean;
+    rbacRequired?: boolean;
+    oauthFlow?: 'none' | 'manual_only';
+    hasTestIdentity?: boolean;
+    signals?: { fakeCookie?: boolean; fakeRoleHeader?: boolean; callerBooleans?: boolean };
+  } | null;
 
-  return NextResponse.json(
-    {
-      ok: false,
-      error: {
-        code: 'DSG_AUTH_RBAC_PROOF_CALLBACK_NOT_WIRED',
-        message: 'Auth/RBAC proof must come from server-side probe or external runner evidence, not client-supplied booleans.',
-      },
-    },
-    { status: 501 },
-  );
+  if (!body?.routes || !Array.isArray(body.routes)) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_AUTH_RBAC_PROOF_INPUT_REQUIRED' } }, { status: 400 });
+  }
+
+  const proof = await runAuthRbacProof({
+    previewUrl: body.previewUrl,
+    routes: body.routes,
+    authRequired: body.authRequired,
+    rbacRequired: body.rbacRequired,
+    oauthFlow: body.oauthFlow,
+    hasTestIdentity: body.hasTestIdentity,
+    signals: body.signals,
+  });
+
+  try {
+    const repoCtx = { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) };
+    const evidence = await writeEvidence(repoCtx, {
+      jobId,
+      evidenceType: 'AUTH_RBAC_PROOF',
+      contentHash: proof.proofHash,
+      summary: proof.summary,
+      metadata: { status: proof.status, routesChecked: proof.routesChecked, hardFailures: proof.hardFailures },
+    });
+
+    const replay = await recordReplayProof(repoCtx, {
+      jobId,
+      replayHash: proof.proofHash,
+      status: proof.status === 'PASS' ? 'PASS' : proof.status === 'FAILED' ? 'FAILED' : 'BLOCK',
+      details: { authRbac: proof, evidenceId: evidence.id },
+    });
+
+    return NextResponse.json({ ok: true, data: { proof, evidenceId: evidence.id, replayProofId: replay.id } }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: error instanceof Error ? error.message : 'DSG_AUTH_RBAC_PROOF_RECORD_FAILED' }, proof },
+      { status: 403 },
+    );
+  }
 }

--- a/lib/dsg/runtime/auth-rbac-proof.ts
+++ b/lib/dsg/runtime/auth-rbac-proof.ts
@@ -1,4 +1,93 @@
-export function evaluateAuthRbacProof(input:{publicOk:boolean; anonBlocked:boolean; nonAdminBlocked:boolean; oauthTestable?:boolean}){
- if(input.oauthTestable===false) return {status:'MANUAL_REQUIRED'};
- return {status: input.publicOk && input.anonBlocked && input.nonAdminBlocked ? 'PASS' : 'BLOCK'};
+import { sha256Json } from './hash';
+
+const REDIRECT_STATUS = new Set([302, 303, 307, 308]);
+const PROTECTED_REJECT_STATUS = new Set([401, 403, 302, 303, 307, 308]);
+
+export type ProbeRoute = { path: string; kind: 'public' | 'protected' | 'admin' };
+
+export type AuthRbacProofInput = {
+  previewUrl?: string;
+  routes: ProbeRoute[];
+  authRequired?: boolean;
+  rbacRequired?: boolean;
+  oauthFlow?: 'none' | 'manual_only';
+  hasTestIdentity?: boolean;
+  signals?: { fakeCookie?: boolean; fakeRoleHeader?: boolean; callerBooleans?: boolean };
+};
+
+export type RouteProbeResult = {
+  path: string;
+  kind: ProbeRoute['kind'];
+  status: number;
+  location?: string;
+  ok: boolean;
+};
+
+export type AuthRbacProofOutput = {
+  status: 'PASS' | 'BLOCK' | 'FAILED' | 'MANUAL_REQUIRED';
+  routesChecked: RouteProbeResult[];
+  summary: string;
+  hardFailures: string[];
+  proofHash: string;
+};
+
+function normalizeUrl(base: string, path: string): string {
+  const target = new URL(path.startsWith('/') ? path : `/${path}`, base);
+  return target.toString();
+}
+
+function isRejected(status: number): boolean {
+  return PROTECTED_REJECT_STATUS.has(status);
+}
+
+async function probeRoute(previewUrl: string, route: ProbeRoute): Promise<RouteProbeResult> {
+  const res = await fetch(normalizeUrl(previewUrl, route.path), { method: 'GET', redirect: 'manual' });
+  const status = res.status;
+  const location = REDIRECT_STATUS.has(status) ? res.headers.get('location') ?? undefined : undefined;
+  const ok = route.kind === 'public' ? status >= 200 && status < 400 : isRejected(status);
+  return { path: route.path, kind: route.kind, status, location, ok };
+}
+
+export async function runAuthRbacProof(input: AuthRbacProofInput): Promise<AuthRbacProofOutput> {
+  const hardFailures: string[] = [];
+  if (!input.previewUrl) hardFailures.push('MISSING_PREVIEW_URL');
+  if (input.signals?.fakeCookie) hardFailures.push('FAKE_COOKIE_SIGNAL');
+  if (input.signals?.fakeRoleHeader) hardFailures.push('FAKE_ROLE_HEADER_SIGNAL');
+  if (input.signals?.callerBooleans) hardFailures.push('CALLER_BOOLEAN_SIGNAL_IGNORED');
+
+  const protectedRoutes = input.routes.filter((r) => r.kind === 'protected');
+  const adminRoutes = input.routes.filter((r) => r.kind === 'admin');
+
+  if (input.authRequired && protectedRoutes.length === 0) hardFailures.push('AUTH_REQUIRED_WITHOUT_PROTECTED_ROUTES');
+  if (input.rbacRequired && adminRoutes.length === 0) hardFailures.push('RBAC_REQUIRED_WITHOUT_ADMIN_ROUTES');
+
+  if (input.oauthFlow === 'manual_only' && !input.hasTestIdentity) {
+    const payload = { status: 'MANUAL_REQUIRED' as const, routesChecked: [], summary: 'OAuth flow requires manual verification', hardFailures };
+    return { ...payload, proofHash: sha256Json(payload) };
+  }
+
+  if (hardFailures.length > 0 || !input.previewUrl) {
+    const payload = { status: 'BLOCK' as const, routesChecked: [], summary: 'Fail-closed: configuration or spoofing signals detected', hardFailures };
+    return { ...payload, proofHash: sha256Json(payload) };
+  }
+
+  const routesChecked: RouteProbeResult[] = [];
+  for (const route of input.routes) routesChecked.push(await probeRoute(input.previewUrl, route));
+
+  const failed = routesChecked.filter((r) => !r.ok);
+  if (failed.some((r) => r.kind === 'protected' && r.status >= 200 && r.status < 300)) {
+    hardFailures.push('PROTECTED_ROUTE_ACCESSIBLE_ANONYMOUS');
+  }
+  if (failed.some((r) => r.kind === 'admin' && r.status >= 200 && r.status < 300)) {
+    hardFailures.push('ADMIN_ROUTE_ACCESSIBLE_NON_ADMIN');
+  }
+
+  const status: AuthRbacProofOutput['status'] = hardFailures.length > 0 ? 'FAILED' : 'PASS';
+  const payload = {
+    status,
+    routesChecked,
+    summary: hardFailures.length > 0 ? 'Auth/RBAC probe found policy violations' : 'Auth/RBAC probe passed',
+    hardFailures,
+  };
+  return { ...payload, proofHash: sha256Json(payload) };
 }

--- a/tests/dsg/auth-rbac-proof.test.ts
+++ b/tests/dsg/auth-rbac-proof.test.ts
@@ -1,2 +1,80 @@
-import { describe,it,expect } from 'vitest'; import { evaluateAuthRbacProof } from '@/lib/dsg/runtime/auth-rbac-proof';
-describe('auth proof',()=>{it('manual when oauth untestable',()=>expect(evaluateAuthRbacProof({publicOk:true,anonBlocked:true,nonAdminBlocked:true,oauthTestable:false}).status).toBe('MANUAL_REQUIRED'));});
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runAuthRbacProof } from '@/lib/dsg/runtime/auth-rbac-proof';
+
+describe('auth/rbac proof probe', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PASS when public is accessible and protected/admin are rejected', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+      .mockResolvedValueOnce(new Response('denied', { status: 401 }))
+      .mockResolvedValueOnce(new Response('redirect', { status: 302, headers: { location: '/login' } })));
+
+    const result = await runAuthRbacProof({
+      previewUrl: 'https://preview.example.com',
+      routes: [
+        { path: '/', kind: 'public' },
+        { path: '/dashboard', kind: 'protected' },
+        { path: '/admin', kind: 'admin' },
+      ],
+      authRequired: true,
+      rbacRequired: true,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.routesChecked).toHaveLength(3);
+  });
+
+  it('FAIL when protected route returns 200 anonymously', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('ok', { status: 200 })));
+    const result = await runAuthRbacProof({
+      previewUrl: 'https://preview.example.com',
+      routes: [{ path: '/protected', kind: 'protected' }],
+      authRequired: true,
+    });
+
+    expect(result.status).toBe('FAILED');
+    expect(result.hardFailures).toContain('PROTECTED_ROUTE_ACCESSIBLE_ANONYMOUS');
+  });
+
+  it('MANUAL_REQUIRED for oauth manual-only without test identity', async () => {
+    const result = await runAuthRbacProof({
+      previewUrl: 'https://preview.example.com',
+      routes: [],
+      oauthFlow: 'manual_only',
+      hasTestIdentity: false,
+    });
+    expect(result.status).toBe('MANUAL_REQUIRED');
+  });
+
+  it('BLOCK on fake role/header signal', async () => {
+    const result = await runAuthRbacProof({
+      previewUrl: 'https://preview.example.com',
+      routes: [],
+      signals: { fakeRoleHeader: true },
+    });
+    expect(result.status).toBe('BLOCK');
+    expect(result.hardFailures).toContain('FAKE_ROLE_HEADER_SIGNAL');
+  });
+
+  it('proofHash is sha256 prefixed', async () => {
+    const result = await runAuthRbacProof({
+      previewUrl: 'https://preview.example.com',
+      routes: [],
+    });
+    expect(result.proofHash.startsWith('sha256:')).toBe(true);
+  });
+
+  it('hardFailures count is correct', async () => {
+    const result = await runAuthRbacProof({
+      routes: [],
+      authRequired: true,
+      rbacRequired: true,
+      signals: { fakeCookie: true, callerBooleans: true },
+    });
+    expect(result.status).toBe('BLOCK');
+    expect(result.hardFailures.length).toBe(5);
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement a real server-side Auth/RBAC proof probe that validates public/protected/admin route behavior against a preview URL and enforces fail-closed proof boundaries. 
- Prevent caller-side spoofing signals (caller booleans, fake cookies, fake role headers) and ensure proof is recorded via evidence/replay layers rather than accepting client booleans.

### Description
- Added a probe engine `runAuthRbacProof` in `lib/dsg/runtime/auth-rbac-proof.ts` that performs `fetch(..., { redirect: 'manual' })` against routes, evaluates allowed reject statuses, aggregates `routesChecked`, status codes, redirect locations, `summary`, `hardFailures`, and returns a `proofHash` computed with `sha256Json`.
- Enforced fail-closed conditions for missing `previewUrl`, spoof signals (`fakeCookie`, `fakeRoleHeader`, `callerBooleans`), missing protected/admin routes when `authRequired`/`rbacRequired` are set, and returned `MANUAL_REQUIRED` for untestable OAuth flows when no test identity is configured.
- Implemented server API route at `app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts` which requires a verified actor (`replay:verify`), calls the probe engine, and records the result as evidence via `writeEvidence` and a replay proof via `recordReplayProof` without claiming production.
- Files changed: `lib/dsg/runtime/auth-rbac-proof.ts`, `app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts`, and tests added at `tests/dsg/auth-rbac-proof.test.ts` covering PASS, protected access failure, OAuth manual-required, fake-role/header block, `proofHash` format, and hardFailures count.

### Testing
- `git diff --check` passed locally.
- `npm run dsg:runtime-check` passed and produced a deterministic runtime check hash.
- `npm run dsg:typecheck` failed in this environment due to missing `vitest` type declarations (pre-existing test setup), which prevented running unit tests here.
- `npm run dsg:verify` failed only because it invokes `dsg:typecheck`; runtime checks passed as noted above.

Claim boundary: this PR only implements the server-side Auth/RBAC proof probe path and records evidence/replay proof; it does not claim production readiness, Manus parity, or a completed production proof.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e1fa5bf08328ae9053e2506d7d33)