### PR TITLE
Upgrade DSG AI Gateway for multimodal governance and add governed tooling layer

### DIFF
--- a/app/api/dsg/ai-gateway/route.ts
+++ b/app/api/dsg/ai-gateway/route.ts
@@ -10,6 +10,20 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
 }
 
+function parseMedia(value: unknown): DsgAiGatewayRequest['media'] {
+  const normalize = (item: unknown) => {
+    const record = asRecord(item);
+    return {
+      url: typeof record.url === 'string' ? record.url.trim() : undefined,
+      base64: typeof record.base64 === 'string' ? record.base64.trim() : undefined,
+      mimeType: typeof record.mimeType === 'string' ? record.mimeType.trim() : undefined,
+    };
+  };
+  if (Array.isArray(value)) return value.map(normalize);
+  if (value && typeof value === 'object') return normalize(value);
+  return undefined;
+}
+
 function parseRequest(body: Record<string, unknown>): DsgAiGatewayRequest {
   return {
     provider: String(body.provider || '').trim() as DsgAiGatewayRequest['provider'],
@@ -19,6 +33,9 @@ function parseRequest(body: Record<string, unknown>): DsgAiGatewayRequest {
     mode: typeof body.mode === 'string' ? body.mode.trim() as DsgAiGatewayRequest['mode'] : undefined,
     history: stringArray(body.history),
     evidence: stringArray(body.evidence),
+    media: parseMedia(body.media),
+    image: asRecord(body.image),
+    audio: asRecord(body.audio),
     maxOutputTokens: typeof body.maxOutputTokens === 'number' ? body.maxOutputTokens : undefined,
     temperature: typeof body.temperature === 'number' ? body.temperature : undefined,
   };

--- a/app/api/dsg/tools/route.ts
+++ b/app/api/dsg/tools/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { executeGovernedToolRequest, prepareGovernedToolRequest, type DsgGovernedToolRequest } from '@/lib/dsg/tools/governed-tools';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
+}
+
+export async function POST(req: Request) {
+  const body = asRecord(await req.json().catch(() => null));
+  const input: DsgGovernedToolRequest = {
+    tool: String(body.tool || '').trim() as DsgGovernedToolRequest['tool'],
+    action: String(body.action || '').trim() as DsgGovernedToolRequest['action'],
+    goal: String(body.goal || '').trim(),
+    args: asRecord(body.args),
+    evidence: stringArray(body.evidence),
+    history: stringArray(body.history),
+    sandboxRoot: typeof body.sandboxRoot === 'string' ? body.sandboxRoot : undefined,
+  };
+
+  if (!['shell', 'file', 'browser', 'search', 'schedule', 'plan', 'workflow', 'api', 'google_workspace', 'persistent_compute'].includes(input.tool)) {
+    return NextResponse.json({ ok: false, error: { code: 'DSG_TOOL_UNSUPPORTED', message: 'tool is not supported by the governed DSG tooling layer' } }, { status: 400 });
+  }
+
+  const result = body.execute === true ? await executeGovernedToolRequest(input) : prepareGovernedToolRequest(input);
+  return NextResponse.json(result, { status: result.ok ? 200 : 400 });
+}

--- a/docs/DSG_AWAKENING_AGENT_PRODUCTION_UPGRADE.md
+++ b/docs/DSG_AWAKENING_AGENT_PRODUCTION_UPGRADE.md
@@ -1,0 +1,49 @@
+# DSG Awakening Agent Production Upgrade
+
+This document records the implemented, evidence-backed subset of the Manus-style production upgrade. It does **not** claim that every external provider action is production-ready; actions without configured credentials, persistence, or explicit confirmation fail closed.
+
+## AI Gateway multimodal modes
+
+`lib/dsg/connectors/ai-gateway.ts` now prepares and executes governed requests for these modes:
+
+- `text` and `json` through the existing provider endpoints.
+- `image_analysis` with required media evidence (`https://` URL or Base64 plus MIME type).
+- `image_generation` through mode-specific image generation endpoints/models where supported.
+- `video_analysis` through Gemini multimodal content parts with required video media evidence.
+- `speech` through OpenAI text-to-speech request shaping.
+- `audio_transcription` through multimodal audio request shaping for providers that support it in this gateway.
+
+Every request keeps the Awakening Decision Frame contract:
+
+- `verify`: hashes goal, prompt, and media references/data before any network call.
+- `samadhi`: locks the request to the declared user goal.
+- `kilesa`: blocks secret-like prompts, unsafe media prompts, unsupported modes, and missing evidence.
+- `parami`: records provider/mode history only from caller-supplied history.
+- `truthBoundary`: returns review-only or blocked status until external output is independently verified.
+
+## Governed tooling layer
+
+`lib/dsg/tools/governed-tools.ts` implements a fail-closed tooling layer and `app/api/dsg/tools/route.ts` exposes it as a server endpoint.
+
+Implemented execution today:
+
+- `shell.exec`: allowlisted local commands only (`pwd`, `node`, `npm`, `npx`, `rg`, `cat`, `sed`, `git`) with denied destructive/network/system-control patterns.
+- `file.read`, `file.write`, `file.append`, `file.edit`: sandbox-confined paths with sensitive path blocking and runtime evidence hashes.
+
+Prepared/review-only governance today:
+
+- `browser`, `search`, `schedule`, `plan`, `workflow`, `api`, `google_workspace`, and `persistent_compute` requests receive deterministic audit hashes, truth labels, and blocked/review reasons. External or persistent actions remain blocked unless a real adapter, confirmation flow, and persistence backend are added.
+
+## Output contract
+
+Responses include:
+
+1. Target/goal lock.
+2. Data status (`ready`, `review`, or `blocked`).
+3. Prepared body or runtime output.
+4. Limitations and unverified boundaries through `blockedReasons`, `audit.truth`, and `outputVerification`.
+
+## Verification commands
+
+- `npx vitest run tests/dsg/ai-gateway.test.ts tests/dsg/governed-tools.test.ts`
+- `npm run dsg:typecheck`

--- a/lib/dsg/connectors/ai-gateway.ts
+++ b/lib/dsg/connectors/ai-gateway.ts
@@ -2,7 +2,7 @@ import { kilesa, parami, samadhi, truthBoundary, userBenefitGate, verify } from 
 import { sha256Json } from '../runtime/hash';
 
 export type DsgAiProvider = 'openai' | 'gemini' | 'anthropic';
-export type DsgAiMode = 'text' | 'json' | 'image_analysis' | 'video_analysis' | 'speech' | 'audio_transcription';
+export type DsgAiMode = 'text' | 'json' | 'image_analysis' | 'image_generation' | 'video_analysis' | 'speech' | 'audio_transcription';
 export type DsgAiPreparedStatus = 'ready' | 'blocked' | 'review';
 
 export type DsgAiGatewayRequest = {
@@ -13,8 +13,17 @@ export type DsgAiGatewayRequest = {
   mode?: DsgAiMode;
   history?: string[];
   evidence?: string[];
+  media?: DsgAiMediaInput | DsgAiMediaInput[];
+  image?: { size?: '1024x1024' | '1024x1536' | '1536x1024' | 'auto'; quality?: 'low' | 'medium' | 'high' | 'auto'; n?: number };
+  audio?: { voice?: string; format?: 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm' };
   maxOutputTokens?: number;
   temperature?: number;
+};
+
+export type DsgAiMediaInput = {
+  url?: string;
+  base64?: string;
+  mimeType?: string;
 };
 
 export type DsgAiGatewayPreparedRequest = {
@@ -47,9 +56,20 @@ const providerDefaults: Record<DsgAiProvider, { model: string; secretNames: stri
   anthropic: { model: 'claude-3-opus-20240229', secretNames: ['ANTHROPIC_API_KEY'] },
 };
 
+const modeDefaultModels: Partial<Record<DsgAiProvider, Partial<Record<DsgAiMode, string>>>> = {
+  openai: {
+    image_generation: 'gpt-image-1',
+    speech: 'gpt-4o-mini-tts',
+    audio_transcription: 'gpt-4o-mini-transcribe',
+  },
+  gemini: {
+    image_generation: 'gemini-2.5-flash-image-preview',
+  },
+};
+
 const modeSupport: Record<DsgAiProvider, DsgAiMode[]> = {
-  openai: ['text', 'json', 'image_analysis', 'speech', 'audio_transcription'],
-  gemini: ['text', 'json', 'image_analysis', 'video_analysis'],
+  openai: ['text', 'json', 'image_analysis', 'image_generation', 'speech', 'audio_transcription'],
+  gemini: ['text', 'json', 'image_analysis', 'image_generation', 'video_analysis', 'audio_transcription'],
   anthropic: ['text', 'json', 'image_analysis'],
 };
 
@@ -61,31 +81,118 @@ function getSecret(provider: DsgAiProvider): { name: string; value: string } | n
   return null;
 }
 
+function mediaInputsFor(input: DsgAiGatewayRequest): DsgAiMediaInput[] {
+  const media = input.media ? (Array.isArray(input.media) ? input.media : [input.media]) : [];
+  return media.map((item) => ({
+    url: item.url?.trim(),
+    base64: item.base64?.trim(),
+    mimeType: item.mimeType?.trim(),
+  }));
+}
+
+function mediaEvidenceFor(media: DsgAiMediaInput[]): string[] {
+  return media.flatMap((item, index) => {
+    const evidence: string[] = [];
+    if (item.url) evidence.push(`media_${index}_url_hash:${sha256Json({ url: item.url })}`);
+    if (item.base64) evidence.push(`media_${index}_base64_hash:${sha256Json({ base64: item.base64 })}`);
+    if (item.mimeType) evidence.push(`media_${index}_mime:${item.mimeType}`);
+    return evidence;
+  });
+}
+
+function mediaBlockedReasonsFor(input: DsgAiGatewayRequest): string[] {
+  const mode = input.mode ?? 'text';
+  if (!['image_analysis', 'video_analysis', 'audio_transcription'].includes(mode)) return [];
+  const media = mediaInputsFor(input);
+  const missing: string[] = [];
+  if (media.length === 0) missing.push('MEDIA_REQUIRED');
+  for (const [index, item] of media.entries()) {
+    if (!item.url && !item.base64) missing.push(`MEDIA_SOURCE_REQUIRED:${index}`);
+    if (item.base64 && !item.mimeType) missing.push(`MEDIA_MIME_REQUIRED:${index}`);
+    if (item.url && !/^https:\/\//i.test(item.url)) missing.push(`MEDIA_URL_HTTPS_REQUIRED:${index}`);
+    if (mode === 'image_analysis' && item.mimeType && !item.mimeType.startsWith('image/')) missing.push(`MEDIA_IMAGE_MIME_REQUIRED:${index}`);
+    if (mode === 'video_analysis' && item.mimeType && !item.mimeType.startsWith('video/')) missing.push(`MEDIA_VIDEO_MIME_REQUIRED:${index}`);
+    if (mode === 'audio_transcription' && item.mimeType && !item.mimeType.startsWith('audio/')) missing.push(`MEDIA_AUDIO_MIME_REQUIRED:${index}`);
+  }
+  return missing;
+}
+
 function riskFlagsFor(input: DsgAiGatewayRequest): string[] {
   const text = `${input.goal}\n${input.prompt}`;
   return [
     /(?:secret|token|service[_-]?role|api[_-]?key|private[_-]?key)/i.test(text) ? 'secret' : '',
     /(?:production verified|certified|guaranteed compliant|guaranteed)/i.test(text) ? 'production_claim' : '',
     /(?:copy .*(?:licensed|proprietary)|bypass license|remove copyright)/i.test(text) ? 'license_violation' : '',
+    /(?:deepfake|impersonate|face swap|non-consensual|explicit|nudity|sexual)/i.test(text) ? 'unsafe_media_request' : '',
   ].filter(Boolean);
+}
+
+function defaultModelFor(provider: DsgAiProvider, mode: DsgAiMode): string {
+  return modeDefaultModels[provider]?.[mode] || providerDefaults[provider].model;
+}
+
+function openAiMediaPart(item: DsgAiMediaInput, mode: DsgAiMode): Record<string, unknown> {
+  if (mode === 'audio_transcription') {
+    return {
+      type: 'input_audio',
+      input_audio: item.base64 ? { data: item.base64, format: (item.mimeType || 'audio/wav').split('/')[1] || 'wav' } : { url: item.url },
+    };
+  }
+  const imageUrl = item.base64 ? `data:${item.mimeType};base64,${item.base64}` : item.url;
+  return { type: 'input_image', image_url: imageUrl };
+}
+
+function geminiMediaPart(item: DsgAiMediaInput): Record<string, unknown> {
+  if (item.base64) return { inlineData: { mimeType: item.mimeType, data: item.base64 } };
+  return { fileData: { mimeType: item.mimeType || 'application/octet-stream', fileUri: item.url } };
+}
+
+function anthropicMediaBlock(item: DsgAiMediaInput): Record<string, unknown> {
+  if (item.base64) return { type: 'image', source: { type: 'base64', media_type: item.mimeType || 'image/png', data: item.base64 } };
+  return { type: 'image', source: { type: 'url', url: item.url } };
 }
 
 function buildBody(input: DsgAiGatewayRequest, model: string): Record<string, unknown> {
   const mode = input.mode ?? 'text';
   const maxOutputTokens = input.maxOutputTokens ?? 1024;
+  const media = mediaInputsFor(input);
+
   if (input.provider === 'openai') {
+    if (mode === 'image_generation') {
+      return {
+        model,
+        prompt: input.prompt,
+        n: input.image?.n ?? 1,
+        size: input.image?.size ?? '1024x1024',
+        quality: input.image?.quality ?? 'auto',
+        metadata: { dsgGoalHash: sha256Json({ goal: input.goal }) },
+      };
+    }
+    if (mode === 'speech') {
+      return {
+        model,
+        input: input.prompt,
+        voice: input.audio?.voice ?? 'alloy',
+        response_format: input.audio?.format ?? 'mp3',
+      };
+    }
+    const content = ['image_analysis', 'audio_transcription'].includes(mode)
+      ? [{ type: 'input_text', text: input.prompt }, ...media.map((item) => openAiMediaPart(item, mode))]
+      : input.prompt;
     return {
       model,
-      input: input.prompt,
+      input: Array.isArray(content) ? [{ role: 'user', content }] : content,
       text: mode === 'json' ? { format: { type: 'json_object' } } : undefined,
       max_output_tokens: maxOutputTokens,
       temperature: input.temperature,
       metadata: { dsgGoalHash: sha256Json({ goal: input.goal }) },
     };
   }
+
   if (input.provider === 'gemini') {
+    const parts = [{ text: input.prompt }, ...media.map(geminiMediaPart)];
     return {
-      contents: [{ role: 'user', parts: [{ text: input.prompt }] }],
+      contents: [{ role: 'user', parts }],
       generationConfig: {
         responseMimeType: mode === 'json' ? 'application/json' : 'text/plain',
         maxOutputTokens,
@@ -94,17 +201,24 @@ function buildBody(input: DsgAiGatewayRequest, model: string): Record<string, un
       systemInstruction: { parts: [{ text: `DSG target: ${input.goal}` }] },
     };
   }
+
+  const content = mode === 'image_analysis' ? [...media.map(anthropicMediaBlock), { type: 'text', text: input.prompt }] : input.prompt;
   return {
     model,
     max_tokens: maxOutputTokens,
     temperature: input.temperature,
     system: `DSG target: ${input.goal}`,
-    messages: [{ role: 'user', content: input.prompt }],
+    messages: [{ role: 'user', content }],
   };
 }
 
-function buildEndpoint(provider: DsgAiProvider, model: string, secretValue: string): string {
-  if (provider === 'openai') return `${process.env.OPENAI_API_BASE || 'https://api.openai.com'}/v1/responses`;
+function buildEndpoint(provider: DsgAiProvider, model: string, secretValue: string, mode: DsgAiMode): string {
+  if (provider === 'openai') {
+    const base = process.env.OPENAI_API_BASE || 'https://api.openai.com';
+    if (mode === 'image_generation') return `${base}/v1/images/generations`;
+    if (mode === 'speech') return `${base}/v1/audio/speech`;
+    return `${base}/v1/responses`;
+  }
   if (provider === 'gemini') return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(secretValue)}`;
   return 'https://api.anthropic.com/v1/messages';
 }
@@ -121,23 +235,25 @@ export function prepareDsgAiGatewayRequest(input: DsgAiGatewayRequest): DsgAiGat
 
   const goal = input.goal.trim();
   const prompt = input.prompt.trim();
-  const model = (input.model || providerConfig.model).trim();
   const mode = input.mode ?? 'text';
+  const model = (input.model || defaultModelFor(input.provider, mode)).trim();
   const target = samadhi('dsg-ai-gateway', goal || 'missing-goal');
   const evidence = [...(input.evidence ?? [])];
   if (goal) evidence.push(`goal_hash:${sha256Json({ goal })}`);
   if (prompt) evidence.push(`prompt_hash:${sha256Json({ prompt })}`);
+  evidence.push(...mediaEvidenceFor(mediaInputsFor({ ...input, goal, prompt, model, mode })));
   const normalizedInput = { ...input, goal, prompt, model, mode };
   const verifiedInput = verify(normalizedInput, evidence);
   const flags = riskFlagsFor(normalizedInput);
   const modeBlocked = !modeSupport[input.provider].includes(mode);
   const secret = getSecret(input.provider);
-  const missing: string[] = [];
+  const missing: string[] = [...mediaBlockedReasonsFor(normalizedInput)];
   if (!goal) missing.push('GOAL_REQUIRED');
   if (!prompt) missing.push('PROMPT_REQUIRED');
   if (!model) missing.push('MODEL_REQUIRED');
   if (modeBlocked) missing.push(`MODE_UNSUPPORTED:${input.provider}:${mode}`);
   if (!secret) missing.push(`SECRET_REQUIRED:${providerConfig.secretNames.join('|')}`);
+  if (flags.includes('unsafe_media_request')) missing.push('UNSAFE_MEDIA_REVIEW_REQUIRED');
 
   const risk = kilesa(`${input.provider}:${mode}:${goal || 'missing-goal'}`, verifiedInput.verified && missing.length === 0, flags);
   const stats = parami([...(input.history ?? []), input.provider, mode]);
@@ -156,7 +272,7 @@ export function prepareDsgAiGatewayRequest(input: DsgAiGatewayRequest): DsgAiGat
   const blockedReasons = [...missing, ...risk.reasons.filter((reason) => reason !== 'VERIFIED'), ...boundary.blockedReasons];
   const status: DsgAiPreparedStatus = blockedReasons.length ? 'blocked' : mode !== 'text' && mode !== 'json' ? 'review' : 'ready';
   const secretValue = secret?.value ?? 'MISSING_SECRET_FAIL_CLOSED';
-  const endpoint = buildEndpoint(input.provider, model || providerConfig.model, secretValue);
+  const endpoint = buildEndpoint(input.provider, model || defaultModelFor(input.provider, mode), secretValue, mode);
   const body = buildBody(normalizedInput, model || providerConfig.model);
   const headers = buildHeaders(input.provider, secretValue);
   const requestHash = sha256Json({ provider: input.provider, model, mode, endpoint: endpoint.replace(secretValue, 'REDACTED'), body });
@@ -191,7 +307,7 @@ export async function executeDsgAiGatewayRequest(input: DsgAiGatewayRequest): Pr
 
   const secret = getSecret(input.provider);
   if (!secret) return { ok: false, prepared, outputVerification: 'blocked_before_call' };
-  const endpoint = buildEndpoint(input.provider, prepared.model, secret.value);
+  const endpoint = buildEndpoint(input.provider, prepared.model, secret.value, prepared.mode);
   const headers = buildHeaders(input.provider, secret.value);
   const response = await fetch(endpoint, {
     method: prepared.method,

--- a/lib/dsg/tools/governed-tools.ts
+++ b/lib/dsg/tools/governed-tools.ts
@@ -1,0 +1,211 @@
+import { execFile } from 'node:child_process';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { kilesa, parami, samadhi, truthBoundary, userBenefitGate, verify } from '../app-builder/agent-runtime/decision-frame';
+import { sha256Json } from '../runtime/hash';
+
+const execFileAsync = promisify(execFile);
+
+export type DsgGovernedToolKind = 'shell' | 'file' | 'browser' | 'search' | 'schedule' | 'plan' | 'workflow' | 'api' | 'google_workspace' | 'persistent_compute';
+export type DsgGovernedToolAction = 'exec' | 'read' | 'write' | 'append' | 'edit' | 'navigate' | 'scrape' | 'query' | 'create' | 'update' | 'allocate' | 'dry_run';
+export type DsgGovernedToolStatus = 'ready' | 'blocked' | 'review';
+
+export type DsgGovernedToolRequest = {
+  tool: DsgGovernedToolKind;
+  action: DsgGovernedToolAction;
+  goal: string;
+  args?: Record<string, unknown>;
+  evidence?: string[];
+  history?: string[];
+  sandboxRoot?: string;
+};
+
+export type DsgGovernedToolPreparedRequest = {
+  ok: boolean;
+  status: DsgGovernedToolStatus;
+  tool: DsgGovernedToolKind;
+  action: DsgGovernedToolAction;
+  args: Record<string, unknown>;
+  audit: {
+    id: string;
+    truth: 'runtime_evidence' | 'external_data_pending_verification' | 'internal_state_pending_verification' | 'external_action_review';
+    requestHash: string;
+  };
+  decisionFrame: {
+    target: ReturnType<typeof samadhi>;
+    verifiedInput: ReturnType<typeof verify<DsgGovernedToolRequest>>;
+    risk: ReturnType<typeof kilesa>;
+    stats: ReturnType<typeof parami>;
+    benefit: ReturnType<typeof userBenefitGate>;
+    truthBoundary: ReturnType<typeof truthBoundary>;
+  };
+  blockedReasons: string[];
+  userOutcome: string;
+};
+
+export type DsgGovernedToolExecutionResult = {
+  ok: boolean;
+  prepared: DsgGovernedToolPreparedRequest;
+  output?: unknown;
+  outputVerification: 'runtime_evidence' | 'blocked_before_execution';
+};
+
+const supportedActions: Record<DsgGovernedToolKind, DsgGovernedToolAction[]> = {
+  shell: ['exec'],
+  file: ['read', 'write', 'append', 'edit'],
+  browser: ['navigate', 'scrape', 'dry_run'],
+  search: ['query', 'dry_run'],
+  schedule: ['create', 'dry_run'],
+  plan: ['create', 'update', 'dry_run'],
+  workflow: ['create', 'update', 'dry_run'],
+  api: ['dry_run'],
+  google_workspace: ['dry_run'],
+  persistent_compute: ['allocate', 'dry_run'],
+};
+
+const shellAllowlist = new Set(['pwd', 'node', 'npm', 'npx', 'rg', 'cat', 'sed', 'git']);
+const shellDenyPattern = /(?:^|\s)(?:rm|sudo|su|chmod|chown|curl|wget|ssh|scp|dd|mkfs|mount|umount|docker|kubectl|vercel|firebase|supabase)(?:\s|$)|[;&|`$<>]/i;
+const sensitivePathPattern = /(?:^|\/)(?:\.env|\.git|node_modules)(?:\/|$)|(?:id_rsa|private[_-]?key|service[_-]?role)/i;
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function splitCommand(command: string): { bin: string; args: string[] } {
+  const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => part.replace(/^['"]|['"]$/g, '')) ?? [];
+  return { bin: parts[0] || '', args: parts.slice(1) };
+}
+
+function pathInsideSandbox(sandboxRoot: string, targetPath: string): { ok: boolean; absolutePath: string; reason?: string } {
+  const root = path.resolve(sandboxRoot || process.cwd());
+  const absolutePath = path.resolve(root, targetPath);
+  if (!absolutePath.startsWith(root + path.sep) && absolutePath !== root) return { ok: false, absolutePath, reason: 'PATH_OUTSIDE_SANDBOX' };
+  if (sensitivePathPattern.test(path.relative(root, absolutePath))) return { ok: false, absolutePath, reason: 'SENSITIVE_PATH_BLOCKED' };
+  return { ok: true, absolutePath };
+}
+
+function blockedReasonsFor(input: DsgGovernedToolRequest): string[] {
+  const args = input.args ?? {};
+  const reasons: string[] = [];
+  if (!input.goal.trim()) reasons.push('GOAL_REQUIRED');
+  if (!supportedActions[input.tool]?.includes(input.action)) reasons.push(`ACTION_UNSUPPORTED:${input.tool}:${input.action}`);
+
+  if (input.tool === 'shell') {
+    const command = asString(args.command);
+    const { bin } = splitCommand(command);
+    if (!command) reasons.push('SHELL_COMMAND_REQUIRED');
+    if (command && (!shellAllowlist.has(bin) || shellDenyPattern.test(command))) reasons.push('SHELL_COMMAND_NOT_ALLOWLISTED');
+  }
+
+  if (input.tool === 'file') {
+    const filePath = asString(args.path);
+    if (!filePath) reasons.push('FILE_PATH_REQUIRED');
+    const checked = pathInsideSandbox(String(input.sandboxRoot || process.cwd()), filePath || '.');
+    if (!checked.ok && checked.reason) reasons.push(checked.reason);
+    if (['write', 'append', 'edit'].includes(input.action) && typeof args.content !== 'string') reasons.push('FILE_CONTENT_REQUIRED');
+  }
+
+  if (input.tool === 'browser') {
+    const url = asString(args.url);
+    if (!url) reasons.push('BROWSER_URL_REQUIRED');
+    if (url && !/^https:\/\//i.test(url)) reasons.push('BROWSER_HTTPS_REQUIRED');
+    if (input.action !== 'dry_run') reasons.push('BROWSER_CONFIRMATION_REQUIRED');
+  }
+
+  if (input.tool === 'search') {
+    if (!asString(args.query)) reasons.push('SEARCH_QUERY_REQUIRED');
+  }
+
+  if (input.tool === 'schedule') {
+    if (!asString(args.cron) && typeof args.intervalMs !== 'number') reasons.push('SCHEDULE_CRON_OR_INTERVAL_REQUIRED');
+    if (input.action !== 'dry_run') reasons.push('SCHEDULE_PERSISTENCE_BACKEND_REQUIRED');
+  }
+
+  if (['api', 'google_workspace', 'persistent_compute'].includes(input.tool) && input.action !== 'dry_run') {
+    reasons.push('EXTERNAL_ACTION_ADAPTER_NOT_CONFIGURED');
+  }
+
+  return reasons;
+}
+
+function truthFor(tool: DsgGovernedToolKind): DsgGovernedToolPreparedRequest['audit']['truth'] {
+  if (tool === 'shell' || tool === 'file') return 'runtime_evidence';
+  if (tool === 'plan' || tool === 'workflow') return 'internal_state_pending_verification';
+  if (tool === 'browser' || tool === 'search') return 'external_data_pending_verification';
+  return 'external_action_review';
+}
+
+export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGovernedToolPreparedRequest {
+  const normalized: DsgGovernedToolRequest = {
+    ...input,
+    goal: input.goal.trim(),
+    args: input.args ?? {},
+    evidence: input.evidence ?? [],
+    history: input.history ?? [],
+    sandboxRoot: input.sandboxRoot || process.cwd(),
+  };
+  const evidence = [
+    ...normalized.evidence!,
+    normalized.goal ? `goal_hash:${sha256Json({ goal: normalized.goal })}` : '',
+    `args_hash:${sha256Json(normalized.args ?? {})}`,
+  ].filter(Boolean);
+  const verifiedInput = verify(normalized, evidence);
+  const reasons = blockedReasonsFor(normalized);
+  const riskFlags = reasons.filter((reason) => /BLOCKED|NOT_ALLOWLISTED|OUTSIDE|SENSITIVE|CONFIRMATION|EXTERNAL_ACTION/.test(reason));
+  const risk = kilesa(`${normalized.tool}:${normalized.action}:${normalized.goal || 'missing-goal'}`, verifiedInput.verified && reasons.length === 0, riskFlags);
+  const boundary = truthBoundary({ verified: verifiedInput.verified && reasons.length === 0, containsSecret: false });
+  const blockedReasons = [...new Set([...reasons, ...risk.reasons.filter((reason) => reason !== 'VERIFIED'), ...boundary.blockedReasons])];
+  const reviewOnly = ['browser', 'search', 'schedule', 'plan', 'workflow', 'api', 'google_workspace', 'persistent_compute'].includes(normalized.tool);
+  const requestHash = sha256Json({ tool: normalized.tool, action: normalized.action, args: normalized.args, evidence });
+
+  return {
+    ok: blockedReasons.length === 0,
+    status: blockedReasons.length ? 'blocked' : reviewOnly ? 'review' : 'ready',
+    tool: normalized.tool,
+    action: normalized.action,
+    args: normalized.args ?? {},
+    audit: { id: `tool:${requestHash}`, truth: truthFor(normalized.tool), requestHash },
+    decisionFrame: {
+      target: samadhi(`dsg-tool:${normalized.tool}`, normalized.goal || 'missing-goal'),
+      verifiedInput,
+      risk,
+      stats: parami([...(normalized.history ?? []), normalized.tool, normalized.action]),
+      benefit: userBenefitGate({
+        userBenefit: 'User gets a governed tool request with fail-closed safety checks before runtime or external action.',
+        easier: true,
+        tangibleOutput: 'Deterministic audit hash, blocked reasons, and truth boundary for the requested tool action.',
+        nextAction: blockedReasons.length ? 'Resolve blocked reasons or request explicit external approval.' : 'Execute only ready shell/file actions or keep review-only actions as plans.',
+      }),
+      truthBoundary: boundary,
+    },
+    blockedReasons,
+    userOutcome: 'Tooling is governed by target lock, evidence hash, risk checks, and a truth label before execution.',
+  };
+}
+
+export async function executeGovernedToolRequest(input: DsgGovernedToolRequest): Promise<DsgGovernedToolExecutionResult> {
+  const prepared = prepareGovernedToolRequest(input);
+  if (!prepared.ok || prepared.status !== 'ready') return { ok: false, prepared, outputVerification: 'blocked_before_execution' };
+
+  if (prepared.tool === 'shell') {
+    const { bin, args } = splitCommand(asString(prepared.args.command));
+    const { stdout, stderr } = await execFileAsync(bin, args, { cwd: input.sandboxRoot || process.cwd(), timeout: Number(prepared.args.timeoutMs ?? 10_000), maxBuffer: 1024 * 1024 });
+    return { ok: true, prepared, output: { stdout, stderr }, outputVerification: 'runtime_evidence' };
+  }
+
+  if (prepared.tool === 'file') {
+    const checked = pathInsideSandbox(String(input.sandboxRoot || process.cwd()), asString(prepared.args.path));
+    if (!checked.ok) return { ok: false, prepared, outputVerification: 'blocked_before_execution' };
+    if (prepared.action === 'read') {
+      const content = await readFile(checked.absolutePath, 'utf8');
+      return { ok: true, prepared, output: { path: prepared.args.path, content, contentHash: sha256Json({ content }) }, outputVerification: 'runtime_evidence' };
+    }
+    await mkdir(path.dirname(checked.absolutePath), { recursive: true });
+    if (prepared.action === 'append') await appendFile(checked.absolutePath, String(prepared.args.content), 'utf8');
+    else await writeFile(checked.absolutePath, String(prepared.args.content), 'utf8');
+    return { ok: true, prepared, output: { path: prepared.args.path, contentHash: sha256Json({ content: prepared.args.content }) }, outputVerification: 'runtime_evidence' };
+  }
+
+  return { ok: false, prepared, outputVerification: 'blocked_before_execution' };
+}

--- a/tests/dsg/ai-gateway.test.ts
+++ b/tests/dsg/ai-gateway.test.ts
@@ -53,6 +53,39 @@ describe('DSG AI gateway', () => {
     expect(result.outputVerification).toBe('unverified_external_output');
   });
 
+
+
+  it('prepares OpenAI image generation with a mode-specific endpoint and review status', () => {
+    process.env.OPENAI_API_KEY = 'openai-secret';
+    const prepared = prepareDsgAiGatewayRequest({ provider: 'openai', goal: 'Create a safe product mockup', prompt: 'A neutral dashboard illustration', mode: 'image_generation' });
+    expect(prepared.ok).toBe(true);
+    expect(prepared.status).toBe('review');
+    expect(prepared.model).toBe('gpt-image-1');
+    expect(prepared.endpoint).toBe('https://api.openai.com/v1/images/generations');
+    expect(prepared.body).toMatchObject({ prompt: 'A neutral dashboard illustration', n: 1, size: '1024x1024' });
+  });
+
+  it('requires verified media evidence for image analysis', () => {
+    process.env.GEMINI_API_KEY = 'gemini-secret';
+    const missing = prepareDsgAiGatewayRequest({ provider: 'gemini', goal: 'Describe the image', prompt: 'What is shown?', mode: 'image_analysis' });
+    expect(missing.ok).toBe(false);
+    expect(missing.blockedReasons).toContain('MEDIA_REQUIRED');
+
+    const prepared = prepareDsgAiGatewayRequest({
+      provider: 'gemini',
+      goal: 'Describe the image',
+      prompt: 'What is shown?',
+      mode: 'image_analysis',
+      media: { url: 'https://example.com/image.png', mimeType: 'image/png' },
+    });
+    expect(prepared.ok).toBe(true);
+    expect(prepared.status).toBe('review');
+    expect(prepared.body.contents).toEqual([
+      { role: 'user', parts: [{ text: 'What is shown?' }, { fileData: { mimeType: 'image/png', fileUri: 'https://example.com/image.png' } }] },
+    ]);
+    expect(prepared.decisionFrame.verifiedInput.evidence.some((entry) => entry.startsWith('media_0_url_hash:sha256:'))).toBe(true);
+  });
+
   it('redacts helpers consistently', () => {
     expect(redactHeaders({ authorization: 'Bearer token', 'x-api-key': 'token', 'content-type': 'application/json' })).toEqual({
       authorization: 'REDACTED',

--- a/tests/dsg/governed-tools.test.ts
+++ b/tests/dsg/governed-tools.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeGovernedToolRequest, prepareGovernedToolRequest } from '../../lib/dsg/tools/governed-tools';
+
+describe('DSG governed tooling layer', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  });
+
+  it('fails closed for destructive shell commands before execution', () => {
+    const prepared = prepareGovernedToolRequest({ tool: 'shell', action: 'exec', goal: 'Inspect working directory', args: { command: 'rm -rf .' } });
+    expect(prepared.ok).toBe(false);
+    expect(prepared.status).toBe('blocked');
+    expect(prepared.blockedReasons).toContain('SHELL_COMMAND_NOT_ALLOWLISTED');
+    expect(prepared.audit.truth).toBe('runtime_evidence');
+  });
+
+  it('executes only allowlisted shell commands as runtime evidence', async () => {
+    const result = await executeGovernedToolRequest({ tool: 'shell', action: 'exec', goal: 'Show node version', args: { command: 'node --version' } });
+    expect(result.ok).toBe(true);
+    expect(result.outputVerification).toBe('runtime_evidence');
+    expect(String((result.output as { stdout: string }).stdout)).toMatch(/^v\d+/);
+  });
+
+  it('keeps file operations inside the sandbox and writes audit-hashed evidence', async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'dsg-tool-'));
+    const result = await executeGovernedToolRequest({
+      tool: 'file',
+      action: 'write',
+      goal: 'Create sandbox note',
+      sandboxRoot: tempRoot,
+      args: { path: 'notes/proof.txt', content: 'verified runtime note' },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.outputVerification).toBe('runtime_evidence');
+    await expect(readFile(path.join(tempRoot, 'notes/proof.txt'), 'utf8')).resolves.toBe('verified runtime note');
+  });
+
+  it('blocks file traversal outside the sandbox', () => {
+    const prepared = prepareGovernedToolRequest({ tool: 'file', action: 'read', goal: 'Read outside file', sandboxRoot: '/tmp/dsg', args: { path: '../secret.txt' } });
+    expect(prepared.ok).toBe(false);
+    expect(prepared.blockedReasons).toContain('PATH_OUTSIDE_SANDBOX');
+  });
+
+  it('marks browser operations as external data requiring confirmation', () => {
+    const prepared = prepareGovernedToolRequest({ tool: 'browser', action: 'navigate', goal: 'Read docs', args: { url: 'https://example.com' } });
+    expect(prepared.ok).toBe(false);
+    expect(prepared.audit.truth).toBe('external_data_pending_verification');
+    expect(prepared.blockedReasons).toContain('BROWSER_CONFIRMATION_REQUIRED');
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the DSG AI gateway multimodal and governed (images, video, audio, TTS, image-generation) while applying the Awakening Decision Frame (`verify`, `samadhi`, `kilesa`, `parami`, `truthBoundary`) to keep requests fail-closed and auditable.
- Provide a small, safe tooling layer so agents can produce verifiable runtime evidence (shell/file) and prepare review-only external actions (browser, search, schedule, persistent compute) under governance.

### Description
- Extended `lib/dsg/connectors/ai-gateway.ts` to add new `DsgAiMode` values (`image_generation`, `image_analysis`, `video_analysis`, `speech`, `audio_transcription`), media input types, mode-default models, provider-specific request shaping, and mode-specific endpoints for OpenAI/Gemini. The gateway now collects media evidence hashes and enforces media requirements for analysis modes.
- Implemented verification, risk checks, mode support validation, `truthBoundary` and deterministic `requestHash` generation in `prepareDsgAiGatewayRequest` and kept multimodal external outputs as review/unverified until independent verification.
- Added media parsing to the API route in `app/api/dsg/ai-gateway/route.ts` to accept `media`, `image`, and `audio` payloads before validation.
- Introduced a governed tooling layer at `lib/dsg/tools/governed-tools.ts` with `prepareGovernedToolRequest` and `executeGovernedToolRequest` implementing fail-closed checks, sandboxed file operations, an allowlisted shell executor, deterministic audit hashes and truth labels; exposed via `app/api/dsg/tools/route.ts`.
- Added tests and documentation: `tests/dsg/ai-gateway.test.ts` (updated) and new `tests/dsg/governed-tools.test.ts`, plus `docs/DSG_AWAKENING_AGENT_PRODUCTION_UPGRADE.md` describing implemented scope and limitations.

### Testing
- Ran unit tests with `npx vitest run tests/dsg/ai-gateway.test.ts tests/dsg/governed-tools.test.ts` and all tests passed (2 files, 12 tests: all ✓).
- Ran type checks with `npm run dsg:typecheck` (`tsc --noEmit`) which completed successfully.
- Ran linter with `npm run lint` (`eslint .`) which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3882f0cc8328bf14d484d9db75d7)