### PR TITLE
Fix DSG readiness blockers: add vitest and harden DSG-8 auth/rbac proof config

### DIFF
--- a/app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts
+++ b/app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts
@@ -1,38 +1,57 @@
 import { NextResponse } from 'next/server';
 import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { getBearerToken } from '@/lib/dsg/server/supabase-rpc';
-import { recordReplayProof, writeEvidence } from '@/lib/dsg/server/repository';
+import { getRuntimeJob, recordReplayProof, writeEvidence } from '@/lib/dsg/server/repository';
 import { runAuthRbacProof } from '@/lib/dsg/runtime/auth-rbac-proof';
+
+type TrustedAuthRbacProofConfig = {
+  previewUrl?: string;
+  routes: Array<{ path: string; kind: 'public' | 'protected' | 'admin' }>;
+  authRequired?: boolean;
+  rbacRequired?: boolean;
+  oauthFlow?: 'none' | 'manual_only';
+  hasTestIdentity?: boolean;
+  signals?: { fakeCookie?: boolean; fakeRoleHeader?: boolean; callerBooleans?: boolean };
+};
+
+function readTrustedAuthRbacConfig(metadata: Record<string, unknown>): TrustedAuthRbacProofConfig | null {
+  const candidates: unknown[] = [
+    metadata.authRbacProofConfig,
+    metadata.authProofConfig,
+    metadata.planMetadata,
+    metadata.plan,
+  ];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const source = candidate as Record<string, unknown>;
+    const config = (source.authRbacProofConfig ?? source.authProofConfig ?? source) as Record<string, unknown>;
+    if (!Array.isArray(config.routes)) continue;
+    return {
+      previewUrl: typeof config.previewUrl === 'string' ? config.previewUrl : undefined,
+      routes: config.routes as TrustedAuthRbacProofConfig['routes'],
+      authRequired: config.authRequired === true,
+      rbacRequired: config.rbacRequired === true,
+      oauthFlow: config.oauthFlow === 'manual_only' ? 'manual_only' : 'none',
+      hasTestIdentity: config.hasTestIdentity === true,
+      signals: typeof config.signals === 'object' && config.signals ? (config.signals as TrustedAuthRbacProofConfig['signals']) : undefined,
+    };
+  }
+  return null;
+}
 
 export async function POST(request: Request, context: { params: Promise<{ jobId: string }> }) {
   const actor = await requireVerifiedDsgActor(request.headers, 'replay:verify');
   const { jobId } = await context.params;
-  const body = (await request.json().catch(() => null)) as {
-    previewUrl?: string;
-    routes?: Array<{ path: string; kind: 'public' | 'protected' | 'admin' }>;
-    authRequired?: boolean;
-    rbacRequired?: boolean;
-    oauthFlow?: 'none' | 'manual_only';
-    hasTestIdentity?: boolean;
-    signals?: { fakeCookie?: boolean; fakeRoleHeader?: boolean; callerBooleans?: boolean };
-  } | null;
-
-  if (!body?.routes || !Array.isArray(body.routes)) {
-    return NextResponse.json({ ok: false, error: { code: 'DSG_AUTH_RBAC_PROOF_INPUT_REQUIRED' } }, { status: 400 });
+  const repoCtx = { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) };
+  const job = await getRuntimeJob(repoCtx, jobId);
+  const trustedConfig = readTrustedAuthRbacConfig((job.metadata ?? {}) as Record<string, unknown>);
+  if (!trustedConfig || trustedConfig.routes.length === 0) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_AUTH_RBAC_PROOF_CONFIG_REQUIRED_SERVER_METADATA' } }, { status: 403 });
   }
 
-  const proof = await runAuthRbacProof({
-    previewUrl: body.previewUrl,
-    routes: body.routes,
-    authRequired: body.authRequired,
-    rbacRequired: body.rbacRequired,
-    oauthFlow: body.oauthFlow,
-    hasTestIdentity: body.hasTestIdentity,
-    signals: body.signals,
-  });
+  const proof = await runAuthRbacProof(trustedConfig);
 
   try {
-    const repoCtx = { workspaceId: actor.workspaceId, actorId: actor.actorId, userAccessToken: getBearerToken(request.headers) };
     const evidence = await writeEvidence(repoCtx, {
       jobId,
       evidenceType: 'AUTH_RBAC_PROOF',

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "firebase-tools": "^15.0.0",
         "tailwindcss": "4.1.11",
         "tw-animate-css": "^1.4.0",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "firebase-tools": "^15.0.0",
     "tailwindcss": "4.1.11",
     "tw-animate-css": "^1.4.0",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
### Motivation
- Add the missing test dependency so type-check and tests that import test types can resolve, addressing a readiness blocker for the repo.
- Ensure DSG-8 auth/RBAC proof uses trusted server-side job/plan metadata as the source of truth and that missing or spoofed client-supplied config does not allow a false PASS.

### Description
- Added `vitest` to `devDependencies` in `package.json` and updated the root entries in `package-lock.json` so test type imports can be resolved by tooling that expects the dev dependency.
- Hardened `app/api/dsg/jobs/[jobId]/auth-rbac-proof/route.ts` to load proof configuration from the server-side runtime job metadata using `getRuntimeJob` and a new `readTrustedAuthRbacConfig` helper that inspects `authRbacProofConfig`, `authProofConfig`, `planMetadata`, and `plan` fallbacks.
- Removed trust of proof truth from caller body and implemented fail-closed behavior: when trusted config is missing or has no routes the route returns `403` with `DSG_AUTH_RBAC_PROOF_CONFIG_REQUIRED_SERVER_METADATA`, while preserving the existing evidence and replay-proof recording flow.

### Testing
- Ran `git diff --check` which completed without issues.
- Attempted to install `vitest` with `npm i -D vitest@latest`, but the install failed due to `403 Forbidden` responses from the npm registry, preventing a real package install in this environment.
- Ran `npm run dsg:typecheck` which failed with `TS2307: Cannot find module 'vitest'` in several test files because `vitest` could not be installed; this blocked further steps in the verification chain.
- Because type-check failed due to the missing package, `npm run dsg:runtime-check` and `npm run dsg:verify` did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fc6730808328a47d73cef3b45672)