### PR TITLE
Implement governed tool adapters and persistence

### DIFF
--- a/lib/dsg/tools/governed-tools.ts
+++ b/lib/dsg/tools/governed-tools.ts
@@ -51,6 +51,19 @@ export type DsgGovernedToolExecutionResult = {
   outputVerification: 'runtime_evidence' | 'blocked_before_execution';
 };
 
+type StoredRecord = {
+  id: string;
+  tool: DsgGovernedToolKind;
+  action: DsgGovernedToolAction;
+  goal: string;
+  args: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  requestHash: string;
+  evidenceHash: string;
+  status: 'created' | 'updated' | 'allocated';
+};
+
 const supportedActions: Record<DsgGovernedToolKind, DsgGovernedToolAction[]> = {
   shell: ['exec'],
   file: ['read', 'write', 'append', 'edit'],
@@ -59,21 +72,28 @@ const supportedActions: Record<DsgGovernedToolKind, DsgGovernedToolAction[]> = {
   schedule: ['create', 'dry_run'],
   plan: ['create', 'update', 'dry_run'],
   workflow: ['create', 'update', 'dry_run'],
-  api: ['dry_run'],
-  google_workspace: ['dry_run'],
+  api: ['query', 'create', 'update', 'dry_run'],
+  google_workspace: ['query', 'create', 'update', 'dry_run'],
   persistent_compute: ['allocate', 'dry_run'],
 };
 
 const shellAllowlist = new Set(['pwd', 'node', 'npm', 'npx', 'rg', 'cat', 'sed', 'git']);
 const shellDenyPattern = /(?:^|\s)(?:rm|sudo|su|chmod|chown|curl|wget|ssh|scp|dd|mkfs|mount|umount|docker|kubectl|vercel|firebase|supabase)(?:\s|$)|[;&|`$<>]/i;
 const sensitivePathPattern = /(?:^|\/)(?:\.env|\.git|node_modules)(?:\/|$)|(?:id_rsa|private[_-]?key|service[_-]?role)/i;
+const privateHostnamePattern = /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|::1$|fc00:|fd00:)/i;
+const externalToolKinds = new Set<DsgGovernedToolKind>(['browser', 'search', 'api', 'google_workspace']);
+const persistedToolKinds = new Set<DsgGovernedToolKind>(['schedule', 'plan', 'workflow', 'persistent_compute']);
 
 function asString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function asBoolean(value: unknown): boolean {
+  return value === true || value === 'true';
+}
+
 function splitCommand(command: string): { bin: string; args: string[] } {
-  const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => part.replace(/^['"]|['"]$/g, '')) ?? [];
+  const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => part.replace(/^["']|["']$/g, '')) ?? [];
   return { bin: parts[0] || '', args: parts.slice(1) };
 }
 
@@ -83,6 +103,43 @@ function pathInsideSandbox(sandboxRoot: string, targetPath: string): { ok: boole
   if (!absolutePath.startsWith(root + path.sep) && absolutePath !== root) return { ok: false, absolutePath, reason: 'PATH_OUTSIDE_SANDBOX' };
   if (sensitivePathPattern.test(path.relative(root, absolutePath))) return { ok: false, absolutePath, reason: 'SENSITIVE_PATH_BLOCKED' };
   return { ok: true, absolutePath };
+}
+
+function parseHttpsUrl(value: unknown): { ok: boolean; url?: URL; reason?: string } {
+  const raw = asString(value);
+  if (!raw) return { ok: false, reason: 'URL_REQUIRED' };
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:') return { ok: false, reason: 'HTTPS_REQUIRED' };
+    if (privateHostnamePattern.test(url.hostname)) return { ok: false, reason: 'PRIVATE_HOST_BLOCKED' };
+    return { ok: true, url };
+  } catch {
+    return { ok: false, reason: 'URL_INVALID' };
+  }
+}
+
+function isAllowedHost(url: URL, allowedHosts: unknown): boolean {
+  if (!Array.isArray(allowedHosts) || allowedHosts.length === 0) return true;
+  return allowedHosts.map((host) => String(host).trim().toLowerCase()).filter(Boolean).includes(url.hostname.toLowerCase());
+}
+
+function persistenceRoot(sandboxRoot: string): string {
+  return path.join(path.resolve(sandboxRoot || process.cwd()), '.dsg-governed-tools');
+}
+
+function persistenceFile(sandboxRoot: string, tool: DsgGovernedToolKind): string {
+  return path.join(persistenceRoot(sandboxRoot), `${tool}.jsonl`);
+}
+
+function recordId(tool: DsgGovernedToolKind, action: DsgGovernedToolAction, args: Record<string, unknown>): string {
+  return `${tool}:${sha256Json({ action, args }).slice(0, 24)}`;
+}
+
+function textFromHtml(html: string): { title: string; text: string } {
+  const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? '';
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ');
+  const text = withoutScripts.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/\s+/g, ' ').trim();
+  return { title: title.replace(/\s+/g, ' ').trim(), text };
 }
 
 function blockedReasonsFor(input: DsgGovernedToolRequest): string[] {
@@ -107,23 +164,52 @@ function blockedReasonsFor(input: DsgGovernedToolRequest): string[] {
   }
 
   if (input.tool === 'browser') {
-    const url = asString(args.url);
-    if (!url) reasons.push('BROWSER_URL_REQUIRED');
-    if (url && !/^https:\/\//i.test(url)) reasons.push('BROWSER_HTTPS_REQUIRED');
-    if (input.action !== 'dry_run') reasons.push('BROWSER_CONFIRMATION_REQUIRED');
+    const parsed = parseHttpsUrl(args.url);
+    if (!parsed.ok) reasons.push(`BROWSER_${parsed.reason}`);
+    else if (!isAllowedHost(parsed.url!, args.allowedHosts)) reasons.push('BROWSER_HOST_NOT_ALLOWLISTED');
+    if (input.action !== 'dry_run' && !asBoolean(args.approved)) reasons.push('BROWSER_CONFIRMATION_REQUIRED');
   }
 
   if (input.tool === 'search') {
     if (!asString(args.query)) reasons.push('SEARCH_QUERY_REQUIRED');
+    const endpoint = parseHttpsUrl(args.endpoint ?? process.env.DSG_SEARCH_ENDPOINT);
+    if (input.action !== 'dry_run' && !endpoint.ok) reasons.push(`SEARCH_ENDPOINT_${endpoint.reason}`);
+    if (endpoint.ok && !isAllowedHost(endpoint.url!, args.allowedHosts)) reasons.push('SEARCH_ENDPOINT_HOST_NOT_ALLOWLISTED');
+    if (input.action !== 'dry_run' && !asBoolean(args.approved)) reasons.push('SEARCH_CONFIRMATION_REQUIRED');
   }
 
   if (input.tool === 'schedule') {
     if (!asString(args.cron) && typeof args.intervalMs !== 'number') reasons.push('SCHEDULE_CRON_OR_INTERVAL_REQUIRED');
-    if (input.action !== 'dry_run') reasons.push('SCHEDULE_PERSISTENCE_BACKEND_REQUIRED');
+    if (typeof args.intervalMs === 'number' && args.intervalMs < 60_000) reasons.push('SCHEDULE_INTERVAL_TOO_SHORT');
   }
 
-  if (['api', 'google_workspace', 'persistent_compute'].includes(input.tool) && input.action !== 'dry_run') {
-    reasons.push('EXTERNAL_ACTION_ADAPTER_NOT_CONFIGURED');
+  if (input.tool === 'plan' || input.tool === 'workflow') {
+    if (input.action === 'create' && !asString(args.title)) reasons.push(`${input.tool.toUpperCase()}_TITLE_REQUIRED`);
+    if (input.action === 'update' && !asString(args.id)) reasons.push(`${input.tool.toUpperCase()}_ID_REQUIRED`);
+  }
+
+  if (input.tool === 'persistent_compute') {
+    if (!asString(args.name)) reasons.push('PERSISTENT_COMPUTE_NAME_REQUIRED');
+    if (typeof args.ttlMs === 'number' && (args.ttlMs < 60_000 || args.ttlMs > 86_400_000)) reasons.push('PERSISTENT_COMPUTE_TTL_OUT_OF_RANGE');
+  }
+
+  if (input.tool === 'api') {
+    const parsed = parseHttpsUrl(args.url);
+    if (input.action !== 'dry_run' && !parsed.ok) reasons.push(`API_${parsed.reason}`);
+    if (parsed.ok && !isAllowedHost(parsed.url!, args.allowedHosts)) reasons.push('API_HOST_NOT_ALLOWLISTED');
+    const method = asString(args.method || (input.action === 'query' ? 'GET' : 'POST')).toUpperCase();
+    if (!['GET', 'POST', 'PUT', 'PATCH'].includes(method)) reasons.push('API_METHOD_NOT_ALLOWLISTED');
+    if (input.action !== 'dry_run' && !asBoolean(args.approved)) reasons.push('API_CONFIRMATION_REQUIRED');
+  }
+
+  if (input.tool === 'google_workspace') {
+    const operation = asString(args.operation);
+    if (!operation) reasons.push('GOOGLE_WORKSPACE_OPERATION_REQUIRED');
+    if (input.action !== 'dry_run' && !['drive.search', 'docs.create', 'sheets.append'].includes(operation)) reasons.push('GOOGLE_WORKSPACE_OPERATION_NOT_ALLOWLISTED');
+    const endpoint = parseHttpsUrl(args.endpoint ?? process.env.DSG_GOOGLE_WORKSPACE_ENDPOINT);
+    if (input.action !== 'dry_run' && !endpoint.ok) reasons.push(`GOOGLE_WORKSPACE_ENDPOINT_${endpoint.reason}`);
+    if (endpoint.ok && !isAllowedHost(endpoint.url!, args.allowedHosts)) reasons.push('GOOGLE_WORKSPACE_ENDPOINT_HOST_NOT_ALLOWLISTED');
+    if (input.action !== 'dry_run' && !asBoolean(args.approved)) reasons.push('GOOGLE_WORKSPACE_CONFIRMATION_REQUIRED');
   }
 
   return reasons;
@@ -131,9 +217,15 @@ function blockedReasonsFor(input: DsgGovernedToolRequest): string[] {
 
 function truthFor(tool: DsgGovernedToolKind): DsgGovernedToolPreparedRequest['audit']['truth'] {
   if (tool === 'shell' || tool === 'file') return 'runtime_evidence';
-  if (tool === 'plan' || tool === 'workflow') return 'internal_state_pending_verification';
+  if (tool === 'plan' || tool === 'workflow' || tool === 'schedule' || tool === 'persistent_compute') return 'internal_state_pending_verification';
   if (tool === 'browser' || tool === 'search') return 'external_data_pending_verification';
   return 'external_action_review';
+}
+
+function readyStatus(tool: DsgGovernedToolKind, action: DsgGovernedToolAction): DsgGovernedToolStatus {
+  if (action === 'dry_run') return 'review';
+  if (tool === 'shell' || tool === 'file' || persistedToolKinds.has(tool) || externalToolKinds.has(tool)) return 'ready';
+  return 'review';
 }
 
 export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGovernedToolPreparedRequest {
@@ -152,16 +244,15 @@ export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGo
   ].filter(Boolean);
   const verifiedInput = verify(normalized, evidence);
   const reasons = blockedReasonsFor(normalized);
-  const riskFlags = reasons.filter((reason) => /BLOCKED|NOT_ALLOWLISTED|OUTSIDE|SENSITIVE|CONFIRMATION|EXTERNAL_ACTION/.test(reason));
+  const riskFlags = reasons.filter((reason) => /BLOCKED|NOT_ALLOWLISTED|OUTSIDE|SENSITIVE|CONFIRMATION|EXTERNAL_ACTION|ENDPOINT|PRIVATE|INVALID|TOO_SHORT|OUT_OF_RANGE/.test(reason));
   const risk = kilesa(`${normalized.tool}:${normalized.action}:${normalized.goal || 'missing-goal'}`, verifiedInput.verified && reasons.length === 0, riskFlags);
   const boundary = truthBoundary({ verified: verifiedInput.verified && reasons.length === 0, containsSecret: false });
   const blockedReasons = [...new Set([...reasons, ...risk.reasons.filter((reason) => reason !== 'VERIFIED'), ...boundary.blockedReasons])];
-  const reviewOnly = ['browser', 'search', 'schedule', 'plan', 'workflow', 'api', 'google_workspace', 'persistent_compute'].includes(normalized.tool);
   const requestHash = sha256Json({ tool: normalized.tool, action: normalized.action, args: normalized.args, evidence });
 
   return {
     ok: blockedReasons.length === 0,
-    status: blockedReasons.length ? 'blocked' : reviewOnly ? 'review' : 'ready',
+    status: blockedReasons.length ? 'blocked' : readyStatus(normalized.tool, normalized.action),
     tool: normalized.tool,
     action: normalized.action,
     args: normalized.args ?? {},
@@ -172,16 +263,93 @@ export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGo
       risk,
       stats: parami([...(normalized.history ?? []), normalized.tool, normalized.action]),
       benefit: userBenefitGate({
-        userBenefit: 'User gets a governed tool request with fail-closed safety checks before runtime or external action.',
+        userBenefit: 'User gets a governed tool request with fail-closed safety checks before runtime, persistence, or external action.',
         easier: true,
-        tangibleOutput: 'Deterministic audit hash, blocked reasons, and truth boundary for the requested tool action.',
-        nextAction: blockedReasons.length ? 'Resolve blocked reasons or request explicit external approval.' : 'Execute only ready shell/file actions or keep review-only actions as plans.',
+        tangibleOutput: 'Deterministic audit hash, blocked reasons, truth boundary, and adapter output for the requested tool action.',
+        nextAction: blockedReasons.length ? 'Resolve blocked reasons or provide explicit approval and allowlisted endpoints.' : 'Execute the ready adapter or inspect the dry-run review output.',
       }),
       truthBoundary: boundary,
     },
     blockedReasons,
     userOutcome: 'Tooling is governed by target lock, evidence hash, risk checks, and a truth label before execution.',
   };
+}
+
+async function executeBrowser(prepared: DsgGovernedToolPreparedRequest): Promise<unknown> {
+  const url = parseHttpsUrl(prepared.args.url).url!;
+  const response = await fetch(url, { headers: { accept: 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8', 'user-agent': 'DSG-ONE-Governed-Tools/1.0' } });
+  const contentType = response.headers.get('content-type') ?? '';
+  const body = (await response.text()).slice(0, Number(prepared.args.maxBytes ?? 250_000));
+  const extracted = contentType.includes('html') ? textFromHtml(body) : { title: '', text: body.replace(/\s+/g, ' ').trim() };
+  const textLimit = Number(prepared.args.textLimit ?? (prepared.action === 'scrape' ? 12_000 : 2_000));
+  return { url: url.toString(), status: response.status, ok: response.ok, contentType, title: extracted.title, text: extracted.text.slice(0, textLimit), contentHash: sha256Json({ body }) };
+}
+
+async function executeSearch(prepared: DsgGovernedToolPreparedRequest): Promise<unknown> {
+  const endpoint = parseHttpsUrl(prepared.args.endpoint ?? process.env.DSG_SEARCH_ENDPOINT).url!;
+  endpoint.searchParams.set('q', asString(prepared.args.query));
+  const response = await fetch(endpoint, { headers: { accept: 'application/json,text/plain;q=0.8', 'user-agent': 'DSG-ONE-Governed-Tools/1.0' } });
+  const raw = (await response.text()).slice(0, Number(prepared.args.maxBytes ?? 250_000));
+  let parsed: unknown = raw;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = { text: raw.slice(0, Number(prepared.args.textLimit ?? 4_000)) };
+  }
+  return { endpoint: endpoint.toString(), status: response.status, ok: response.ok, results: parsed, resultHash: sha256Json({ raw }) };
+}
+
+async function persistRecord(input: DsgGovernedToolRequest, prepared: DsgGovernedToolPreparedRequest): Promise<StoredRecord> {
+  const root = String(input.sandboxRoot || process.cwd());
+  const now = new Date().toISOString();
+  const status = prepared.tool === 'persistent_compute' ? 'allocated' : prepared.action === 'update' ? 'updated' : 'created';
+  const record: StoredRecord = {
+    id: asString(prepared.args.id) || recordId(prepared.tool, prepared.action, prepared.args),
+    tool: prepared.tool,
+    action: prepared.action,
+    goal: input.goal.trim(),
+    args: prepared.args,
+    createdAt: now,
+    updatedAt: now,
+    requestHash: prepared.audit.requestHash,
+    evidenceHash: sha256Json({ truth: prepared.audit.truth, args: prepared.args, goal: input.goal }),
+    status,
+  };
+  await mkdir(persistenceRoot(root), { recursive: true });
+  await appendFile(persistenceFile(root, prepared.tool), `${JSON.stringify(record)}\n`, 'utf8');
+  return record;
+}
+
+async function executeApi(prepared: DsgGovernedToolPreparedRequest): Promise<unknown> {
+  const url = parseHttpsUrl(prepared.args.url).url!;
+  const method = asString(prepared.args.method || (prepared.action === 'query' ? 'GET' : 'POST')).toUpperCase();
+  const body = method === 'GET' ? undefined : JSON.stringify(prepared.args.body ?? {});
+  const response = await fetch(url, { method, headers: { accept: 'application/json,text/plain;q=0.8', 'content-type': 'application/json' }, body });
+  const raw = (await response.text()).slice(0, Number(prepared.args.maxBytes ?? 250_000));
+  let parsed: unknown = raw;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = { text: raw.slice(0, Number(prepared.args.textLimit ?? 4_000)) };
+  }
+  return { url: url.toString(), method, status: response.status, ok: response.ok, body: parsed, bodyHash: sha256Json({ raw }) };
+}
+
+async function executeGoogleWorkspace(prepared: DsgGovernedToolPreparedRequest): Promise<unknown> {
+  const endpoint = parseHttpsUrl(prepared.args.endpoint ?? process.env.DSG_GOOGLE_WORKSPACE_ENDPOINT).url!;
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { accept: 'application/json,text/plain;q=0.8', 'content-type': 'application/json' },
+    body: JSON.stringify({ operation: prepared.args.operation, payload: prepared.args.payload ?? {} }),
+  });
+  const raw = (await response.text()).slice(0, Number(prepared.args.maxBytes ?? 250_000));
+  let parsed: unknown = raw;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = { text: raw.slice(0, Number(prepared.args.textLimit ?? 4_000)) };
+  }
+  return { operation: prepared.args.operation, status: response.status, ok: response.ok, body: parsed, bodyHash: sha256Json({ raw }) };
 }
 
 export async function executeGovernedToolRequest(input: DsgGovernedToolRequest): Promise<DsgGovernedToolExecutionResult> {
@@ -206,6 +374,12 @@ export async function executeGovernedToolRequest(input: DsgGovernedToolRequest):
     else await writeFile(checked.absolutePath, String(prepared.args.content), 'utf8');
     return { ok: true, prepared, output: { path: prepared.args.path, contentHash: sha256Json({ content: prepared.args.content }) }, outputVerification: 'runtime_evidence' };
   }
+
+  if (prepared.tool === 'browser') return { ok: true, prepared, output: await executeBrowser(prepared), outputVerification: 'runtime_evidence' };
+  if (prepared.tool === 'search') return { ok: true, prepared, output: await executeSearch(prepared), outputVerification: 'runtime_evidence' };
+  if (persistedToolKinds.has(prepared.tool)) return { ok: true, prepared, output: await persistRecord(input, prepared), outputVerification: 'runtime_evidence' };
+  if (prepared.tool === 'api') return { ok: true, prepared, output: await executeApi(prepared), outputVerification: 'runtime_evidence' };
+  if (prepared.tool === 'google_workspace') return { ok: true, prepared, output: await executeGoogleWorkspace(prepared), outputVerification: 'runtime_evidence' };
 
   return { ok: false, prepared, outputVerification: 'blocked_before_execution' };
 }

--- a/tests/dsg/governed-tools.test.ts
+++ b/tests/dsg/governed-tools.test.ts
@@ -1,13 +1,15 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { executeGovernedToolRequest, prepareGovernedToolRequest } from '../../lib/dsg/tools/governed-tools';
 
 describe('DSG governed tooling layer', () => {
   let tempRoot: string | undefined;
 
   afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
     tempRoot = undefined;
   });
@@ -47,10 +49,64 @@ describe('DSG governed tooling layer', () => {
     expect(prepared.blockedReasons).toContain('PATH_OUTSIDE_SANDBOX');
   });
 
-  it('marks browser operations as external data requiring confirmation', () => {
+  it('keeps browser operations blocked until explicit approval is supplied', () => {
     const prepared = prepareGovernedToolRequest({ tool: 'browser', action: 'navigate', goal: 'Read docs', args: { url: 'https://example.com' } });
     expect(prepared.ok).toBe(false);
     expect(prepared.audit.truth).toBe('external_data_pending_verification');
     expect(prepared.blockedReasons).toContain('BROWSER_CONFIRMATION_REQUIRED');
+  });
+
+  it('executes approved browser navigation and returns hashed runtime evidence', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('<html><head><title>Docs</title></head><body><main>Governed adapter evidence</main></body></html>', { status: 200, headers: { 'content-type': 'text/html' } })),
+    );
+
+    const result = await executeGovernedToolRequest({ tool: 'browser', action: 'navigate', goal: 'Read docs', args: { url: 'https://example.com/docs', approved: true } });
+
+    expect(result.ok).toBe(true);
+    expect(result.outputVerification).toBe('runtime_evidence');
+    expect(result.prepared.status).toBe('ready');
+    expect(result.output).toMatchObject({ status: 200, ok: true, title: 'Docs' });
+    expect((result.output as { text: string }).text).toContain('Governed adapter evidence');
+  });
+
+  it('persists governed plans as append-only evidence records inside the sandbox', async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'dsg-tool-'));
+    const result = await executeGovernedToolRequest({
+      tool: 'plan',
+      action: 'create',
+      goal: 'Create implementation plan',
+      sandboxRoot: tempRoot,
+      args: { title: 'Adapter rollout', steps: ['verify', 'execute', 'persist'] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.outputVerification).toBe('runtime_evidence');
+    expect(result.prepared.audit.truth).toBe('internal_state_pending_verification');
+    const persisted = await readFile(path.join(tempRoot, '.dsg-governed-tools', 'plan.jsonl'), 'utf8');
+    expect(persisted).toContain('Adapter rollout');
+    expect(persisted).toContain(result.prepared.audit.requestHash);
+  });
+
+  it('requires configured and approved endpoints for search execution', () => {
+    const prepared = prepareGovernedToolRequest({ tool: 'search', action: 'query', goal: 'Search docs', args: { query: 'governed tools' } });
+    expect(prepared.ok).toBe(false);
+    expect(prepared.blockedReasons).toContain('SEARCH_ENDPOINT_URL_REQUIRED');
+    expect(prepared.blockedReasons).toContain('SEARCH_CONFIRMATION_REQUIRED');
+  });
+
+  it('executes approved API requests only against HTTPS allowlisted hosts', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ saved: true }), { status: 201, headers: { 'content-type': 'application/json' } })));
+
+    const result = await executeGovernedToolRequest({
+      tool: 'api',
+      action: 'create',
+      goal: 'Create external ticket',
+      args: { url: 'https://api.example.com/tickets', method: 'POST', body: { title: 'Need proof' }, allowedHosts: ['api.example.com'], approved: true },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toMatchObject({ status: 201, ok: true, method: 'POST', body: { saved: true } });
   });
 });


### PR DESCRIPTION
### Motivation
- Finish the Governed Tooling execution layer so agents can perform approved external actions and persist internal plans while enforcing the Awakening Decision Frame safety gates.
- Provide deterministic, auditable runtime evidence for browser/search/API/Google Workspace calls and append-only persistence for plans, schedules, workflows, and persistent compute allocations.

### Description
- Added execution adapters for `browser`, `search`, `api`, and `google_workspace` that perform HTTPS-only requests, block private hosts, respect an `allowedHosts` allowlist, require explicit approval for external actions, and return bounded, hashed evidence payloads (`lib/dsg/tools/governed-tools.ts`).
- Added append-only JSONL persistence under a sandbox root for `schedule`, `plan`, `workflow`, and `persistent_compute` with deterministic `requestHash` and `evidenceHash` metadata (`.dsg-governed-tools/*.jsonl`).
- Expanded `supportedActions` for `api` and `google_workspace`, added `parseHttpsUrl`, `isAllowedHost`, `persistenceFile`/`persistenceRoot`, `persistRecord`, and helper adapters (`executeBrowser`, `executeSearch`, `executeApi`, `executeGoogleWorkspace`), and wired them into `executeGovernedToolRequest` so execution only runs when `prepareGovernedToolRequest` returns `ready`.
- Hardened the decision logic by extending truth/ready status handling and risk flags so dry-runs remain review-only while approved and validated requests run as runtime evidence.
- Extended tests to cover browser approval+execution, plan persistence, search endpoint gating, and API execution, and added test stubs for network fetch where needed (`tests/dsg/governed-tools.test.ts`).

### Testing
- Ran `npm run dsg:typecheck` and the TypeScript checks succeeded.
- Ran `npx vitest run tests/dsg/governed-tools.test.ts` and the governed-tools suite passed (9 tests passed).
- Ran `npm run lint` and linting completed without errors.
- Ran the full test run with `npx vitest run tests/dsg`, which showed the governed-tools tests passing but unrelated test suites failed due to unresolved `@/...` path aliases in other project tests (these failures are outside the scope of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3e443ca4832887e6030e292b0abb)