### PR TITLE
Governed tools: mark confirmation-only requests as `review` and enrich UI output/details

### DIFF
--- a/components/dsg/governed-tools/GovernedToolPanels.tsx
+++ b/components/dsg/governed-tools/GovernedToolPanels.tsx
@@ -58,6 +58,11 @@ function externalUrl(output: unknown) {
   return typeof value === 'string' && value.startsWith('https://') ? value : null;
 }
 
+function outputField(output: unknown, key: string) {
+  if (!output || typeof output !== 'object') return undefined;
+  return (output as Record<string, unknown>)[key];
+}
+
 function InfoRow({ label, value }: { label: string; value?: unknown }) {
   if (value === undefined || value === null || value === '') return null;
   return (
@@ -98,7 +103,7 @@ function DecisionFramePanel({ prepared }: { prepared: DsgGovernedToolPreparedReq
     <section className="space-y-2 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
       <p className="text-xs font-black uppercase tracking-[0.18em] text-[#d6a63a]">Decision frame</p>
       <div className="grid gap-2 sm:grid-cols-2">
-        <InfoRow label="Risk status" value={frame.risk.state ?? 'unknown'} />
+        <InfoRow label="Risk status" value={(frame.risk as { status?: string; state?: string }).status ?? frame.risk.state ?? 'unknown'} />
         <InfoRow label="Truth ok" value={String(frame.truthBoundary.ok)} />
       </div>
       {Array.isArray(frame.risk.reasons) && frame.risk.reasons.length ? <BlockedReasonsList reasons={frame.risk.reasons} /> : null}
@@ -143,6 +148,20 @@ function ToolOutputViewer({ result }: { result: DsgGovernedToolExecutionResult }
   const output = result.output;
   const url = externalUrl(output);
   if (!output) return null;
+  const tool = result.prepared.tool;
+  const primaryFields = tool === 'browser'
+    ? ['url', 'status', 'contentType', 'title']
+    : tool === 'search'
+      ? ['endpoint', 'status']
+      : tool === 'api'
+        ? ['url', 'method', 'status']
+        : tool === 'google_workspace'
+          ? ['operation', 'status']
+          : tool === 'shell'
+            ? ['stdout', 'stderr']
+            : tool === 'file'
+              ? ['path', 'contentHash']
+              : ['operation', 'status'];
   return (
     <section className="space-y-2 rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3">
       <div className="flex items-center justify-between gap-2">
@@ -152,8 +171,13 @@ function ToolOutputViewer({ result }: { result: DsgGovernedToolExecutionResult }
       <div className="grid gap-2 sm:grid-cols-2">
         <InfoRow label="Verification" value={result.outputVerification} />
         <InfoRow label="Execution phase" value={result.executionDecisionFrame?.phase} />
+        {primaryFields.map((field) => <InfoRow key={field} label={field} value={outputField(output, field)} />)}
       </div>
-      <JsonBlock label={`${result.prepared.tool} output`} value={output} />
+      {tool === 'browser' ? <JsonBlock label="Scraped text" value={outputField(output, 'text') ?? ''} /> : null}
+      {tool === 'search' ? <JsonBlock label="Search results" value={outputField(output, 'results') ?? []} /> : null}
+      {(tool === 'api' || tool === 'google_workspace') ? <JsonBlock label="Response body" value={outputField(output, 'body') ?? {}} /> : null}
+      {(tool === 'shell' || tool === 'file') ? <JsonBlock label={`${tool} details`} value={output} /> : null}
+      {!['browser', 'search', 'api', 'google_workspace', 'shell', 'file'].includes(tool) ? <JsonBlock label={`${tool} output`} value={output} /> : null}
     </section>
   );
 }
@@ -174,6 +198,7 @@ function PersistedRecordsView({ records }: { records: StoredRecord[] }) {
               <InfoRow label="Tool" value={record.tool} />
               <InfoRow label="Action" value={record.action} />
               <InfoRow label="Goal" value={record.goal} />
+              <InfoRow label="Created" value={record.createdAt} />
               <InfoRow label="Updated" value={record.updatedAt} />
               <InfoRow label="Request hash" value={record.requestHash} />
               <InfoRow label="Evidence hash" value={record.evidenceHash} />

--- a/lib/dsg/tools/governed-tools.ts
+++ b/lib/dsg/tools/governed-tools.ts
@@ -612,11 +612,12 @@ export function prepareGovernedToolRequest(input: DsgGovernedToolRequest): DsgGo
   const risk = kilesa(`${normalized.tool}:${normalized.action}:${normalized.goal || 'missing-goal'}`, verifiedInput.verified && reasons.length === 0, riskFlags);
   const boundary = truthBoundary({ verified: verifiedInput.verified && reasons.length === 0, containsSecret: false });
   const blockedReasons = [...new Set([...reasons, ...risk.reasons.filter((reason) => reason !== 'VERIFIED'), ...boundary.blockedReasons])];
+  const confirmationOnlyReview = reasons.length > 0 && reasons.every((reason) => reason.endsWith('_CONFIRMATION_REQUIRED'));
   const requestHash = sha256Json({ tool: normalized.tool, action: normalized.action, args: normalized.args, evidence });
 
   return {
     ok: blockedReasons.length === 0,
-    status: blockedReasons.length ? 'blocked' : readyStatus(normalized.tool, normalized.action),
+    status: blockedReasons.length ? (confirmationOnlyReview ? 'review' : 'blocked') : readyStatus(normalized.tool, normalized.action),
     tool: normalized.tool,
     action: normalized.action,
     goal: normalized.goal,

--- a/tests/dsg/governed-tools.test.ts
+++ b/tests/dsg/governed-tools.test.ts
@@ -52,6 +52,7 @@ describe('DSG governed tooling layer', () => {
   it('keeps browser operations blocked until explicit approval is supplied', () => {
     const prepared = prepareGovernedToolRequest({ tool: 'browser', action: 'navigate', goal: 'Read docs', args: { url: 'https://example.com' } });
     expect(prepared.ok).toBe(false);
+    expect(prepared.status).toBe('review');
     expect(prepared.audit.truth).toBe('external_data_pending_verification');
     expect(prepared.blockedReasons).toContain('BROWSER_CONFIRMATION_REQUIRED');
   });


### PR DESCRIPTION
### Motivation

- Distinguish external actions that only need user confirmation from hard blocks so the UI can show a clear `review` state for approval flows. 
- Improve visibility of adapter outputs and persisted records in the Governed Tools panel to meet transparency and audit requirements.

### Description

- Update `prepareGovernedToolRequest` to treat requests whose only blocked reasons end with `_CONFIRMATION_REQUIRED` as `status: 'review'` instead of `blocked`, while keeping `ok: false` (fail-closed until approval). (see `lib/dsg/tools/governed-tools.ts`).
- Expand Governed Tools UI (`components/dsg/governed-tools/GovernedToolPanels.tsx`) with a generic `outputField` helper, tool-specific primary output rows for `browser`, `search`, `api`, `google_workspace`, `shell`, and `file`, conditional JSON viewers for scraped text / results / response bodies, and improved Decision Frame `risk` status mapping. 
- Add `Created` timestamp display to persisted record entries in the Persisted Records view. 
- Align tests by asserting the browser dry-run prepare result reports `status: 'review'` when confirmation is required. (see `tests/dsg/governed-tools.test.ts`).

### Testing

- Ran unit tests with `npx vitest run tests/dsg/governed-tools.test.ts`, all tests passed (`17 passed`).
- Ran type checking with `npm run dsg:typecheck` (`tsc --noEmit`) which completed successfully.
- Ran linter with `npm run lint`, which reported a pre-existing `react-hooks/set-state-in-effect` issue in `app/page.tsx` unrelated to these changes (lint failed on that existing file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdcba7d4483288050d61f2d16f8cf)