### PR TITLE
DSG-6: Implement signed build proof callback path from GitHub Actions

### DIFF
--- a/.github/workflows/dsg-app-builder-build.yml
+++ b/.github/workflows/dsg-app-builder-build.yml
@@ -46,7 +46,9 @@ jobs:
             "treeHash": "${{ inputs.tree_hash }}",
             "githubRunId": "${{ github.run_id }}",
             "githubSha": "${{ github.sha }}",
-            "status": "${{ job.status }}"
+            "status": "${{ job.status }}",
+            "startedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           JSON
 
@@ -56,3 +58,10 @@ jobs:
           name: dsg-build-proof-${{ inputs.job_id }}
           path: .dsg-build-proof/
           retention-days: 7
+
+      - name: Upload signed build proof callback
+        if: always()
+        env:
+          DSG_CALLBACK_SECRET: ${{ secrets.DSG_CALLBACK_SECRET }}
+          DSG_BUILD_PROOF_CALLBACK_URL: ${{ secrets.DSG_BUILD_PROOF_CALLBACK_URL }}
+        run: node scripts/dsg-upload-build-proof-evidence.mjs

--- a/app/api/dsg/runtime/build-proof/callback/route.ts
+++ b/app/api/dsg/runtime/build-proof/callback/route.ts
@@ -1,0 +1,79 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { recordReplayProof, writeEvidence } from '@/lib/dsg/server/repository';
+
+export type BuildProofPayload = {
+  jobId: string;
+  branch: string;
+  treeHash: string;
+  githubRunId: string;
+  githubSha: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+};
+
+export function computeBuildProofHash(payload: BuildProofPayload): string {
+  return createHmac('sha256', 'dsg-build-proof-hash').update(JSON.stringify(payload)).digest('hex');
+}
+
+function verifySignature(rawBody: string, header: string | null, secret: string): boolean {
+  if (!header || !header.startsWith('sha256=')) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const actual = header.slice('sha256='.length);
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(actual, 'hex'), Buffer.from(expected, 'hex'));
+}
+
+function payloadValid(payload: Partial<BuildProofPayload> | null): payload is BuildProofPayload {
+  return !!payload?.jobId && !!payload.branch && !!payload.treeHash && !!payload.githubRunId && !!payload.githubSha && !!payload.status;
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.DSG_CALLBACK_SECRET;
+  if (!secret) return NextResponse.json({ ok: false, error: { code: 'DSG_CALLBACK_SECRET_REQUIRED' } }, { status: 500 });
+
+  const signature = request.headers.get('x-dsg-signature');
+  if (!signature) return NextResponse.json({ ok: false, error: { code: 'DSG_CALLBACK_SIGNATURE_REQUIRED' } }, { status: 401 });
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, signature, secret)) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_CALLBACK_SIGNATURE_INVALID' } }, { status: 401 });
+  }
+
+  const payload = JSON.parse(rawBody) as Partial<BuildProofPayload>;
+  if (!payloadValid(payload)) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_BUILD_PROOF_PAYLOAD_REQUIRED' } }, { status: 400 });
+  }
+
+  const buildStatus = /^(success|pass)$/i.test(payload.status) ? 'BUILD_VERIFIED' : 'FAILED';
+  const replayStatus = buildStatus === 'BUILD_VERIFIED' ? 'PASS' : 'FAILED';
+  const proofHash = `sha256:${computeBuildProofHash(payload)}`;
+
+  const repoCtx = {
+    workspaceId: process.env.DSG_CALLBACK_WORKSPACE_ID ?? '',
+    actorId: process.env.DSG_CALLBACK_ACTOR_ID ?? '',
+    userAccessToken: process.env.DSG_CALLBACK_USER_ACCESS_TOKEN,
+  };
+
+  try {
+    const evidence = await writeEvidence(repoCtx, {
+      jobId: payload.jobId,
+      evidenceType: 'BUILD_PROOF',
+      contentHash: proofHash,
+      summary: `Build proof callback ${buildStatus}; CI status=${payload.status}`,
+      metadata: { ...payload, buildStatus, claimBoundary: 'DSG-6 implements signed build proof callback path.' },
+    });
+
+    const replay = await recordReplayProof(repoCtx, {
+      jobId: payload.jobId,
+      replayHash: proofHash,
+      status: replayStatus,
+      details: { buildProof: payload, evidenceId: evidence.id, buildStatus },
+    });
+
+    return NextResponse.json({ ok: true, data: { buildStatus, evidenceId: evidence.id, replayProofId: replay.id, proofHash } }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { code: error instanceof Error ? error.message : 'DSG_BUILD_PROOF_RECORD_FAILED' } }, { status: 403 });
+  }
+}

--- a/scripts/dsg-upload-build-proof-evidence.mjs
+++ b/scripts/dsg-upload-build-proof-evidence.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { createHmac } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+const secret = process.env.DSG_CALLBACK_SECRET;
+const callbackUrl = process.env.DSG_BUILD_PROOF_CALLBACK_URL;
+
+if (!secret) throw new Error('DSG_CALLBACK_SECRET_REQUIRED');
+if (!callbackUrl) throw new Error('DSG_BUILD_PROOF_CALLBACK_URL_REQUIRED');
+
+const rawBody = await readFile('.dsg-build-proof/build-proof.json', 'utf8');
+const signature = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+
+const response = await fetch(callbackUrl, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'x-dsg-signature': signature,
+  },
+  body: rawBody,
+});
+
+if (!response.ok) {
+  const text = await response.text();
+  throw new Error(`DSG_BUILD_PROOF_CALLBACK_FAILED_${response.status}:${text}`);
+}
+
+console.log('DSG build proof callback uploaded.');

--- a/tests/dsg/build-proof-callback.test.ts
+++ b/tests/dsg/build-proof-callback.test.ts
@@ -1,0 +1,74 @@
+import { createHmac } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/dsg/server/repository', () => ({
+  writeEvidence: vi.fn(async () => ({ id: 'ev1' })),
+  recordReplayProof: vi.fn(async () => ({ id: 'rp1' })),
+}));
+
+import { POST, computeBuildProofHash } from '@/app/api/dsg/runtime/build-proof/callback/route';
+import { recordReplayProof } from '@/lib/dsg/server/repository';
+
+const basePayload = {
+  jobId: 'job-1',
+  branch: 'feat/x',
+  treeHash: 'sha256:tree',
+  githubRunId: '123',
+  githubSha: 'abc',
+  status: 'success',
+};
+
+function signedRequest(payload: unknown, secret: string) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  return new Request('http://localhost/api/dsg/runtime/build-proof/callback', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-dsg-signature': signature },
+    body,
+  });
+}
+
+describe('build proof callback route', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.DSG_CALLBACK_SECRET = 'secret';
+    process.env.DSG_CALLBACK_WORKSPACE_ID = 'ws';
+    process.env.DSG_CALLBACK_ACTOR_ID = 'actor';
+    process.env.DSG_CALLBACK_USER_ACCESS_TOKEN = 'token';
+  });
+
+  it('rejects missing signature', async () => {
+    const res = await POST(new Request('http://localhost', { method: 'POST', body: JSON.stringify(basePayload) }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects invalid signature', async () => {
+    const res = await POST(new Request('http://localhost', { method: 'POST', headers: { 'x-dsg-signature': 'sha256=deadbeef' }, body: JSON.stringify(basePayload) }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects missing payload fields', async () => {
+    const res = await POST(signedRequest({ jobId: 'x' }, 'secret'));
+    expect(res.status).toBe(400);
+  });
+
+  it('records FAILED for failed workflow status', async () => {
+    const res = await POST(signedRequest({ ...basePayload, status: 'failed' }, 'secret'));
+    expect(res.status).toBe(201);
+    expect(recordReplayProof).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ status: 'FAILED' }));
+  });
+
+  it('records BUILD_VERIFIED for success status', async () => {
+    const res = await POST(signedRequest(basePayload, 'secret'));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.data.buildStatus).toBe('BUILD_VERIFIED');
+    expect(recordReplayProof).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ status: 'PASS' }));
+  });
+
+  it('proof hash deterministic', () => {
+    const one = computeBuildProofHash(basePayload);
+    const two = computeBuildProofHash(basePayload);
+    expect(one).toBe(two);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure CI-produced build proof artifact is delivered to DSG via a signed, server-verified callback rather than trusting client-supplied fields, and fail-closed on any invalid or missing proof data. 
- Provide a deterministic proof hash and record build proof evidence + replay using the repository evidence layer so downstream gates can rely on an auditable record without claiming production.

### Description
- Update workflow `.github/workflows/dsg-app-builder-build.yml` to always write `.dsg-build-proof/build-proof.json` (includes `jobId`, `branch`, `treeHash`, `githubRunId`, `githubSha`, `status`, `startedAt`, `completedAt`) and call a signed uploader step. 
- Add `scripts/dsg-upload-build-proof-evidence.mjs` which reads the raw JSON artifact, signs the raw body with HMAC SHA-256 using `DSG_CALLBACK_SECRET` and POSTs it with header `x-dsg-signature: sha256=<hex>` to `DSG_BUILD_PROOF_CALLBACK_URL`. 
- Add callback route `app/api/dsg/runtime/build-proof/callback/route.ts` that verifies HMAC with `timingSafeEqual`, rejects missing/invalid signatures (401), rejects missing required fields (400), computes a deterministic proof hash, and records evidence via existing `writeEvidence` + `recordReplayProof`; success/pass maps to `BUILD_VERIFIED`/`PASS`, otherwise `FAILED`/`FAILED`. 
- Add tests `tests/dsg/build-proof-callback.test.ts` covering missing signature, invalid signature, missing fields, failed workflow => FAILED, success => BUILD_VERIFIED, and deterministic proof hash; do not accept any client `body.ok` and do not claim PRODUCTION. 
- Files changed: `.github/workflows/dsg-app-builder-build.yml`, `scripts/dsg-upload-build-proof-evidence.mjs`, `app/api/dsg/runtime/build-proof/callback/route.ts`, `tests/dsg/build-proof-callback.test.ts`.

### Testing
- `git diff --check` passed. 
- `npm run dsg:runtime-check` passed (deterministic runtime check). 
- `npm run dsg:typecheck` failed in this environment due to missing `vitest` types/dependency preventing TypeScript from resolving test types. 
- `npm run dsg:verify` failed because it runs `dsg:typecheck` and the same `vitest` dependency was unavailable; running `vitest` directly also failed due to registry/network policy returning HTTP 403. 

Evidence: commit `4762f59` contains the changes and the callback enforces HMAC-signed raw JSON with timing-safe verification and fail-closed behavior. 

Claim boundary: DSG-6 implements signed build proof callback path. No claim of Manus parity, production readiness, or production-proof completeness is made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e8cdaf04832880590e0b8ba72ca9)