### PR TITLE
Protect dashboard from anonymous access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage/
 
 # TypeScript build cache
 tsconfig.tsbuildinfo
+
+# DSG local secrets
+.dsg-local/

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+const AUTH_COOKIE_NAMES = [
+  'sb-access-token',
+  'sb-refresh-token',
+  '__session',
+  'next-auth.session-token',
+  '__Secure-next-auth.session-token',
+];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (!pathname.startsWith('/dashboard')) {
+    return NextResponse.next();
+  }
+
+  const hasAuthCookie = AUTH_COOKIE_NAMES.some((name) => Boolean(request.cookies.get(name)?.value));
+
+  if (!hasAuthCookie) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    url.searchParams.set('next', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};


### PR DESCRIPTION
Adds middleware to redirect anonymous /dashboard access to /login and stores local DSG test identity outside git.