### PR TITLE
Integrate governed tools UI panels

### DIFF
--- a/app/api/dsg/tools/route.ts
+++ b/app/api/dsg/tools/route.ts
@@ -16,7 +16,11 @@ export async function POST(req: Request) {
     tool: String(body.tool || '').trim() as DsgGovernedToolRequest['tool'],
     action: String(body.action || '').trim() as DsgGovernedToolRequest['action'],
     goal: String(body.goal || '').trim(),
-    args: asRecord(body.args),
+    args: {
+      ...asRecord(body.args),
+      ...(body.approved === true ? { approved: true } : {}),
+      ...(Array.isArray(body.allowedHosts) ? { allowedHosts: stringArray(body.allowedHosts) } : {}),
+    },
     evidence: stringArray(body.evidence),
     history: stringArray(body.history),
     sandboxRoot: typeof body.sandboxRoot === 'string' ? body.sandboxRoot : undefined,

--- a/components/app-builder-agent-runtime-view.tsx
+++ b/components/app-builder-agent-runtime-view.tsx
@@ -13,6 +13,8 @@ import {
   Wrench,
   XCircle,
 } from 'lucide-react';
+import { GovernedToolPanel } from '@/components/dsg/governed-tools/GovernedToolPanels';
+import type { DsgGovernedToolExecutionResult, DsgGovernedToolPreparedRequest, DsgGovernedToolRequest } from '@/lib/dsg/tools/governed-tools';
 import { cn } from '@/lib/utils';
 
 type ApiResult<T> = { ok: true; data: T } | { ok: false; error: { code?: string; message?: string } };
@@ -83,6 +85,8 @@ export function AppBuilderAgentRuntimeView() {
   const [job, setJob] = useState<BuilderJob | null>(null);
   const [handoff, setHandoff] = useState<Handoff | null>(null);
   const [toolCall, setToolCall] = useState<ToolCall | null>(null);
+  const [governedPrepared, setGovernedPrepared] = useState<DsgGovernedToolPreparedRequest | null>(null);
+  const [governedResult, setGovernedResult] = useState<DsgGovernedToolExecutionResult | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -101,6 +105,24 @@ export function AppBuilderAgentRuntimeView() {
     return readResult(json);
   }
 
+  async function governedTool(input: DsgGovernedToolRequest, execute = false) {
+    const response = await fetch('/api/dsg/tools', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...input, execute }),
+    });
+    const json = (await response.json().catch(() => ({ ok: false, error: { message: 'INVALID_GOVERNED_TOOL_JSON' } }))) as DsgGovernedToolPreparedRequest | DsgGovernedToolExecutionResult;
+    if (!response.ok && !('prepared' in json)) throw new Error('GOVERNED_TOOL_PREPARE_FAILED');
+    if ('prepared' in json) {
+      setGovernedResult(json);
+      setGovernedPrepared(json.prepared);
+    } else {
+      setGovernedResult(null);
+      setGovernedPrepared(json);
+    }
+    return json;
+  }
+
   async function runStep(name: string, fn: () => Promise<void>) {
     setBusy(name);
     setError(null);
@@ -116,6 +138,8 @@ export function AppBuilderAgentRuntimeView() {
   const createJob = () => runStep('goal', async () => {
     setHandoff(null);
     setToolCall(null);
+    setGovernedPrepared(null);
+    setGovernedResult(null);
     const data = await api<BuilderJob>('/api/dsg/app-builder/jobs', {
       method: 'POST',
       body: JSON.stringify({
@@ -132,7 +156,21 @@ export function AppBuilderAgentRuntimeView() {
     if (!job) throw new Error('APP_BUILDER_JOB_REQUIRED');
     setHandoff(null);
     setToolCall(null);
-    setJob(await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/plan`, { method: 'POST' }));
+    const plannedJob = await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/plan`, { method: 'POST' });
+    setJob(plannedJob);
+    await governedTool({
+      tool: 'plan',
+      action: 'dry_run',
+      goal: plannedJob.goal?.normalizedGoal || goal || 'Review App Builder plan before runtime handoff',
+      args: {
+        title: plannedJob.prd?.summary || 'App Builder governed plan',
+        jobId: plannedJob.id,
+        planHash: plannedJob.planHash,
+        steps: plannedJob.proposedPlan?.steps ?? [],
+      },
+      evidence: [plannedJob.planHash ? `plan_hash:${plannedJob.planHash}` : 'plan_hash:pending'],
+      history: ['ui:createPlan'],
+    });
   });
 
   const approvePlan = () => runStep('approval', async () => {
@@ -147,7 +185,22 @@ export function AppBuilderAgentRuntimeView() {
 
   const createHandoff = () => runStep('handoff', async () => {
     if (!job?.approvalHash) throw new Error('APP_BUILDER_APPROVAL_REQUIRED');
-    setHandoff(await api<Handoff>(`/api/dsg/app-builder/jobs/${job.id}/runtime-handoff`, { method: 'POST' }));
+    const handoffDraft = await api<Handoff>(`/api/dsg/app-builder/jobs/${job.id}/runtime-handoff`, { method: 'POST' });
+    setHandoff(handoffDraft);
+    await governedTool({
+      tool: 'workflow',
+      action: 'dry_run',
+      goal: job.goal?.normalizedGoal || goal || 'Review runtime handoff workflow before execution',
+      args: {
+        title: 'App Builder runtime handoff',
+        jobId: job.id,
+        planHash: handoffDraft.planHash,
+        approvalHash: handoffDraft.approvalHash,
+        runtimeStatus: handoffDraft.runtimeStatus,
+      },
+      evidence: [`plan_hash:${handoffDraft.planHash}`, `approval_hash:${handoffDraft.approvalHash}`],
+      history: ['ui:createHandoff'],
+    });
   });
 
   const launchRuntimeTool = () => runStep('tool-call', async () => {
@@ -249,6 +302,7 @@ export function AppBuilderAgentRuntimeView() {
         </section>
 
         <aside className="space-y-3 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+          <GovernedToolPanel prepared={governedPrepared} result={governedResult} busy={busy === 'governed-tool'} />
           <div className="flex items-start gap-2 rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3 text-xs leading-5 text-[#d9d9d9]">
             <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-[#d6a63a]" />
             <p>จอนี้ใช้ endpoint จริงของ repo เท่านั้น ไม่มี mock result และจะไม่เคลม production verified จนกว่าจะมี proof ครบ</p>

--- a/components/dsg/app-builder/AppBuilderConsoleClient.tsx
+++ b/components/dsg/app-builder/AppBuilderConsoleClient.tsx
@@ -5,11 +5,13 @@ import { PRDViewer } from './PRDViewer';
 import { PlanObserverPanel } from './PlanObserverPanel';
 import { HandoffPanel } from './HandoffPanel';
 import { RuntimeGatePanel } from './RuntimeGatePanel';
+import { GovernedToolPanel, collectPersistedRecords } from '@/components/dsg/governed-tools/GovernedToolPanels';
 import type { DsgAppBuilderPrd } from '@/lib/dsg/app-builder/types/prd';
 import type { DsgAppTemplate } from '@/lib/dsg/app-builder/templates/template-registry';
 import type { DsgPlanDraft, DsgPlanObserverResult } from '@/lib/dsg/app-builder/plan/types';
 import type { DsgAppBuilderApprovalGate, DsgRuntimeHandoffDraft } from '@/lib/dsg/app-builder/approval/types';
 import type { RuntimeExecutionGateResult } from '@/lib/dsg/app-builder/runtime/types';
+import type { DsgGovernedToolAction, DsgGovernedToolExecutionResult, DsgGovernedToolKind, DsgGovernedToolPreparedRequest } from '@/lib/dsg/tools/governed-tools';
 
 type PrdResponse = {
   ok: boolean;
@@ -58,7 +60,7 @@ type AgentLoopResponse = {
   productionReadyClaim?: false;
 };
 
-type PreviewMode = 'concept' | 'live' | 'monitor' | 'brain';
+type PreviewMode = 'concept' | 'live' | 'monitor' | 'brain' | 'tools';
 
 const liveGeneratedAppPath = '/generated-apps/2f3b20b0-824c-4d4a-ae6a-250bd18f3392';
 
@@ -100,8 +102,10 @@ function statusTone(status: string) {
 }
 
 function stateTone(state: string) {
-  if (state.includes('BLOCK') || state.includes('REQUIRED') || state.includes('NOT_CONFIGURED')) return 'border-rose-400/40 bg-rose-500/10 text-rose-100';
-  if (state.includes('ready') || state.includes('APPROVED') || state.includes('created') || state.includes('PASS')) return 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100';
+  const normalized = state.toLowerCase();
+  if (normalized.includes('block') || normalized.includes('required') || normalized.includes('not_configured')) return 'border-rose-400/40 bg-rose-500/10 text-rose-100';
+  if (normalized.includes('review')) return 'border-amber-400/40 bg-amber-500/10 text-amber-100';
+  if (normalized.includes('ready') || normalized.includes('approved') || normalized.includes('created') || normalized.includes('pass') || normalized.includes('runtime_evidence')) return 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100';
   return 'border-slate-700 bg-slate-950 text-slate-300';
 }
 
@@ -130,6 +134,13 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
   const [loadingPlan, setLoadingPlan] = useState(false);
   const [loadingHandoff, setLoadingHandoff] = useState(false);
   const [loadingRuntimeGate, setLoadingRuntimeGate] = useState(false);
+  const [toolKind, setToolKind] = useState<DsgGovernedToolKind>('plan');
+  const [toolAction, setToolAction] = useState<DsgGovernedToolAction>('dry_run');
+  const [toolArgsText, setToolArgsText] = useState('{\n  "title": "Console dry-run plan",\n  "payload": { "source": "app-builder-console" }\n}');
+  const [toolAllowedHosts, setToolAllowedHosts] = useState('');
+  const [governedPrepared, setGovernedPrepared] = useState<DsgGovernedToolPreparedRequest | null>(null);
+  const [governedResult, setGovernedResult] = useState<DsgGovernedToolExecutionResult | null>(null);
+  const [loadingGovernedTool, setLoadingGovernedTool] = useState(false);
 
   const criteriaList = useMemo(() => criteria.split('\n').map((line) => line.trim()).filter(Boolean), [criteria]);
   const timeline = useMemo(() => [
@@ -139,7 +150,8 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
     { label: 'Plan', state: plan ? 'ready' : 'waiting', detail: plan ? 'Plan observer available' : 'Run Plan + Observer' },
     { label: 'Handoff', state: handoff ? handoff.status : 'waiting', detail: handoff ? 'Approval handoff created' : 'Approval required' },
     { label: 'Runtime gate', state: runtimeGate ? runtimeGate.status : 'waiting', detail: runtimeGate ? runtimeGate.status : 'Not executed' },
-  ], [goal, prd, plan, handoff, runtimeGate, agentLoop]);
+    { label: 'Governed tool', state: governedResult?.outputVerification || governedPrepared?.status || 'waiting', detail: governedPrepared ? `${governedPrepared.tool}.${governedPrepared.action} · ${governedPrepared.audit.truth}` : 'Prepare or execute from Tools panel' },
+  ], [goal, prd, plan, handoff, runtimeGate, agentLoop, governedPrepared, governedResult]);
 
   function applyStarter(app: (typeof starterApps)[number]) {
     setGoal(app.goal);
@@ -281,6 +293,60 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
     }
   }
 
+
+  function parseToolArgs(approved = false) {
+    const parsed = JSON.parse(toolArgsText || '{}') as Record<string, unknown>;
+    const allowedHosts = toolAllowedHosts.split('\n').map((host) => host.trim()).filter(Boolean);
+    return {
+      ...parsed,
+      ...(allowedHosts.length ? { allowedHosts } : {}),
+      ...(approved ? { approved: true } : {}),
+    };
+  }
+
+  async function runGovernedTool(execute: boolean, approved = false) {
+    const trimmedGoal = goal.trim();
+    if (!trimmedGoal) {
+      setStatus('APP_BUILDER_GOAL_REQUIRED');
+      return;
+    }
+
+    setLoadingGovernedTool(true);
+    setStatus(`${execute ? 'Executing' : 'Preparing'} governed ${toolKind}.${toolAction}…`);
+    try {
+      const response = await fetch('/api/dsg/tools', {
+        method: 'POST',
+        headers: dsgHeaders,
+        body: JSON.stringify({
+          tool: toolKind,
+          action: toolAction,
+          goal: trimmedGoal,
+          args: parseToolArgs(approved),
+          evidence: ['ui:app-builder-console', plan?.jobId ? `plan:${plan.jobId}` : 'plan:not-generated'],
+          history: timeline.map((item) => `${item.label}:${item.state}`),
+          execute,
+        }),
+      });
+      const json = (await response.json()) as DsgGovernedToolPreparedRequest | DsgGovernedToolExecutionResult | { ok: false; error?: { message?: string; code?: string } };
+      if ('prepared' in json) {
+        setGovernedResult(json);
+        setGovernedPrepared(json.prepared);
+        setStatus(`${json.ok ? 'GOVERNED_TOOL_EXECUTED' : 'GOVERNED_TOOL_BLOCKED'} · ${json.outputVerification} · records=${collectPersistedRecords(json).length}`);
+      } else if ('tool' in json) {
+        setGovernedResult(null);
+        setGovernedPrepared(json);
+        setStatus(`${json.ok ? 'GOVERNED_TOOL_READY' : 'GOVERNED_TOOL_REVIEW_OR_BLOCKED'} · ${json.status} · reasons=${json.blockedReasons.length}`);
+      } else {
+        throw new Error(json.error?.message || json.error?.code || 'GOVERNED_TOOL_REQUEST_FAILED');
+      }
+      setPreviewMode('tools');
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'GOVERNED_TOOL_REQUEST_FAILED');
+    } finally {
+      setLoadingGovernedTool(false);
+    }
+  }
+
   async function startRuntimeGate() {
     if (!handoff || !plan) {
       setStatus('RUNTIME_HANDOFF_REQUIRED');
@@ -344,6 +410,7 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
             <button onClick={() => void generatePlan()} disabled={loadingPlan} className="rounded-2xl border border-violet-400/40 bg-violet-500/10 px-5 py-3 text-sm font-black text-violet-100 hover:bg-violet-500/20 disabled:cursor-not-allowed disabled:opacity-60">{loadingPlan ? 'Observing…' : 'Plan + Observer'}</button>
             <button onClick={() => void createHandoff()} disabled={loadingHandoff || !plan || !observer} className="rounded-2xl border border-cyan-400/40 bg-cyan-500/10 px-5 py-3 text-sm font-black text-cyan-100 hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-60">{loadingHandoff ? 'Hashing…' : 'Approval + Handoff'}</button>
             <button onClick={() => void startRuntimeGate()} disabled={loadingRuntimeGate || !handoff} className="rounded-2xl border border-rose-400/40 bg-rose-500/10 px-5 py-3 text-sm font-black text-rose-100 hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-60">{loadingRuntimeGate ? 'Checking…' : 'Start Runtime Gate'}</button>
+            <button onClick={() => setPreviewMode('tools')} className="rounded-2xl border border-amber-400/40 bg-amber-500/10 px-5 py-3 text-sm font-black text-amber-100 hover:bg-amber-500/20">Governed Tools</button>
           </div>
 
           <div className={`mt-4 rounded-2xl border p-3 text-xs font-mono ${statusTone(status)}`}>
@@ -366,7 +433,7 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
               <h2 className="mt-1 text-2xl font-black text-white">พรีวิวแอปข้างๆ</h2>
             </div>
             <div className="flex rounded-2xl border border-slate-800 bg-slate-950 p-1 text-xs font-bold">
-              {(['concept', 'live', 'monitor', 'brain'] as PreviewMode[]).map((mode) => (
+              {(['concept', 'live', 'monitor', 'brain', 'tools'] as PreviewMode[]).map((mode) => (
                 <button key={mode} onClick={() => setPreviewMode(mode)} className={`rounded-xl px-3 py-2 ${previewMode === mode ? 'bg-indigo-600 text-white' : 'text-slate-400 hover:text-white'}`}>{mode}</button>
               ))}
             </div>
@@ -403,6 +470,35 @@ export function AppBuilderConsoleClient({ initialPrd }: { initialPrd: DsgAppBuil
                   <p className="mt-2 text-xs leading-5 opacity-85">{item.detail}</p>
                 </div>
               ))}
+            </div>
+          ) : null}
+
+          {previewMode === 'tools' ? (
+            <div className="mt-5 space-y-4">
+              <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4">
+                <p className="text-xs font-bold uppercase tracking-[0.2em] text-amber-200">Governed tool workbench</p>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <label className="text-xs font-bold text-slate-300">Tool
+                    <select value={toolKind} onChange={(event) => setToolKind(event.target.value as DsgGovernedToolKind)} className="mt-1 w-full rounded-xl border border-slate-700 bg-slate-950 p-2 text-slate-100">
+                      {(['plan', 'workflow', 'schedule', 'persistent_compute', 'browser', 'search', 'api', 'google_workspace', 'file', 'shell'] as DsgGovernedToolKind[]).map((tool) => <option key={tool} value={tool}>{tool}</option>)}
+                    </select>
+                  </label>
+                  <label className="text-xs font-bold text-slate-300">Action
+                    <input value={toolAction} onChange={(event) => setToolAction(event.target.value as DsgGovernedToolAction)} className="mt-1 w-full rounded-xl border border-slate-700 bg-slate-950 p-2 text-slate-100" />
+                  </label>
+                </div>
+                <label className="mt-3 block text-xs font-bold text-slate-300">Args JSON
+                  <textarea value={toolArgsText} onChange={(event) => setToolArgsText(event.target.value)} rows={8} className="mt-1 w-full rounded-xl border border-slate-700 bg-slate-950 p-3 font-mono text-xs leading-5 text-slate-100" />
+                </label>
+                <label className="mt-3 block text-xs font-bold text-slate-300">Allowed hosts, one per line
+                  <textarea value={toolAllowedHosts} onChange={(event) => setToolAllowedHosts(event.target.value)} rows={3} className="mt-1 w-full rounded-xl border border-slate-700 bg-slate-950 p-3 font-mono text-xs leading-5 text-slate-100" placeholder="api.example.com" />
+                </label>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button onClick={() => void runGovernedTool(false)} disabled={loadingGovernedTool} className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-xs font-black text-amber-100 disabled:opacity-60">Prepare only</button>
+                  <button onClick={() => void runGovernedTool(true)} disabled={loadingGovernedTool} className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-xs font-black text-emerald-100 disabled:opacity-60">Execute governed</button>
+                </div>
+              </div>
+              <GovernedToolPanel prepared={governedPrepared} result={governedResult} busy={loadingGovernedTool} onApprove={() => void runGovernedTool(true, true)} />
             </div>
           ) : null}
 

--- a/components/dsg/governed-tools/GovernedToolPanels.tsx
+++ b/components/dsg/governed-tools/GovernedToolPanels.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { AlertTriangle, CheckCircle2, Database, ExternalLink, ShieldAlert, ShieldCheck, XCircle } from 'lucide-react';
+import type { DsgGovernedToolExecutionResult, DsgGovernedToolPreparedRequest, StoredRecord } from '@/lib/dsg/tools/governed-tools';
+import { cn } from '@/lib/utils';
+
+const confirmationReasons = new Set([
+  'BROWSER_CONFIRMATION_REQUIRED',
+  'SEARCH_CONFIRMATION_REQUIRED',
+  'API_CONFIRMATION_REQUIRED',
+  'GOOGLE_WORKSPACE_CONFIRMATION_REQUIRED',
+]);
+
+const allowlistReasons = new Set([
+  'BROWSER_HOST_NOT_ALLOWLISTED',
+  'SEARCH_ENDPOINT_HOST_NOT_ALLOWLISTED',
+  'API_HOST_NOT_ALLOWLISTED',
+  'GOOGLE_WORKSPACE_ENDPOINT_HOST_NOT_ALLOWLISTED',
+]);
+
+type GovernedToolPanelProps = {
+  prepared?: DsgGovernedToolPreparedRequest | null;
+  result?: DsgGovernedToolExecutionResult | null;
+  persistedRecords?: StoredRecord[];
+  busy?: boolean;
+  onApprove?: () => void;
+};
+
+function statusTone(status?: string) {
+  if (status === 'blocked' || status === 'blocked_before_execution') return 'border-[#b4232b]/45 bg-[#b4232b]/10 text-[#ffb4b8]';
+  if (status === 'review') return 'border-[#d66a2f]/45 bg-[#d66a2f]/10 text-[#ffd1a8]';
+  if (status === 'ready' || status === 'runtime_evidence') return 'border-[#d6a63a]/45 bg-[#d6a63a]/10 text-[#f5d27a]';
+  return 'border-[#c8c8c8]/15 bg-[#111113] text-[#c8c8c8]';
+}
+
+function pretty(value: unknown) {
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function getOutputRecord(output: unknown): StoredRecord | null {
+  if (!output || typeof output !== 'object') return null;
+  const record = (output as { record?: unknown }).record;
+  if (!record || typeof record !== 'object') return null;
+  return record as StoredRecord;
+}
+
+function getOutputRecords(output: unknown): StoredRecord[] {
+  if (!output || typeof output !== 'object') return [];
+  const value = (output as { records?: unknown }).records;
+  return Array.isArray(value) ? (value as StoredRecord[]) : [];
+}
+
+function externalUrl(output: unknown) {
+  if (!output || typeof output !== 'object') return null;
+  const value = (output as { url?: unknown; endpoint?: unknown }).url ?? (output as { endpoint?: unknown }).endpoint;
+  return typeof value === 'string' && value.startsWith('https://') ? value : null;
+}
+
+function InfoRow({ label, value }: { label: string; value?: unknown }) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div className="rounded-xl border border-[#c8c8c8]/10 bg-[#0c0c0d] p-2">
+      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-[#8d8d8d]">{label}</p>
+      <p className="mt-1 break-words font-mono text-[11px] text-[#d9d9d9]">{String(value)}</p>
+    </div>
+  );
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  return (
+    <details className="rounded-xl border border-[#c8c8c8]/10 bg-[#0c0c0d] p-3" open>
+      <summary className="cursor-pointer text-xs font-black text-[#f2f2f2]">{label}</summary>
+      <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-black/35 p-2 text-[11px] leading-5 text-[#c8c8c8]">{pretty(value)}</pre>
+    </details>
+  );
+}
+
+function BlockedReasonsList({ reasons }: { reasons: string[] }) {
+  if (!reasons.length) return null;
+  return (
+    <div className="rounded-xl border border-[#b4232b]/35 bg-[#b4232b]/10 p-3">
+      <div className="flex items-center gap-2 text-[#ffb4b8]">
+        <ShieldAlert className="h-4 w-4" />
+        <p className="text-xs font-black uppercase tracking-[0.18em]">Blocked / review reasons</p>
+      </div>
+      <ul className="mt-2 space-y-1 text-xs leading-5 text-[#ffd7d9]">
+        {reasons.map((reason) => <li key={reason}>• {reason}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+function DecisionFramePanel({ prepared }: { prepared: DsgGovernedToolPreparedRequest }) {
+  const frame = prepared.decisionFrame;
+  return (
+    <section className="space-y-2 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-[#d6a63a]">Decision frame</p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <InfoRow label="Risk status" value={frame.risk.state ?? 'unknown'} />
+        <InfoRow label="Truth ok" value={String(frame.truthBoundary.ok)} />
+      </div>
+      {Array.isArray(frame.risk.reasons) && frame.risk.reasons.length ? <BlockedReasonsList reasons={frame.risk.reasons} /> : null}
+      <div className="grid gap-2">
+        <InfoRow label="User benefit" value={frame.benefit.userBenefit} />
+        <InfoRow label="Easier" value={String(frame.benefit.easier)} />
+        <InfoRow label="Tangible output" value={frame.benefit.tangibleOutput} />
+        <InfoRow label="Next action" value={frame.benefit.nextAction} />
+      </div>
+      {frame.truthBoundary.blockedReasons?.length ? <BlockedReasonsList reasons={frame.truthBoundary.blockedReasons} /> : null}
+    </section>
+  );
+}
+
+function ApprovalPanel({ prepared, busy, onApprove }: { prepared: DsgGovernedToolPreparedRequest; busy?: boolean; onApprove?: () => void }) {
+  const needsConfirmation = prepared.blockedReasons.some((reason) => confirmationReasons.has(reason));
+  const needsAllowlist = prepared.blockedReasons.some((reason) => allowlistReasons.has(reason));
+  if (!needsConfirmation && !needsAllowlist) return null;
+
+  return (
+    <section className="space-y-3 rounded-xl border border-[#d66a2f]/45 bg-[#d66a2f]/10 p-3 text-xs leading-5 text-[#ffd1a8]">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <div>
+          <p className="font-black">External action requires explicit control</p>
+          <p className="text-[#d9d9d9]">Review the tool, action, goal, and args before approving. Approval is sent as <span className="font-mono">args.approved=true</span>.</p>
+        </div>
+      </div>
+      {needsAllowlist ? (
+        <p className="rounded-lg border border-[#b4232b]/30 bg-[#b4232b]/10 p-2 text-[#ffb4b8]">Host is not allowlisted. Add the exact host to <span className="font-mono">allowedHosts</span>, then retry; do not bypass this for unknown endpoints.</p>
+      ) : null}
+      {needsConfirmation && onApprove ? (
+        <button type="button" onClick={onApprove} disabled={busy} className="rounded-xl border border-[#d6a63a]/45 bg-[#d6a63a]/15 px-3 py-2 font-black text-[#f5d27a] disabled:cursor-not-allowed disabled:opacity-60">
+          {busy ? 'Approving…' : 'Approve and execute governed tool'}
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+function ToolOutputViewer({ result }: { result: DsgGovernedToolExecutionResult }) {
+  const output = result.output;
+  const url = externalUrl(output);
+  if (!output) return null;
+  return (
+    <section className="space-y-2 rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-[#f5d27a]">Execution output</p>
+        {url ? <a href={url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs font-bold text-[#f5d27a] underline">Open URL<ExternalLink className="h-3 w-3" /></a> : null}
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <InfoRow label="Verification" value={result.outputVerification} />
+        <InfoRow label="Execution phase" value={result.executionDecisionFrame?.phase} />
+      </div>
+      <JsonBlock label={`${result.prepared.tool} output`} value={output} />
+    </section>
+  );
+}
+
+function PersistedRecordsView({ records }: { records: StoredRecord[] }) {
+  if (!records.length) return null;
+  return (
+    <section className="space-y-2 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+      <div className="flex items-center gap-2 text-[#d9d9d9]">
+        <Database className="h-4 w-4 text-[#d6a63a]" />
+        <p className="text-xs font-black uppercase tracking-[0.18em]">Persisted records</p>
+      </div>
+      <div className="space-y-2">
+        {records.map((record) => (
+          <details key={`${record.id}:${record.revision}:${record.eventHash}`} className="rounded-xl border border-[#c8c8c8]/10 bg-[#0c0c0d] p-3">
+            <summary className="cursor-pointer text-xs font-black text-[#f2f2f2]">{record.id} · {record.status}</summary>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <InfoRow label="Tool" value={record.tool} />
+              <InfoRow label="Action" value={record.action} />
+              <InfoRow label="Goal" value={record.goal} />
+              <InfoRow label="Updated" value={record.updatedAt} />
+              <InfoRow label="Request hash" value={record.requestHash} />
+              <InfoRow label="Evidence hash" value={record.evidenceHash} />
+            </div>
+            <JsonBlock label="Record args" value={record.args} />
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function collectPersistedRecords(result?: DsgGovernedToolExecutionResult | null): StoredRecord[] {
+  if (!result) return [];
+  const one = getOutputRecord(result.output);
+  return [...(one ? [one] : []), ...getOutputRecords(result.output)];
+}
+
+export function GovernedToolPanel({ prepared, result, persistedRecords = [], busy, onApprove }: GovernedToolPanelProps) {
+  const activePrepared = result?.prepared ?? prepared;
+  const records = [...persistedRecords, ...collectPersistedRecords(result)];
+
+  if (!activePrepared && !result) {
+    return (
+      <section className="rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3 text-xs leading-5 text-[#8d8d8d]">
+        No governed tool request prepared yet. Prepare a request to see status, audit truth, decision frame, approval controls, output, and persisted records.
+      </section>
+    );
+  }
+
+  if (!activePrepared) return null;
+
+  return (
+    <div className="space-y-3">
+      <section className={cn('rounded-xl border p-3', statusTone(activePrepared.status))}>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.18em]">Governed tool request</p>
+            <h3 className="mt-1 text-lg font-black text-[#f2f2f2]">{activePrepared.tool} · {activePrepared.action}</h3>
+          </div>
+          <span className="rounded-full border border-white/10 px-2.5 py-1 text-xs font-black">{activePrepared.status}</span>
+        </div>
+        <div className="mt-3 grid gap-2">
+          <InfoRow label="Goal" value={activePrepared.goal} />
+          <InfoRow label="Audit id" value={activePrepared.audit.id} />
+          <InfoRow label="Audit truth" value={activePrepared.audit.truth} />
+          <InfoRow label="Request hash" value={activePrepared.audit.requestHash} />
+        </div>
+        <div className="mt-3 flex items-center gap-2 text-xs text-[#d9d9d9]">
+          {activePrepared.ok ? <CheckCircle2 className="h-4 w-4 text-[#d6a63a]" /> : <XCircle className="h-4 w-4 text-[#ffb4b8]" />}
+          <span>{activePrepared.userOutcome}</span>
+        </div>
+      </section>
+
+      <BlockedReasonsList reasons={activePrepared.blockedReasons} />
+      <ApprovalPanel prepared={activePrepared} busy={busy} onApprove={onApprove} />
+      <JsonBlock label="Prepared args" value={activePrepared.args} />
+      <DecisionFramePanel prepared={activePrepared} />
+      {result ? <ToolOutputViewer result={result} /> : null}
+      <PersistedRecordsView records={records} />
+      <section className={cn('rounded-xl border p-3 text-xs leading-5', statusTone(result?.outputVerification))}>
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4" />
+          <p><span className="font-black">Output verification:</span> {result?.outputVerification ?? 'not executed yet'}</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/dsg/tools/governed-tools.ts
+++ b/lib/dsg/tools/governed-tools.ts
@@ -26,6 +26,7 @@ export type DsgGovernedToolPreparedRequest = {
   status: DsgGovernedToolStatus;
   tool: DsgGovernedToolKind;
   action: DsgGovernedToolAction;
+  goal: string;
   args: Record<string, unknown>;
   audit: {
     id: string;
@@ -618,6 +619,7 @@ export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGo
     status: blockedReasons.length ? 'blocked' : readyStatus(normalized.tool, normalized.action),
     tool: normalized.tool,
     action: normalized.action,
+    goal: normalized.goal,
     args: normalized.args ?? {},
     audit: { id: `tool:${requestHash}`, truth: truthFor(normalized.tool), requestHash },
     decisionFrame: {


### PR DESCRIPTION
### Motivation

- Surface prepared governed tool requests and execution results in the App Builder UI so users can inspect audit/truth, decision frames, blocked reasons, and approve external actions before execution.
- Provide a self-service Governed Tools workbench for developers to prepare and execute governed `plan`/`workflow`/external-tool dry-runs and real executions with allowlist and explicit approval controls.
- Make governed tooling outcomes (including persisted records and output verification) discoverable in the runtime monitor and timeline for transparency and auditability.

### Description

- Add a reusable UI module `components/dsg/governed-tools/GovernedToolPanels.tsx` that displays prepared requests, blocked/review reasons, decision-frame data (risk/benefit/truthBoundary), approval controls, execution output, output verification, and persisted record inspection.
- Integrate governed dry-run visibility into `AppBuilderAgentRuntimeView` so that plan creation and runtime handoff produce a governed `plan`/`workflow` dry-run and the right-side monitor shows the prepared request and result via the new `GovernedToolPanel` component.
- Add a Governed Tools workbench tab to `AppBuilderConsoleClient` with selectable tool/kind/action, editable JSON `args`, allowed-hosts input, `Prepare only` / `Execute governed` actions, and support for rerunning execution with `approved: true` via an approval callback wired to the panel.
- Wire server side `/api/dsg/tools` to merge top-level `approved` and `allowedHosts` into the request `args`, and expose the `goal` on `DsgGovernedToolPreparedRequest` so the UI can display the governed user goal; also refine timeline/status tone handling to include `runtime_evidence` and review states.

### Testing

- Ran type-checking with `npm run dsg:typecheck` (TypeScript `tsc --noEmit`) and it succeeded.
- Ran unit tests with `npx vitest run tests/dsg/governed-tools.test.ts` and all tests passed (`17` tests passed).
- Ran `npm run lint` and it failed due to an existing unrelated lint issue in `app/page.tsx` (React hook usage), which did not originate from these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcda7672ec8328bae6c0bad27ab9aa)