### PR TITLE
Add governed AI gateway, OpenAPI function definitions, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,10 @@ DSG_ONE_V1_SUPABASE_SERVICE_ROLE_KEY=""
 
 # Optional local-only compatibility bridge. Do not enable for production.
 DSG_ALLOW_DEV_HEADER_ACTOR="false"
+
+# Optional governed AI gateway providers. Server-side only; never expose these in client code.
+OPENAI_API_KEY=""
+OPENAI_API_BASE=""
+ANTHROPIC_API_KEY=""
+# GEMINI_API_KEY is listed above; GOOGLE_GENERATIVE_AI_API_KEY is accepted as a compatibility alias.
+GOOGLE_GENERATIVE_AI_API_KEY=""

--- a/app/api/dsg/ai-gateway/route.ts
+++ b/app/api/dsg/ai-gateway/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { executeDsgAiGatewayRequest, prepareDsgAiGatewayRequest, type DsgAiGatewayRequest } from '@/lib/dsg/connectors/ai-gateway';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
+}
+
+function parseRequest(body: Record<string, unknown>): DsgAiGatewayRequest {
+  return {
+    provider: String(body.provider || '').trim() as DsgAiGatewayRequest['provider'],
+    goal: String(body.goal || '').trim(),
+    prompt: String(body.prompt || '').trim(),
+    model: typeof body.model === 'string' ? body.model.trim() : undefined,
+    mode: typeof body.mode === 'string' ? body.mode.trim() as DsgAiGatewayRequest['mode'] : undefined,
+    history: stringArray(body.history),
+    evidence: stringArray(body.evidence),
+    maxOutputTokens: typeof body.maxOutputTokens === 'number' ? body.maxOutputTokens : undefined,
+    temperature: typeof body.temperature === 'number' ? body.temperature : undefined,
+  };
+}
+
+export async function POST(req: Request) {
+  const body = asRecord(await req.json().catch(() => null));
+  const input = parseRequest(body);
+  const execute = body.execute === true;
+
+  if (!['openai', 'gemini', 'anthropic'].includes(input.provider)) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_AI_PROVIDER_UNSUPPORTED', message: 'provider must be openai, gemini, or anthropic' } }, { status: 400 });
+  }
+
+  const result = execute ? await executeDsgAiGatewayRequest(input) : prepareDsgAiGatewayRequest(input);
+  return NextResponse.json(result, { status: result.ok ? 200 : 400 });
+}

--- a/app/generated-apps/2f3b20b0-824c-4d4a-ae6a-250bd18f3392/page.tsx
+++ b/app/generated-apps/2f3b20b0-824c-4d4a-ae6a-250bd18f3392/page.tsx
@@ -43,7 +43,6 @@ export default function GeneratedDsgAbcGamePage() {
   const stars = useMemo(() => '⭐'.repeat(Math.max(0, Math.min(score, 6))), [score]);
 
   async function loadItems() {
-    setStatus('กำลังโหลดหลักฐาน backend…');
     const response = await fetch(`/api/generated-apps/${APP_ID}/items`, { cache: 'no-store' });
     const json = await response.json();
     if (!response.ok || !json.ok) throw new Error(json.error?.message || 'GENERATED_APP_BACKEND_FAILED');
@@ -98,7 +97,11 @@ export default function GeneratedDsgAbcGamePage() {
   }
 
   useEffect(() => {
-    loadItems().catch((error) => setStatus(error instanceof Error ? error.message : 'GENERATED_APP_LOAD_FAILED'));
+    const timer = window.setTimeout(() => {
+      loadItems().catch((error) => setStatus(error instanceof Error ? error.message : 'GENERATED_APP_LOAD_FAILED'));
+    }, 0);
+
+    return () => window.clearTimeout(timer);
   }, []);
 
   return (

--- a/lib/dsg/connectors/ai-gateway.ts
+++ b/lib/dsg/connectors/ai-gateway.ts
@@ -1,0 +1,219 @@
+import { kilesa, parami, samadhi, truthBoundary, userBenefitGate, verify } from '../app-builder/agent-runtime/decision-frame';
+import { sha256Json } from '../runtime/hash';
+
+export type DsgAiProvider = 'openai' | 'gemini' | 'anthropic';
+export type DsgAiMode = 'text' | 'json' | 'image_analysis' | 'video_analysis' | 'speech' | 'audio_transcription';
+export type DsgAiPreparedStatus = 'ready' | 'blocked' | 'review';
+
+export type DsgAiGatewayRequest = {
+  provider: DsgAiProvider;
+  goal: string;
+  prompt: string;
+  model?: string;
+  mode?: DsgAiMode;
+  history?: string[];
+  evidence?: string[];
+  maxOutputTokens?: number;
+  temperature?: number;
+};
+
+export type DsgAiGatewayPreparedRequest = {
+  ok: boolean;
+  status: DsgAiPreparedStatus;
+  provider: DsgAiProvider;
+  model: string;
+  mode: DsgAiMode;
+  endpoint: string;
+  method: 'POST';
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+  decisionFrame: {
+    target: ReturnType<typeof samadhi>;
+    verifiedInput: ReturnType<typeof verify<DsgAiGatewayRequest>>;
+    risk: ReturnType<typeof kilesa>;
+    stats: ReturnType<typeof parami>;
+    benefit: ReturnType<typeof userBenefitGate>;
+    truthBoundary: ReturnType<typeof truthBoundary>;
+  };
+  requiredSecret: string;
+  requestHash: string;
+  blockedReasons: string[];
+  userOutcome: string;
+};
+
+const providerDefaults: Record<DsgAiProvider, { model: string; secretNames: string[] }> = {
+  openai: { model: 'gpt-5', secretNames: ['OPENAI_API_KEY'] },
+  gemini: { model: 'gemini-2.5-flash', secretNames: ['GEMINI_API_KEY', 'GOOGLE_GENERATIVE_AI_API_KEY'] },
+  anthropic: { model: 'claude-3-opus-20240229', secretNames: ['ANTHROPIC_API_KEY'] },
+};
+
+const modeSupport: Record<DsgAiProvider, DsgAiMode[]> = {
+  openai: ['text', 'json', 'image_analysis', 'speech', 'audio_transcription'],
+  gemini: ['text', 'json', 'image_analysis', 'video_analysis'],
+  anthropic: ['text', 'json', 'image_analysis'],
+};
+
+function getSecret(provider: DsgAiProvider): { name: string; value: string } | null {
+  for (const name of providerDefaults[provider].secretNames) {
+    const value = process.env[name];
+    if (value && value.trim()) return { name, value };
+  }
+  return null;
+}
+
+function riskFlagsFor(input: DsgAiGatewayRequest): string[] {
+  const text = `${input.goal}\n${input.prompt}`;
+  return [
+    /(?:secret|token|service[_-]?role|api[_-]?key|private[_-]?key)/i.test(text) ? 'secret' : '',
+    /(?:production verified|certified|guaranteed compliant|guaranteed)/i.test(text) ? 'production_claim' : '',
+    /(?:copy .*(?:licensed|proprietary)|bypass license|remove copyright)/i.test(text) ? 'license_violation' : '',
+  ].filter(Boolean);
+}
+
+function buildBody(input: DsgAiGatewayRequest, model: string): Record<string, unknown> {
+  const mode = input.mode ?? 'text';
+  const maxOutputTokens = input.maxOutputTokens ?? 1024;
+  if (input.provider === 'openai') {
+    return {
+      model,
+      input: input.prompt,
+      text: mode === 'json' ? { format: { type: 'json_object' } } : undefined,
+      max_output_tokens: maxOutputTokens,
+      temperature: input.temperature,
+      metadata: { dsgGoalHash: sha256Json({ goal: input.goal }) },
+    };
+  }
+  if (input.provider === 'gemini') {
+    return {
+      contents: [{ role: 'user', parts: [{ text: input.prompt }] }],
+      generationConfig: {
+        responseMimeType: mode === 'json' ? 'application/json' : 'text/plain',
+        maxOutputTokens,
+        temperature: input.temperature,
+      },
+      systemInstruction: { parts: [{ text: `DSG target: ${input.goal}` }] },
+    };
+  }
+  return {
+    model,
+    max_tokens: maxOutputTokens,
+    temperature: input.temperature,
+    system: `DSG target: ${input.goal}`,
+    messages: [{ role: 'user', content: input.prompt }],
+  };
+}
+
+function buildEndpoint(provider: DsgAiProvider, model: string, secretValue: string): string {
+  if (provider === 'openai') return `${process.env.OPENAI_API_BASE || 'https://api.openai.com'}/v1/responses`;
+  if (provider === 'gemini') return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(secretValue)}`;
+  return 'https://api.anthropic.com/v1/messages';
+}
+
+function buildHeaders(provider: DsgAiProvider, secretValue: string): Record<string, string> {
+  if (provider === 'openai') return { 'content-type': 'application/json', authorization: `Bearer ${secretValue}` };
+  if (provider === 'anthropic') return { 'content-type': 'application/json', 'x-api-key': secretValue, 'anthropic-version': '2023-06-01' };
+  return { 'content-type': 'application/json' };
+}
+
+export function prepareDsgAiGatewayRequest(input: DsgAiGatewayRequest): DsgAiGatewayPreparedRequest {
+  const providerConfig = providerDefaults[input.provider];
+  if (!providerConfig) throw new Error('DSG_AI_PROVIDER_UNSUPPORTED');
+
+  const goal = input.goal.trim();
+  const prompt = input.prompt.trim();
+  const model = (input.model || providerConfig.model).trim();
+  const mode = input.mode ?? 'text';
+  const target = samadhi('dsg-ai-gateway', goal || 'missing-goal');
+  const evidence = [...(input.evidence ?? [])];
+  if (goal) evidence.push(`goal_hash:${sha256Json({ goal })}`);
+  if (prompt) evidence.push(`prompt_hash:${sha256Json({ prompt })}`);
+  const normalizedInput = { ...input, goal, prompt, model, mode };
+  const verifiedInput = verify(normalizedInput, evidence);
+  const flags = riskFlagsFor(normalizedInput);
+  const modeBlocked = !modeSupport[input.provider].includes(mode);
+  const secret = getSecret(input.provider);
+  const missing: string[] = [];
+  if (!goal) missing.push('GOAL_REQUIRED');
+  if (!prompt) missing.push('PROMPT_REQUIRED');
+  if (!model) missing.push('MODEL_REQUIRED');
+  if (modeBlocked) missing.push(`MODE_UNSUPPORTED:${input.provider}:${mode}`);
+  if (!secret) missing.push(`SECRET_REQUIRED:${providerConfig.secretNames.join('|')}`);
+
+  const risk = kilesa(`${input.provider}:${mode}:${goal || 'missing-goal'}`, verifiedInput.verified && missing.length === 0, flags);
+  const stats = parami([...(input.history ?? []), input.provider, mode]);
+  const benefit = userBenefitGate({
+    userBenefit: 'User gets one fail-closed model gateway that states provider, model, required secret, risk, and evidence before any external AI call.',
+    easier: true,
+    tangibleOutput: 'Prepared provider request with decision-frame status and deterministic request hash.',
+    nextAction: missing.length || risk.state === 'blocked' ? 'Fix blocked reasons before execution.' : 'Execute through server-side gateway and store output as unverified until independently checked.',
+  });
+  const boundary = truthBoundary({
+    verified: verifiedInput.verified && missing.length === 0,
+    containsSecret: flags.includes('secret'),
+    containsProductionClaim: flags.includes('production_claim'),
+    containsLicenseRisk: flags.includes('license_violation'),
+  });
+  const blockedReasons = [...missing, ...risk.reasons.filter((reason) => reason !== 'VERIFIED'), ...boundary.blockedReasons];
+  const status: DsgAiPreparedStatus = blockedReasons.length ? 'blocked' : mode !== 'text' && mode !== 'json' ? 'review' : 'ready';
+  const secretValue = secret?.value ?? 'MISSING_SECRET_FAIL_CLOSED';
+  const endpoint = buildEndpoint(input.provider, model || providerConfig.model, secretValue);
+  const body = buildBody(normalizedInput, model || providerConfig.model);
+  const headers = buildHeaders(input.provider, secretValue);
+  const requestHash = sha256Json({ provider: input.provider, model, mode, endpoint: endpoint.replace(secretValue, 'REDACTED'), body });
+
+  return {
+    ok: status !== 'blocked',
+    status,
+    provider: input.provider,
+    model: model || providerConfig.model,
+    mode,
+    endpoint: redactUrl(endpoint),
+    method: 'POST',
+    headers: redactHeaders(headers),
+    body,
+    decisionFrame: { target, verifiedInput, risk, stats, benefit, truthBoundary: boundary },
+    requiredSecret: providerConfig.secretNames.join('|'),
+    requestHash,
+    blockedReasons: [...new Set(blockedReasons)],
+    userOutcome: 'A governed AI request can be reviewed before network execution; missing secrets or unsafe claims fail closed.',
+  };
+}
+
+export async function executeDsgAiGatewayRequest(input: DsgAiGatewayRequest): Promise<{
+  ok: boolean;
+  prepared: DsgAiGatewayPreparedRequest;
+  responseStatus?: number;
+  responseBody?: unknown;
+  outputVerification: 'unverified_external_output' | 'blocked_before_call';
+}> {
+  const prepared = prepareDsgAiGatewayRequest(input);
+  if (!prepared.ok) return { ok: false, prepared, outputVerification: 'blocked_before_call' };
+
+  const secret = getSecret(input.provider);
+  if (!secret) return { ok: false, prepared, outputVerification: 'blocked_before_call' };
+  const endpoint = buildEndpoint(input.provider, prepared.model, secret.value);
+  const headers = buildHeaders(input.provider, secret.value);
+  const response = await fetch(endpoint, {
+    method: prepared.method,
+    headers,
+    body: JSON.stringify(prepared.body),
+  });
+  const text = await response.text();
+  let responseBody: unknown = text;
+  if (text.trim().startsWith('{') || text.trim().startsWith('[')) responseBody = JSON.parse(text);
+  return {
+    ok: response.ok,
+    prepared,
+    responseStatus: response.status,
+    responseBody,
+    outputVerification: 'unverified_external_output',
+  };
+}
+
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, /authorization|api-key/i.test(key) ? 'REDACTED' : value]));
+}
+
+export function redactUrl(url: string): string {
+  return url.replace(/([?&]key=)[^&]+/i, '$1REDACTED');
+}

--- a/lib/dsg/connectors/openapi.ts
+++ b/lib/dsg/connectors/openapi.ts
@@ -59,3 +59,72 @@ export function openApiToGovernedTools(document: OpenApiDocument): GovernedTool[
 
   return tools;
 }
+
+
+export type OpenApiFunctionDefinition = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+  dsg: {
+    method: string;
+    path: string;
+    riskLevel: RiskLevel;
+    requiresApproval: boolean;
+    schemaHash: string;
+    truthBoundary: 'function_definition_only_not_runtime_evidence';
+  };
+};
+
+function parameterSchema(operation: OpenApiOperation): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const parameter of operation.parameters ?? []) {
+    if (!parameter || typeof parameter !== 'object' || Array.isArray(parameter)) continue;
+    const record = parameter as Record<string, unknown>;
+    const name = typeof record.name === 'string' ? record.name : '';
+    if (!name) continue;
+    properties[name] = record.schema && typeof record.schema === 'object'
+      ? record.schema
+      : { type: 'string', description: typeof record.description === 'string' ? record.description : undefined };
+    if (record.required === true) required.push(name);
+  }
+
+  if (operation.requestBody && typeof operation.requestBody === 'object' && !Array.isArray(operation.requestBody)) {
+    const requestBody = operation.requestBody as Record<string, unknown>;
+    properties.requestBody = requestBody;
+    if (requestBody.required === true) required.push('requestBody');
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required: [...new Set(required)].sort(),
+    additionalProperties: false,
+  };
+}
+
+export function openApiToGovernedFunctionDefinitions(document: OpenApiDocument): OpenApiFunctionDefinition[] {
+  return openApiToGovernedTools(document).map((tool) => {
+    const operation = document.paths?.[tool.path]?.[tool.method.toLowerCase()] ?? {};
+    return {
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: parameterSchema(operation),
+      },
+      dsg: {
+        method: tool.method,
+        path: tool.path,
+        riskLevel: tool.riskLevel,
+        requiresApproval: tool.requiresApproval,
+        schemaHash: tool.schemaHash,
+        truthBoundary: 'function_definition_only_not_runtime_evidence',
+      },
+    };
+  });
+}

--- a/tests/dsg/ai-gateway.test.ts
+++ b/tests/dsg/ai-gateway.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeDsgAiGatewayRequest, prepareDsgAiGatewayRequest, redactHeaders, redactUrl } from '../../lib/dsg/connectors/ai-gateway';
+
+describe('DSG AI gateway', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it('fails closed when the provider secret is missing', () => {
+    const prepared = prepareDsgAiGatewayRequest({ provider: 'openai', goal: 'Draft a PRD', prompt: 'Create sections' });
+    expect(prepared.ok).toBe(false);
+    expect(prepared.status).toBe('blocked');
+    expect(prepared.blockedReasons).toContain('SECRET_REQUIRED:OPENAI_API_KEY');
+    expect(prepared.decisionFrame.truthBoundary.productionReadyClaim).toBe(false);
+  });
+
+  it('prepares a Gemini JSON request with deterministic verification evidence', () => {
+    process.env.GEMINI_API_KEY = 'gemini-secret';
+    const prepared = prepareDsgAiGatewayRequest({ provider: 'gemini', goal: 'Return a task schema', prompt: 'Return JSON only', mode: 'json' });
+    expect(prepared.ok).toBe(true);
+    expect(prepared.model).toBe('gemini-2.5-flash');
+    expect(prepared.endpoint).toContain('generateContent?key=REDACTED');
+    expect(prepared.body.generationConfig).toMatchObject({ responseMimeType: 'application/json' });
+    expect(prepared.decisionFrame.verifiedInput.evidence.some((entry) => entry.startsWith('goal_hash:sha256:'))).toBe(true);
+    expect(prepared.requestHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('blocks secret-like prompts before network execution', async () => {
+    process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+    const result = await executeDsgAiGatewayRequest({ provider: 'anthropic', goal: 'Review deploy', prompt: 'Use this api_key abc123' });
+    expect(result.ok).toBe(false);
+    expect(result.outputVerification).toBe('blocked_before_call');
+    expect(result.prepared.blockedReasons).toContain('secret');
+  });
+
+  it('redacts provider credentials from returned execution metadata', async () => {
+    process.env.OPENAI_API_KEY = 'openai-secret';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '{"id":"resp"}' });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const result = await executeDsgAiGatewayRequest({ provider: 'openai', goal: 'Summarize', prompt: 'Summarize this safely' });
+    expect(result.ok).toBe(true);
+    expect(result.prepared.headers.authorization).toBe('REDACTED');
+    expect(fetchMock.mock.calls[0][1]?.headers.authorization).toBe('Bearer openai-secret');
+    expect(result.responseBody).toEqual({ id: 'resp' });
+    expect(result.outputVerification).toBe('unverified_external_output');
+  });
+
+  it('redacts helpers consistently', () => {
+    expect(redactHeaders({ authorization: 'Bearer token', 'x-api-key': 'token', 'content-type': 'application/json' })).toEqual({
+      authorization: 'REDACTED',
+      'x-api-key': 'REDACTED',
+      'content-type': 'application/json',
+    });
+    expect(redactUrl('https://x.test/path?key=abc&other=1')).toBe('https://x.test/path?key=REDACTED&other=1');
+  });
+});

--- a/tests/dsg/openapi-functions.test.ts
+++ b/tests/dsg/openapi-functions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { openApiToGovernedFunctionDefinitions } from '../../lib/dsg/connectors/openapi';
+
+describe('OpenAPI governed function definitions', () => {
+  it('converts operations into gated function definitions without runtime claims', () => {
+    const functions = openApiToGovernedFunctionDefinitions({
+      openapi: '3.0.0',
+      paths: {
+        '/events': {
+          get: { operationId: 'listEvents', summary: 'List events' },
+          post: {
+            operationId: 'createEvent',
+            summary: 'Create event',
+            requestBody: { required: true, content: { 'application/json': { schema: { type: 'object' } } } },
+          },
+        },
+        '/events/{id}': {
+          delete: {
+            operationId: 'deleteEvent',
+            summary: 'Delete event',
+            parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          },
+        },
+      },
+    });
+
+    expect(functions.map((fn) => fn.function.name)).toEqual(['listEvents', 'createEvent', 'deleteEvent']);
+    expect(functions[0].dsg.requiresApproval).toBe(false);
+    expect(functions[1].dsg.requiresApproval).toBe(true);
+    expect(functions[2].dsg.riskLevel).toBe('CRITICAL');
+    expect(functions[2].function.parameters.required).toEqual(['id']);
+    expect(functions.every((fn) => fn.dsg.truthBoundary === 'function_definition_only_not_runtime_evidence')).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a server-side, fail-closed AI gateway so DSG can prepare/execute OpenAI/Gemini/Anthropic calls under the Awakening Decision Frame with deterministic evidence and refuse execution when secrets or unsafe claims are missing. 
- Expose a governed API surface for preparing or executing provider requests while ensuring credentials are redacted and external outputs remain explicitly unverified. 
- Surface OpenAPI operations as governed function definitions (tool-contract friendly) and fix a generated-app effect pattern to satisfy lint rules.

### Description

- Add a new AI gateway implementation at `lib/dsg/connectors/ai-gateway.ts` that provides `prepareDsgAiGatewayRequest` and `executeDsgAiGatewayRequest`, applies `verify`/`samadhi`/`kilesa`/`parami` decision-frame checks, computes a deterministic `requestHash`, redacts credentials from returned metadata, and fails-closed when required secrets or unsafe inputs are detected. 
- Add server API route `app/api/dsg/ai-gateway/route.ts` that returns a prepared request or performs an execution only after provider validation. 
- Extend the OpenAPI connector in `lib/dsg/connectors/openapi.ts` with `openApiToGovernedFunctionDefinitions` to produce function-style definitions including parameter schemas, risk/approval metadata, `schemaHash`, and an explicit truth boundary that function definitions are not runtime evidence. 
- Update `.env.example` with server-only AI provider environment variables (`OPENAI_API_KEY`, `OPENAI_API_BASE`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`), add tests under `tests/dsg/` for the gateway and OpenAPI function conversion, and adjust one generated app page to avoid synchronous `setState` in an effect so lint passes.

### Testing

- Ran `npm run dsg:verify` which includes claim-gate, deterministic runtime check, typecheck, and lint, and it succeeded after the change. 
- Built the app with `npm run build` and the production build completed successfully (no fatal errors). 
- Executed unit tests with `npx vitest run tests/dsg/ai-gateway.test.ts tests/dsg/openapi-functions.test.ts` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33df5fcc83289b42f8df0691fb79)