### PR TITLE
fix: resolve Next.js route export type error for build-proof callback

### DIFF
--- a/app/api/dsg/runtime/build-proof/callback/route.ts
+++ b/app/api/dsg/runtime/build-proof/callback/route.ts
@@ -1,21 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
+import { computeBuildProofHash, type BuildProofPayload } from '@/lib/dsg/server/build-proof';
 import { recordReplayProof, writeEvidence } from '@/lib/dsg/server/repository';
-
-export type BuildProofPayload = {
-  jobId: string;
-  branch: string;
-  treeHash: string;
-  githubRunId: string;
-  githubSha: string;
-  status: string;
-  startedAt?: string;
-  completedAt?: string;
-};
-
-export function computeBuildProofHash(payload: BuildProofPayload): string {
-  return createHmac('sha256', 'dsg-build-proof-hash').update(JSON.stringify(payload)).digest('hex');
-}
 
 function verifySignature(rawBody: string, header: string | null, secret: string): boolean {
   if (!header || !header.startsWith('sha256=')) return false;

--- a/lib/dsg/server/build-proof.ts
+++ b/lib/dsg/server/build-proof.ts
@@ -1,0 +1,16 @@
+import { createHmac } from 'node:crypto';
+
+export type BuildProofPayload = {
+  jobId: string;
+  branch: string;
+  treeHash: string;
+  githubRunId: string;
+  githubSha: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+};
+
+export function computeBuildProofHash(payload: BuildProofPayload): string {
+  return createHmac('sha256', 'dsg-build-proof-hash').update(JSON.stringify(payload)).digest('hex');
+}

--- a/tests/dsg/build-proof-callback.test.ts
+++ b/tests/dsg/build-proof-callback.test.ts
@@ -6,7 +6,8 @@ vi.mock('@/lib/dsg/server/repository', () => ({
   recordReplayProof: vi.fn(async () => ({ id: 'rp1' })),
 }));
 
-import { POST, computeBuildProofHash } from '@/app/api/dsg/runtime/build-proof/callback/route';
+import { POST } from '@/app/api/dsg/runtime/build-proof/callback/route';
+import { computeBuildProofHash } from '@/lib/dsg/server/build-proof';
 import { recordReplayProof } from '@/lib/dsg/server/repository';
 
 const basePayload = {


### PR DESCRIPTION
### Motivation
- Next.js route modules only allow specific route handler exports and exporting helper symbols from a route file caused `next build` type validation to fail. 

### Description
- Removed `BuildProofPayload` and `computeBuildProofHash` from `app/api/dsg/runtime/build-proof/callback/route.ts` and imported them from a new library module `lib/dsg/server/build-proof.ts`. 
- Added `lib/dsg/server/build-proof.ts` which defines `BuildProofPayload` and `computeBuildProofHash`. 
- Updated `tests/dsg/build-proof-callback.test.ts` to import `computeBuildProofHash` from the new library instead of the route file. 

### Testing
- `npm run build` before the change failed with a Next.js route export type error `computeBuildProofHash is not a valid Route export field`. 
- `npm run build` after the change completed successfully (`EXIT:0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ff6917108328bac23cc07527d0e3)