### PR TITLE
Add DSG Codex closure notes for instructions 6–8

### DIFF
--- a/docs/dsg-codex-closure/06-governance-approval-flow.md
+++ b/docs/dsg-codex-closure/06-governance-approval-flow.md
@@ -1,0 +1,22 @@
+# DSG Codex Closure 06: Governance, Approval Flow, Rollback
+
+Status: REVIEW
+Production claim: false
+
+## Scope
+Advanced governance, approval flow, and rollback.
+
+## Completed evidence
+- App Builder has goal lock, PRD/plan, gate, approval, and runtime handoff flow.
+- Governed tool records include eventHash, previousEventHash, revision, and materialized state.
+- Missing proof must stay missing in UI.
+- Fake governance numbers must not be shown.
+
+## Remaining work
+- ApprovalRequest persistence for paused high-risk operations.
+- User approve/deny API for governed tool execution.
+- RollbackEvent persistence.
+- Tests for file/API/persistence rollback.
+
+## Truth boundary
+This instruction is closed as REVIEW, not PASS.

--- a/docs/dsg-codex-closure/07-stability-error-recovery.md
+++ b/docs/dsg-codex-closure/07-stability-error-recovery.md
@@ -1,0 +1,24 @@
+# DSG Codex Closure 07: Stability, Error Handling, Recovery
+
+Status: PARTIAL PASS / REVIEW
+Production claim: false
+
+## Scope
+Comprehensive test coverage, adapter tracing, fail-closed behavior, and recovery readiness.
+
+## Completed evidence
+- Governed tool tests cover schedule CRUD lifecycle.
+- Governed tool tests cover persistent_compute allocate/read/deallocate lifecycle.
+- Search adapter fails closed on empty verified results.
+- API adapter records adapterDecisionTrace.
+- Google Workspace adapter fails closed on HTTP error.
+- Browser adapter fails closed on unverified HTTP response.
+- Build log analyzer classifies PASS / FAIL / REVIEW and extracts TypeScript file/line evidence.
+
+## Remaining work
+- Retry with exponential backoff for retryable external API operations.
+- Alerting channel for critical adapter/runtime failures.
+- Centralized persisted error ledger for executionDecisionFrame and adapterDecisionTrace.
+
+## Truth boundary
+Stability evidence exists, but production-ready recovery is not fully complete.

--- a/docs/dsg-codex-closure/08-feature-expansion-orchestration.md
+++ b/docs/dsg-codex-closure/08-feature-expansion-orchestration.md
@@ -1,0 +1,25 @@
+# DSG Codex Closure 08: Feature Expansion and Cross-Tool Orchestration
+
+Status: OPEN / REVIEW
+Production claim: false
+
+## Scope
+Advanced adapters, media tools, specialized generation tools, workflow orchestration, contextual state, and unified tracing.
+
+## Completed evidence
+- Governed tool layer has adapter step tracing.
+- Schedule and persistent_compute runtime manifests exist.
+- App Builder worker script can generate app/API/docs/migration proof.
+- CI worker runs runtime check, typecheck, product-ready gate, and build.
+- Build log analyzer can classify build logs.
+
+## Remaining work
+- Advanced media adapters: video analysis and audio processing.
+- Specialized adapters: image generation and presentation generation.
+- Workflow dynamic input/output mapping.
+- Workflow conditional execution.
+- Ephemeral and persistent contextual state management.
+- Unified workflow event logging across multiple tool calls.
+
+## Truth boundary
+Instruction 08 is not complete. It is documented as the next expansion layer.


### PR DESCRIPTION
### Motivation
- Capture the current closure status, evidence, and remaining work for governance/approval/rollback, stability/error-recovery, and feature-expansion/orchestration so the project record reflects current readiness levels. 
- Provide concise guidance on outstanding technical gaps for each instruction to drive follow-up tasks and testing.

### Description
- Add `docs/dsg-codex-closure/06-governance-approval-flow.md` documenting governance, approval flow, rollback scope with status `REVIEW` and a short list of remaining work. 
- Add `docs/dsg-codex-closure/07-stability-error-recovery.md` documenting stability and recovery evidence with status `PARTIAL PASS / REVIEW` and remaining reliability items. 
- Add `docs/dsg-codex-closure/08-feature-expansion-orchestration.md` documenting feature expansion scope with status `OPEN / REVIEW` and a prioritized list of expansion work.

### Testing
- Ran `ls -la docs/dsg-codex-closure` and `grep -R "Status:" docs/dsg-codex-closure` to validate the files were created and contain status lines, and both commands reported the new files and statuses. 
- Ran `npm run dsg:typecheck` which executes `tsc --noEmit` and completed without type errors. 
- Ran `npm run build:termux` which ran the Next.js production build and generated static pages successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7045f49c8328b0826a10890d1806)