### PR TITLE
Refine customer App Builder workspace UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,15 @@ OPENAI_API_BASE=""
 ANTHROPIC_API_KEY=""
 # GEMINI_API_KEY is listed above; GOOGLE_GENERATIVE_AI_API_KEY is accepted as a compatibility alias.
 GOOGLE_GENERATIVE_AI_API_KEY=""
+
+# Remote browser provider registry.
+# These values only make providers env-ready. They do not claim verified autonomous browser execution
+# until the corresponding executor adapter is implemented and tested.
+PLAYWRIGHT_CDP_WS_ENDPOINT=""
+PLAYWRIGHT_DEFAULT_CONTEXT_ID=""
+BROWSERBASE_API_KEY=""
+BROWSERBASE_PROJECT_ID=""
+BROWSERBASE_REGION=""
+BROWSERBASE_PROJECT_NAME=""
+STEEL_API_KEY=""
+STEEL_BASE_URL=""

--- a/app/api/dsg/agent-runtime/services/route.ts
+++ b/app/api/dsg/agent-runtime/services/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { listAgentRuntimeServices } from '@/lib/dsg/agent-runtime/service-registry';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    data: {
+      services: listAgentRuntimeServices(),
+      truthBoundary: 'Remote browser automation is connector_required until a real executor is wired. Existing server-side App Builder tool calls remain available through approved job flow.',
+    },
+  });
+}

--- a/app/api/dsg/ai/openai/chat/route.ts
+++ b/app/api/dsg/ai/openai/chat/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { runOpenAIAdapter } from '@/lib/dsg/ai/openai-adapter';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null) as {
+    input?: string;
+    messages?: Array<{ role: 'system' | 'developer' | 'user' | 'assistant'; content: string }>;
+    model?: string;
+    maxOutputTokens?: number;
+    temperature?: number;
+  } | null;
+
+  if (!body) {
+    return NextResponse.json({ ok: false, error: { message: 'INVALID_JSON_BODY' } }, { status: 400 });
+  }
+
+  try {
+    const output = await runOpenAIAdapter(body);
+    return NextResponse.json({ ok: true, data: output });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: { message: error instanceof Error ? error.message : 'OPENAI_ADAPTER_FAILED' },
+    }, { status: error instanceof Error && error.message === 'OPENAI_API_KEY_MISSING' ? 503 : 500 });
+  }
+}

--- a/app/api/dsg/ai/openai/status/route.ts
+++ b/app/api/dsg/ai/openai/status/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getOpenAIAdapterStatus } from '@/lib/dsg/ai/openai-adapter';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    data: getOpenAIAdapterStatus(),
+  });
+}

--- a/app/api/dsg/remote-browser/providers/route.ts
+++ b/app/api/dsg/remote-browser/providers/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { listRemoteBrowserProviders } from '@/lib/dsg/remote-browser/provider-registry';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    data: {
+      providers: listRemoteBrowserProviders(),
+      truthBoundary: 'Providers are env-gated. A provider with env present remains adapter_pending until a verified executor adapter is implemented.',
+    },
+  });
+}

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/artifacts/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/artifacts/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { addRemoteBrowserArtifact, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
+import type { RemoteBrowserArtifact } from '@/lib/dsg/remote-browser/types';
+
+export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+  try {
+    const session = getRemoteBrowserSession(params.sessionId);
+    return NextResponse.json({ ok: true, data: { artifacts: session.artifacts } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
+  }
+}
+
+export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+  const body = await req.json().catch(() => null) as Partial<RemoteBrowserArtifact> | null;
+  const title = typeof body?.title === 'string' ? body.title.trim() : '';
+  const detail = typeof body?.detail === 'string' ? body.detail.trim() : '';
+  const type = body?.type ?? 'manual_note';
+  const status = body?.status ?? 'available';
+  const url = typeof body?.url === 'string' ? body.url.trim() : undefined;
+
+  if (!title) return NextResponse.json({ ok: false, error: { message: 'ARTIFACT_TITLE_REQUIRED' } }, { status: 400 });
+  if (!detail) return NextResponse.json({ ok: false, error: { message: 'ARTIFACT_DETAIL_REQUIRED' } }, { status: 400 });
+
+  try {
+    const session = addRemoteBrowserArtifact({ sessionId: params.sessionId, type, status, title, detail, url });
+    return NextResponse.json({ ok: true, data: { session } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_ARTIFACT_FAILED' } }, { status: 400 });
+  }
+}

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/artifacts/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/artifacts/route.ts
@@ -2,16 +2,20 @@ import { NextResponse } from 'next/server';
 import { addRemoteBrowserArtifact, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
 import type { RemoteBrowserArtifact } from '@/lib/dsg/remote-browser/types';
 
-export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(_req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   try {
-    const session = getRemoteBrowserSession(params.sessionId);
+    const session = getRemoteBrowserSession(sessionId);
     return NextResponse.json({ ok: true, data: { artifacts: session.artifacts } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
   }
 }
 
-export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+export async function POST(req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   const body = await req.json().catch(() => null) as Partial<RemoteBrowserArtifact> | null;
   const title = typeof body?.title === 'string' ? body.title.trim() : '';
   const detail = typeof body?.detail === 'string' ? body.detail.trim() : '';
@@ -23,7 +27,7 @@ export async function POST(req: Request, { params }: { params: { sessionId: stri
   if (!detail) return NextResponse.json({ ok: false, error: { message: 'ARTIFACT_DETAIL_REQUIRED' } }, { status: 400 });
 
   try {
-    const session = addRemoteBrowserArtifact({ sessionId: params.sessionId, type, status, title, detail, url });
+    const session = addRemoteBrowserArtifact({ sessionId, type, status, title, detail, url });
     return NextResponse.json({ ok: true, data: { session } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_ARTIFACT_FAILED' } }, { status: 400 });

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/[checkpointId]/resolve/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/[checkpointId]/resolve/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from 'next/server';
 import { resolveRemoteBrowserCheckpoint } from '@/lib/dsg/remote-browser/session-store';
 
-export async function POST(req: Request, { params }: { params: { sessionId: string; checkpointId: string } }) {
+type RouteContext = { params: Promise<{ sessionId: string; checkpointId: string }> };
+
+export async function POST(req: Request, context: RouteContext) {
+  const { sessionId, checkpointId } = await context.params;
   const body = await req.json().catch(() => null) as { detail?: string } | null;
 
   try {
     const session = resolveRemoteBrowserCheckpoint({
-      sessionId: params.sessionId,
-      checkpointId: params.checkpointId,
+      sessionId,
+      checkpointId,
       detail: typeof body?.detail === 'string' ? body.detail : undefined,
     });
     return NextResponse.json({ ok: true, data: { session } });

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/[checkpointId]/resolve/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/[checkpointId]/resolve/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { resolveRemoteBrowserCheckpoint } from '@/lib/dsg/remote-browser/session-store';
+
+export async function POST(req: Request, { params }: { params: { sessionId: string; checkpointId: string } }) {
+  const body = await req.json().catch(() => null) as { detail?: string } | null;
+
+  try {
+    const session = resolveRemoteBrowserCheckpoint({
+      sessionId: params.sessionId,
+      checkpointId: params.checkpointId,
+      detail: typeof body?.detail === 'string' ? body.detail : undefined,
+    });
+    return NextResponse.json({ ok: true, data: { session } });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_CHECKPOINT_RESOLVE_FAILED' },
+    }, { status: 400 });
+  }
+}

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/route.ts
@@ -2,16 +2,20 @@ import { NextResponse } from 'next/server';
 import { addRemoteBrowserCheckpoint, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
 import type { RemoteBrowserCheckpoint } from '@/lib/dsg/remote-browser/types';
 
-export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(_req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   try {
-    const session = getRemoteBrowserSession(params.sessionId);
+    const session = getRemoteBrowserSession(sessionId);
     return NextResponse.json({ ok: true, data: { checkpoints: session.checkpoints } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
   }
 }
 
-export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+export async function POST(req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   const body = await req.json().catch(() => null) as Partial<RemoteBrowserCheckpoint> | null;
   const type = body?.type ?? 'takeover';
   const state = body?.state ?? 'active';
@@ -20,7 +24,7 @@ export async function POST(req: Request, { params }: { params: { sessionId: stri
   if (!instruction) return NextResponse.json({ ok: false, error: { message: 'CHECKPOINT_INSTRUCTION_REQUIRED' } }, { status: 400 });
 
   try {
-    const session = addRemoteBrowserCheckpoint({ sessionId: params.sessionId, type, state, instruction });
+    const session = addRemoteBrowserCheckpoint({ sessionId, type, state, instruction });
     return NextResponse.json({ ok: true, data: { session } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_CHECKPOINT_FAILED' } }, { status: 400 });

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/checkpoints/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { addRemoteBrowserCheckpoint, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
+import type { RemoteBrowserCheckpoint } from '@/lib/dsg/remote-browser/types';
+
+export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+  try {
+    const session = getRemoteBrowserSession(params.sessionId);
+    return NextResponse.json({ ok: true, data: { checkpoints: session.checkpoints } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
+  }
+}
+
+export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+  const body = await req.json().catch(() => null) as Partial<RemoteBrowserCheckpoint> | null;
+  const type = body?.type ?? 'takeover';
+  const state = body?.state ?? 'active';
+  const instruction = typeof body?.instruction === 'string' ? body.instruction.trim() : '';
+
+  if (!instruction) return NextResponse.json({ ok: false, error: { message: 'CHECKPOINT_INSTRUCTION_REQUIRED' } }, { status: 400 });
+
+  try {
+    const session = addRemoteBrowserCheckpoint({ sessionId: params.sessionId, type, state, instruction });
+    return NextResponse.json({ ok: true, data: { session } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_CHECKPOINT_FAILED' } }, { status: 400 });
+  }
+}

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/navigation/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/navigation/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { appendRemoteBrowserNavigation, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
+import type { RemoteBrowserNavigationEvent } from '@/lib/dsg/remote-browser/types';
+
+export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+  try {
+    const session = getRemoteBrowserSession(params.sessionId);
+    return NextResponse.json({ ok: true, data: { navigationLog: session.navigationLog } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
+  }
+}
+
+export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+  const body = await req.json().catch(() => null) as Partial<RemoteBrowserNavigationEvent> | null;
+  const action = body?.action ?? 'note';
+  const status = body?.status ?? 'completed';
+  const detail = typeof body?.detail === 'string' ? body.detail.trim() : '';
+  const url = typeof body?.url === 'string' ? body.url.trim() : undefined;
+
+  if (!detail) return NextResponse.json({ ok: false, error: { message: 'NAVIGATION_DETAIL_REQUIRED' } }, { status: 400 });
+
+  try {
+    const session = appendRemoteBrowserNavigation({ sessionId: params.sessionId, action, status, url, detail });
+    return NextResponse.json({ ok: true, data: { session } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_NAVIGATION_FAILED' } }, { status: 400 });
+  }
+}

--- a/app/api/dsg/remote-browser/sessions/[sessionId]/navigation/route.ts
+++ b/app/api/dsg/remote-browser/sessions/[sessionId]/navigation/route.ts
@@ -2,16 +2,20 @@ import { NextResponse } from 'next/server';
 import { appendRemoteBrowserNavigation, getRemoteBrowserSession } from '@/lib/dsg/remote-browser/session-store';
 import type { RemoteBrowserNavigationEvent } from '@/lib/dsg/remote-browser/types';
 
-export async function GET(_req: Request, { params }: { params: { sessionId: string } }) {
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(_req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   try {
-    const session = getRemoteBrowserSession(params.sessionId);
+    const session = getRemoteBrowserSession(sessionId);
     return NextResponse.json({ ok: true, data: { navigationLog: session.navigationLog } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_NOT_FOUND' } }, { status: 404 });
   }
 }
 
-export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+export async function POST(req: Request, context: RouteContext) {
+  const { sessionId } = await context.params;
   const body = await req.json().catch(() => null) as Partial<RemoteBrowserNavigationEvent> | null;
   const action = body?.action ?? 'note';
   const status = body?.status ?? 'completed';
@@ -21,7 +25,7 @@ export async function POST(req: Request, { params }: { params: { sessionId: stri
   if (!detail) return NextResponse.json({ ok: false, error: { message: 'NAVIGATION_DETAIL_REQUIRED' } }, { status: 400 });
 
   try {
-    const session = appendRemoteBrowserNavigation({ sessionId: params.sessionId, action, status, url, detail });
+    const session = appendRemoteBrowserNavigation({ sessionId, action, status, url, detail });
     return NextResponse.json({ ok: true, data: { session } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_NAVIGATION_FAILED' } }, { status: 400 });

--- a/app/api/dsg/remote-browser/sessions/route.ts
+++ b/app/api/dsg/remote-browser/sessions/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { createRemoteBrowserSession, listRemoteBrowserSessions } from '@/lib/dsg/remote-browser/session-store';
+import type { RemoteBrowserCreateSessionInput } from '@/lib/dsg/remote-browser/types';
+
+export async function GET() {
+  return NextResponse.json({ ok: true, data: { sessions: listRemoteBrowserSessions() } });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null) as Partial<RemoteBrowserCreateSessionInput> | null;
+  const goal = typeof body?.goal === 'string' ? body.goal.trim() : '';
+  const startUrl = typeof body?.startUrl === 'string' ? body.startUrl.trim() : '';
+  const providerId = body?.providerId;
+
+  if (!goal) return NextResponse.json({ ok: false, error: { message: 'REMOTE_BROWSER_GOAL_REQUIRED' } }, { status: 400 });
+  if (!startUrl) return NextResponse.json({ ok: false, error: { message: 'REMOTE_BROWSER_START_URL_REQUIRED' } }, { status: 400 });
+
+  try {
+    const session = createRemoteBrowserSession({ goal, startUrl, providerId });
+    return NextResponse.json({ ok: true, data: { session } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: { message: error instanceof Error ? error.message : 'REMOTE_BROWSER_SESSION_CREATE_FAILED' } }, { status: 400 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,29 +45,31 @@ type NavItem = {
 };
 
 const navItems: NavItem[] = [
-  { id: 'chat', label: { th: 'คุยกับเอเจนต์', en: 'Agent chat' }, helper: { th: 'เริ่มงานตรงนี้', en: 'Start work here' }, icon: MessageSquare },
-  { id: 'dashboard', label: { th: 'ภาพรวม', en: 'Overview' }, helper: { th: 'สถานะจริง', en: 'Real status' }, icon: Activity },
-  { id: 'agents', label: { th: 'เอเจนต์', en: 'Agents' }, helper: { th: 'เครื่องมือและรันไทม์', en: 'Tools and runtime' }, icon: Terminal },
-  { id: 'executions', label: { th: 'หลักฐาน', en: 'Evidence' }, helper: { th: 'ก่อนเคลม', en: 'Before claims' }, icon: ShieldCheck },
+  { id: 'chat', label: { th: 'สร้างแอป', en: 'Build app' }, helper: { th: 'เริ่มจากไอเดีย', en: 'Start from an idea' }, icon: MessageSquare },
+  { id: 'dashboard', label: { th: 'โปรเจกต์ของฉัน', en: 'My projects' }, helper: { th: 'สถานะและขั้นตอนถัดไป', en: 'Status and next actions' }, icon: Activity },
+  { id: 'agents', label: { th: 'บริการเอเจนต์', en: 'Agent services' }, helper: { th: 'เครื่องมือที่ใช้ได้', en: 'Usable tools' }, icon: Terminal },
+  { id: 'executions', label: { th: 'หลักฐาน', en: 'Evidence' }, helper: { th: 'PR / branch / proof', en: 'PR / branch / proof' }, icon: ShieldCheck },
   { id: 'governance', label: { th: 'กำกับดูแล', en: 'Governance' }, helper: { th: 'นโยบายและอนุมัติ', en: 'Policy and approval' }, icon: Lock },
-  { id: 'proof', label: { th: 'ตรวจสอบ', en: 'Audit' }, helper: { th: 'พร้อมตรวจ', en: 'Audit view' }, icon: FileText },
+  { id: 'proof', label: { th: 'ส่งมอบงาน', en: 'Handoff' }, helper: { th: 'รายงานให้ลูกค้า', en: 'Customer report' }, icon: FileText },
 ];
 
 const copy = {
   th: {
-    brandSub: 'รันไทม์มีหลักฐาน',
-    controlPlane: 'ศูนย์ควบคุม',
+    brandSub: 'บริการสร้างแอปมีหลักฐาน',
+    controlPlane: 'พื้นที่บริการลูกค้า',
     language: 'ภาษา',
-    searchPlaceholder: 'ค้นหาจะเปิดเมื่อมีดัชนีหลักฐานจริง',
-    notificationLabel: 'แจ้งเตือนยังไม่เปิดจนกว่าจะมี event จริง',
+    searchPlaceholder: 'ค้นหาเมนู เช่น สร้างแอป, หลักฐาน, ตรวจสอบ',
+    notificationLabel: 'ดูคำแนะนำขั้นตอนถัดไป',
     noMock: 'ไม่ใช้ข้อมูลจำลอง',
     workTitle: 'พื้นที่ทำงานหลัก',
-    workSubtitle: 'คุยงานกับเอเจนต์เป็นหลัก หน้าจออื่นเป็นหมวดเสริม ไม่ใส่ช่องใหญ่ที่กดไม่ได้',
+    workSubtitle: 'ทุกหน้าต้องกดแล้วได้ผล: สร้างงาน, เปิดหลักฐาน, คัดลอก proof, หรือดาวน์โหลดรายงาน',
     rulesTitle: 'กฎหน้าจอ',
+    searchNoResult: 'ไม่พบเมนูที่ตรงกัน ลองพิมพ์ สร้างแอป / หลักฐาน / ตรวจสอบ',
+    notificationText: 'เริ่มที่ “สร้างแอป” → อนุมัติแผน → สร้าง PR → คัดลอก proof JSON. ยังไม่ใช้ Vercel จนกว่าจะต้องตรวจ preview/production proof.',
     rules: [
-      'ใช้เฉพาะข้อมูลจริงจาก endpoint หรือแหล่งสาธารณะที่อ้างอิงได้',
-      'ไม่เดาผลผู้บริโภค ไม่แตะหลังบ้าน และไม่แสดงตัวเลขปลอม',
-      'ทอง = ผ่าน/พร้อม, แดง = เสี่ยง/ติดขัด, เงิน = รายละเอียดตรวจต่อ',
+      'ใช้เฉพาะข้อมูลจริงจาก endpoint หรือหลักฐานที่คัดลอก/ดาวน์โหลดได้',
+      'ไม่แสดงตัวเลขปลอม ไม่ใส่ปุ่มที่กดแล้วไม่เกิดอะไร',
+      'ทอง = พร้อมทำต่อ, แดง = ติดขัด, เงิน = รายละเอียดตรวจต่อ',
     ],
     monitor: {
       title: 'สด',
@@ -90,19 +92,21 @@ const copy = {
     },
   },
   en: {
-    brandSub: 'Evidence runtime',
-    controlPlane: 'Control plane',
+    brandSub: 'Evidence-backed app service',
+    controlPlane: 'Customer workspace',
     language: 'Language',
-    searchPlaceholder: 'Search opens after a real evidence index exists',
-    notificationLabel: 'Notifications open after real evidence events exist',
+    searchPlaceholder: 'Search menu: build app, evidence, handoff',
+    notificationLabel: 'Show next-step guidance',
     noMock: 'No mock data',
     workTitle: 'Primary workspace',
-    workSubtitle: 'Agent chat is the main work area. Other screens are supporting categories. No large inactive blocks.',
+    workSubtitle: 'Every screen should produce a tangible action: create work, open evidence, copy proof, or download a report.',
     rulesTitle: 'Screen rules',
+    searchNoResult: 'No matching menu. Try build app / evidence / handoff.',
+    notificationText: 'Start at Build app → approve plan → create PR → copy proof JSON. Do not spend Vercel quota until preview/production proof is required.',
     rules: [
-      'Use only real endpoints or cited public research sources',
-      'No guessed consumer results, no back-office access, no fake metrics',
-      'Gold = ready, red = risk, silver = review detail',
+      'Use only real endpoints or proof users can copy/download',
+      'No fake metrics and no dead buttons',
+      'Gold = ready, red = blocked, silver = review detail',
     ],
     monitor: {
       title: 'Live',
@@ -125,6 +129,17 @@ const copy = {
     },
   },
 } as const;
+
+function viewFromHash(): View {
+  if (typeof window === 'undefined') return 'chat';
+  const value = window.location.hash.replace('#', '') as View;
+  return navItems.some((item) => item.id === value) ? value : 'chat';
+}
+
+function navigateTo(view: View) {
+  window.location.hash = view;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
 
 function statusClass(state: ProbeState) {
   if (state === 'pass') return 'border-[#d6a63a]/40 bg-[#d6a63a]/10 text-[#f5d27a]';
@@ -246,8 +261,36 @@ function LiveMonitor({ lang }: { lang: Lang }) {
 export default function App() {
   const [currentView, setCurrentView] = useState<View>('chat');
   const [lang, setLang] = useState<Lang>('th');
+  const [searchQuery, setSearchQuery] = useState('');
   const text = copy[lang];
   const current = navItems.find((item) => item.id === currentView) ?? navItems[0];
+
+  useEffect(() => {
+    const syncHash = () => setCurrentView(viewFromHash());
+    syncHash();
+    window.addEventListener('hashchange', syncHash);
+    return () => window.removeEventListener('hashchange', syncHash);
+  }, []);
+
+  function handleNavigate(view: View) {
+    setCurrentView(view);
+    navigateTo(view);
+  }
+
+  function handleSearchSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const query = searchQuery.trim().toLowerCase();
+    const found = navItems.find((item) => {
+      const labels = [item.id, item.label.th, item.label.en, item.helper.th, item.helper.en].join(' ').toLowerCase();
+      return labels.includes(query);
+    });
+    if (found) {
+      handleNavigate(found.id);
+      setSearchQuery('');
+      return;
+    }
+    window.alert(text.searchNoResult);
+  }
 
   const renderView = () => {
     switch(currentView) {
@@ -279,7 +322,7 @@ export default function App() {
             return (
               <button
                 key={item.id}
-                onClick={() => setCurrentView(item.id)}
+                onClick={() => handleNavigate(item.id)}
                 className={cn(
                   'w-full rounded-xl border px-3 py-2 text-left transition-colors',
                   active ? 'border-[#d6a63a]/35 bg-[#d6a63a]/10 text-[#f5d27a]' : 'border-transparent text-[#c8c8c8] hover:border-[#c8c8c8]/20 hover:bg-[#c8c8c8]/5',
@@ -317,14 +360,15 @@ export default function App() {
           </div>
 
           <div className="flex items-center gap-2">
-            <div className="relative hidden md:block">
+            <form onSubmit={handleSearchSubmit} className="relative hidden md:block">
               <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#8d8d8d]" />
               <input
-                disabled
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
                 placeholder={text.searchPlaceholder}
-                className="h-9 w-72 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] pl-8 pr-3 text-xs text-[#8d8d8d] outline-none"
+                className="h-9 w-72 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] pl-8 pr-3 text-xs text-[#d9d9d9] outline-none focus:border-[#d6a63a]/40"
               />
-            </div>
+            </form>
             <div className="flex rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-0.5" aria-label={text.language}>
               {(['th', 'en'] as const).map((option) => (
                 <button
@@ -336,7 +380,7 @@ export default function App() {
                 </button>
               ))}
             </div>
-            <button className="rounded-xl border border-[#c8c8c8]/15 p-2 text-[#8d8d8d]" aria-label={text.notificationLabel}>
+            <button onClick={() => window.alert(text.notificationText)} className="rounded-xl border border-[#c8c8c8]/15 p-2 text-[#8d8d8d] hover:border-[#d6a63a]/35 hover:text-[#d6a63a]" aria-label={text.notificationLabel}>
               <Bell className="h-4 w-4" />
             </button>
             <span className="hidden rounded-xl border border-[#b4232b]/30 bg-[#b4232b]/10 px-2.5 py-2 text-[11px] font-black uppercase text-[#ffb4b8] lg:inline-flex">

--- a/components/agents-view.tsx
+++ b/components/agents-view.tsx
@@ -1,12 +1,69 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
-import { ArrowRight, Clipboard, Key, Lock, Search, Terminal } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ArrowRight, Clipboard, ExternalLink, Key, Lock, Play, RefreshCw, Search, Terminal } from 'lucide-react';
 
-const agentCapabilities = [
-  { id: 'app-builder-step-15', name: 'App Builder Planning Agent', status: 'พร้อมใช้งาน', scope: 'Goal, PRD, plan, gate, approval, handoff', proof: 'Step 15 API routes', target: 'chat' },
-  { id: 'runtime-step-16', name: 'Action Runtime Executor', status: 'ใช้หลังอนุมัติ', scope: 'สร้าง branch, เขียนไฟล์, เปิด PR', proof: 'GitHub PR evidence', target: 'chat' },
-  { id: 'production-claim-gate', name: 'Production Claim Gate', status: 'ประหยัด quota', scope: 'ตรวจ production readiness claim', proof: 'ใช้ Vercel เฉพาะรอบ proof', target: 'proof' },
+type RuntimeServiceStatus = 'available' | 'approval_required' | 'connector_required' | 'quota_gated';
+type RuntimeService = {
+  id: string;
+  label: string;
+  description: string;
+  status: RuntimeServiceStatus;
+  implementation: string;
+  action: string;
+  endpoint?: string;
+  requiredSecrets: string[];
+  evidence: string[];
+  userBenefit: string;
+  truthBoundary: string;
+};
+
+type ApiResult = {
+  ok: boolean;
+  data?: {
+    services: RuntimeService[];
+    truthBoundary: string;
+  };
+};
+
+const fallbackServices: RuntimeService[] = [
+  {
+    id: 'dsg.app_builder.launch_agent_runtime',
+    label: 'Launch App Builder agent runtime',
+    description: 'Approved runtime launcher for App Builder jobs.',
+    status: 'approval_required',
+    implementation: 'server_tool_call',
+    action: 'Use from the App Builder flow after approval.',
+    endpoint: '/api/dsg/app-builder/jobs/:jobId/tool-call',
+    requiredSecrets: ['GITHUB_TOKEN'],
+    evidence: ['runtime-environment-manifest', 'action-layer-contract', 'audit-event'],
+    userBenefit: 'Controlled execution with visible proof.',
+    truthBoundary: 'Runtime evidence only. Not production proof.',
+  },
+  {
+    id: 'browser.local.open_url',
+    label: 'Open generated app in this browser',
+    description: 'Client-side browser inspection action for manual proof.',
+    status: 'available',
+    implementation: 'client_browser_action',
+    action: 'Open URL from this screen.',
+    requiredSecrets: [],
+    evidence: ['manual-screenshot', 'user-visible-url'],
+    userBenefit: 'Inspect a page now without using remote browser quota.',
+    truthBoundary: 'Local browser only, not autonomous remote browser.',
+  },
+  {
+    id: 'remote.browser.session',
+    label: 'Remote browser session',
+    description: 'Manus-style remote browser automation contract for future executor integration.',
+    status: 'connector_required',
+    implementation: 'not_implemented_in_repo',
+    action: 'Connect a real remote browser executor before enabling autonomous browsing.',
+    requiredSecrets: ['REMOTE_BROWSER_ENDPOINT_OR_VENDOR_TOKEN'],
+    evidence: ['browser-session-id', 'screenshot-url', 'navigation-log'],
+    userBenefit: 'Future autonomous page inspection with browser proof.',
+    truthBoundary: 'Remote browser executor not found in this repo yet.',
+  },
 ];
 
 function goTo(hash: string) {
@@ -14,105 +71,181 @@ function goTo(hash: string) {
   window.dispatchEvent(new HashChangeEvent('hashchange'));
 }
 
+function statusClass(status: RuntimeServiceStatus) {
+  if (status === 'available') return 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400';
+  if (status === 'approval_required') return 'border-[#d6a63a]/30 bg-[#d6a63a]/10 text-[#f5d27a]';
+  if (status === 'quota_gated') return 'border-amber-500/25 bg-amber-500/10 text-amber-200';
+  return 'border-slate-700 bg-slate-800 text-slate-300';
+}
+
+function serviceActionLabel(service: RuntimeService) {
+  if (service.id === 'browser.local.open_url') return 'เปิด URL';
+  if (service.status === 'available') return 'ใช้งาน';
+  if (service.status === 'approval_required') return 'ไปอนุมัติ';
+  if (service.status === 'quota_gated') return 'ดู proof ก่อน';
+  return 'Copy contract';
+}
+
 export function AgentsView() {
   const [query, setQuery] = useState('');
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [services, setServices] = useState<RuntimeService[]>(fallbackServices);
+  const [loading, setLoading] = useState(false);
+  const [browserUrl, setBrowserUrl] = useState('/product-ready');
+  const [truthBoundary, setTruthBoundary] = useState('Remote browser automation requires a real connector. Existing App Builder tool calls remain available through approved job flow.');
+
+  async function loadServices() {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/dsg/agent-runtime/services', { cache: 'no-store' });
+      const json = await response.json().catch(() => null) as ApiResult | null;
+      if (response.ok && json?.ok && json.data?.services?.length) {
+        setServices(json.data.services);
+        setTruthBoundary(json.data.truthBoundary);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadServices();
+  }, []);
+
   const rows = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return agentCapabilities;
-    return agentCapabilities.filter((agent) => `${agent.name} ${agent.status} ${agent.scope} ${agent.proof}`.toLowerCase().includes(q));
-  }, [query]);
+    if (!q) return services;
+    return services.filter((service) => `${service.label} ${service.status} ${service.description} ${service.evidence.join(' ')} ${service.userBenefit}`.toLowerCase().includes(q));
+  }, [query, services]);
+
+  async function copyService(service: RuntimeService) {
+    await navigator.clipboard.writeText(JSON.stringify(service, null, 2));
+    setCopied(service.id);
+    window.setTimeout(() => setCopied(null), 1400);
+  }
 
   async function copyServiceMenu() {
-    const text = agentCapabilities.map((agent) => `${agent.name}\n- status: ${agent.status}\n- scope: ${agent.scope}\n- proof: ${agent.proof}`).join('\n\n');
+    const text = services.map((service) => `${service.label}\n- id: ${service.id}\n- status: ${service.status}\n- action: ${service.action}\n- evidence: ${service.evidence.join(', ')}\n- boundary: ${service.truthBoundary}`).join('\n\n');
     await navigator.clipboard.writeText(text);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1400);
+    setCopied('all');
+    window.setTimeout(() => setCopied(null), 1400);
+  }
+
+  function openLocalBrowser() {
+    const target = browserUrl.trim() || '/product-ready';
+    window.open(target, '_blank', 'noopener,noreferrer');
+  }
+
+  async function copyBrowserProofTask() {
+    const target = browserUrl.trim() || '/product-ready';
+    const task = {
+      tool: 'browser.local.open_url',
+      target,
+      expectedProof: ['visible URL', 'manual screenshot', 'observed result'],
+      truthBoundary: 'Manual browser inspection only. Remote browser automation is connector_required until wired.',
+    };
+    await navigator.clipboard.writeText(JSON.stringify(task, null, 2));
+    setCopied('browser-task');
+    window.setTimeout(() => setCopied(null), 1400);
   }
 
   return (
     <div className="mx-auto max-w-6xl space-y-6">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">บริการเอเจนต์</h1>
-          <p className="mt-1 text-slate-500">เลือกบริการที่ใช้งานได้จริง: สร้างแผน, อนุมัติ, เปิด PR, หรือเตรียม proof โดยไม่โชว์ key ลับ</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">บริการเอเจนต์ / Runtime Console</h1>
+          <p className="mt-1 text-slate-500">ดึง action-layer, tool calling และ browser contract ออกมาให้กดใช้แบบ Manus-style โดยไม่เคลม remote browser เกินหลักฐาน</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <button onClick={() => goTo('chat')} className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">เริ่มใช้ Agent <ArrowRight className="h-4 w-4" /></button>
-          <button onClick={() => void copyServiceMenu()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy services'}</button>
+          <button onClick={() => void loadServices()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Refresh</button>
+          <button onClick={() => void copyServiceMenu()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied === 'all' ? 'คัดลอกแล้ว' : 'Copy services'}</button>
         </div>
       </div>
 
       <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
         <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200">
-          <Lock className="h-4 w-4" /> Permission boundary
+          <Lock className="h-4 w-4" /> Action-layer boundary
         </div>
-        <p className="mt-3">หน้านี้ไม่เปิดเผย runtime key และไม่ใส่ปุ่มปลอม. ปุ่มทุกตัวพาไปใช้งาน agent, ดู proof หรือคัดลอกเมนูบริการได้จริง.</p>
+        <p className="mt-3">{truthBoundary}</p>
       </div>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900 p-5">
+        <div className="mb-3 flex items-center gap-2 text-sm font-bold text-slate-200"><ExternalLink className="h-4 w-4 text-indigo-400" /> Local Browser Proof</div>
+        <p className="mb-4 text-sm text-slate-500">กดเปิด route ใน browser เครื่องผู้ใช้เพื่อเก็บหลักฐานด้วยตา/สกรีนช็อตก่อน. นี่ไม่ใช่ remote browser automation.</p>
+        <div className="flex flex-col gap-2 md:flex-row">
+          <input value={browserUrl} onChange={(event) => setBrowserUrl(event.target.value)} placeholder="/product-ready หรือ https://..." className="min-w-0 flex-1 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none focus:border-indigo-500/40" />
+          <button onClick={openLocalBrowser} className="inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500"><Play className="h-4 w-4" /> เปิดดู</button>
+          <button onClick={() => void copyBrowserProofTask()} className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied === 'browser-task' ? 'คัดลอกแล้ว' : 'Copy task'}</button>
+        </div>
+      </section>
 
       <div className="relative">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-        <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="ค้นหาบริการ เช่น PR, runtime, production..." className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-indigo-500/40" />
+        <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="ค้นหา service เช่น browser, PR, runtime, Vercel..." className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-indigo-500/40" />
       </div>
 
       <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
         <table className="w-full text-left text-sm">
           <thead className="border-b border-slate-800 bg-slate-900/50 text-slate-500">
             <tr>
-              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Capability</th>
-              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Scope</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Service</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Benefit / Evidence</th>
               <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Status</th>
-              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider text-right">Proof</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider text-right">Endpoint / Secrets</th>
               <th className="px-6 py-4 text-center text-xs font-medium uppercase tracking-wider">Action</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
-            {rows.map((agent) => {
-              const ready = agent.target === 'chat';
-              return (
-                <tr key={agent.id} className="hover:bg-slate-800/20">
-                  <td className="px-6 py-4 font-medium text-slate-200">
-                    <div className="flex items-center gap-3">
-                      <div className="flex h-8 w-8 items-center justify-center rounded border border-slate-700 bg-slate-800">
-                        <Terminal className="h-4 w-4 text-indigo-400" />
-                      </div>
-                      <div>
-                        <p>{agent.name}</p>
-                        <p className="mt-0.5 font-mono text-xs text-slate-500">{agent.id}</p>
-                      </div>
+            {rows.map((service) => (
+              <tr key={service.id} className="hover:bg-slate-800/20">
+                <td className="px-6 py-4 font-medium text-slate-200">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-8 w-8 items-center justify-center rounded border border-slate-700 bg-slate-800">
+                      <Terminal className="h-4 w-4 text-indigo-400" />
                     </div>
-                  </td>
-                  <td className="px-6 py-4 text-slate-400">{agent.scope}</td>
-                  <td className="px-6 py-4">
-                    <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${ready ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400' : 'border-amber-500/20 bg-amber-500/10 text-amber-200'}`}>
-                      {agent.status}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-right text-xs text-slate-500">{agent.proof}</td>
-                  <td className="px-6 py-4 text-center">
-                    <button onClick={() => goTo(agent.target)} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">
-                      {ready ? 'ใช้งาน' : 'ดู proof'}
-                    </button>
-                  </td>
-                </tr>
-              );
-            })}
+                    <div>
+                      <p>{service.label}</p>
+                      <p className="mt-0.5 font-mono text-xs text-slate-500">{service.id}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-slate-400">
+                  <p>{service.userBenefit}</p>
+                  <p className="mt-1 text-xs text-slate-500">proof: {service.evidence.join(', ')}</p>
+                </td>
+                <td className="px-6 py-4">
+                  <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${statusClass(service.status)}`}>{service.status}</span>
+                </td>
+                <td className="px-6 py-4 text-right text-xs text-slate-500">
+                  <p className="font-mono">{service.endpoint || service.implementation}</p>
+                  <p>{service.requiredSecrets.length ? service.requiredSecrets.join(', ') : 'no secret'}</p>
+                </td>
+                <td className="px-6 py-4 text-center">
+                  {service.id === 'browser.local.open_url' ? (
+                    <button onClick={openLocalBrowser} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">{serviceActionLabel(service)}</button>
+                  ) : service.status === 'approval_required' ? (
+                    <button onClick={() => goTo('chat')} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">{serviceActionLabel(service)}</button>
+                  ) : service.status === 'quota_gated' ? (
+                    <button onClick={() => goTo('proof')} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">{serviceActionLabel(service)}</button>
+                  ) : (
+                    <button onClick={() => void copyService(service)} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">{copied === service.id ? 'Copied' : serviceActionLabel(service)}</button>
+                  )}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
 
       <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
         <h3 className="mb-2 flex items-center gap-2 font-semibold text-slate-200">
-          <Key className="h-4 w-4 text-slate-400" /> Runtime API key
+          <Key className="h-4 w-4 text-slate-400" /> Runtime key / remote browser
         </h3>
-        <p className="mb-4 text-sm text-slate-500">ผู้ใช้ได้ประโยชน์จากการเห็น boundary: key ไม่โชว์ใน UI, action ถูกผูกผ่าน server และหลักฐานออกมาเป็น PR/proof เท่านั้น.</p>
+        <p className="mb-4 text-sm text-slate-500">key ไม่โชว์ใน UI. Remote browser ต้องมี executor จริงก่อนจึงจะเปิด autonomous browsing ได้. ตอนนี้ผู้ใช้ยังได้ประโยชน์จาก local browser proof + PR evidence โดยไม่เปลือง Vercel quota.</p>
         <div className="flex gap-3">
-          <div className="flex flex-1 items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-2 font-mono text-sm text-slate-500">
-            server-side only
-          </div>
-          <button onClick={() => goTo('executions')} className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-200 hover:bg-slate-800">
-            ดูหลักฐาน
-          </button>
+          <div className="flex flex-1 items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-2 font-mono text-sm text-slate-500">server-side only / connector required</div>
+          <button onClick={() => goTo('executions')} className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-200 hover:bg-slate-800">ดูหลักฐาน</button>
         </div>
       </div>
     </div>

--- a/components/agents-view.tsx
+++ b/components/agents-view.tsx
@@ -1,32 +1,58 @@
 'use client';
 
-import React from 'react';
-import { Copy, Key, Lock, MoreHorizontal, Plus, Terminal } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { ArrowRight, Clipboard, Key, Lock, Search, Terminal } from 'lucide-react';
 
 const agentCapabilities = [
-  { id: 'app-builder-step-15', name: 'App Builder Planning Agent', status: 'planning-ready', scope: 'Goal, PRD, plan, gate, approval, handoff', proof: 'Step 15 API routes' },
-  { id: 'runtime-step-16', name: 'Action Runtime Executor', status: 'not-enabled', scope: 'Write files, run commands, test, build, deploy', proof: 'Missing Step 16 runtime evidence' },
-  { id: 'production-claim-gate', name: 'Production Claim Gate', status: 'blocked', scope: 'Production readiness claim', proof: 'Requires deployment + runtime proof ids' },
+  { id: 'app-builder-step-15', name: 'App Builder Planning Agent', status: 'พร้อมใช้งาน', scope: 'Goal, PRD, plan, gate, approval, handoff', proof: 'Step 15 API routes', target: 'chat' },
+  { id: 'runtime-step-16', name: 'Action Runtime Executor', status: 'ใช้หลังอนุมัติ', scope: 'สร้าง branch, เขียนไฟล์, เปิด PR', proof: 'GitHub PR evidence', target: 'chat' },
+  { id: 'production-claim-gate', name: 'Production Claim Gate', status: 'ประหยัด quota', scope: 'ตรวจ production readiness claim', proof: 'ใช้ Vercel เฉพาะรอบ proof', target: 'proof' },
 ];
 
+function goTo(hash: string) {
+  window.location.hash = hash;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
 export function AgentsView() {
+  const [query, setQuery] = useState('');
+  const [copied, setCopied] = useState(false);
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return agentCapabilities;
+    return agentCapabilities.filter((agent) => `${agent.name} ${agent.status} ${agent.scope} ${agent.proof}`.toLowerCase().includes(q));
+  }, [query]);
+
+  async function copyServiceMenu() {
+    const text = agentCapabilities.map((agent) => `${agent.name}\n- status: ${agent.status}\n- scope: ${agent.scope}\n- proof: ${agent.proof}`).join('\n\n');
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
   return (
     <div className="mx-auto max-w-6xl space-y-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Agents & Runtime</h1>
-          <p className="mt-1 text-slate-500">Capability inventory. Nothing here claims live execution unless runtime evidence exists.</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">บริการเอเจนต์</h1>
+          <p className="mt-1 text-slate-500">เลือกบริการที่ใช้งานได้จริง: สร้างแผน, อนุมัติ, เปิด PR, หรือเตรียม proof โดยไม่โชว์ key ลับ</p>
         </div>
-        <button disabled className="flex items-center gap-2 rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-slate-500">
-          <Plus className="h-4 w-4" /> New Agent disabled
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => goTo('chat')} className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">เริ่มใช้ Agent <ArrowRight className="h-4 w-4" /></button>
+          <button onClick={() => void copyServiceMenu()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy services'}</button>
+        </div>
       </div>
 
       <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
         <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200">
           <Lock className="h-4 w-4" /> Permission boundary
         </div>
-        <p className="mt-3">The App Builder Agent can prepare an approved handoff. Runtime execution, API keys, shell commands, file writes, and deployment require Step 16 evidence before the UI may call them active.</p>
+        <p className="mt-3">หน้านี้ไม่เปิดเผย runtime key และไม่ใส่ปุ่มปลอม. ปุ่มทุกตัวพาไปใช้งาน agent, ดู proof หรือคัดลอกเมนูบริการได้จริง.</p>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+        <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="ค้นหาบริการ เช่น PR, runtime, production..." className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-indigo-500/40" />
       </div>
 
       <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
@@ -41,8 +67,8 @@ export function AgentsView() {
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
-            {agentCapabilities.map((agent) => {
-              const ready = agent.status === 'planning-ready';
+            {rows.map((agent) => {
+              const ready = agent.target === 'chat';
               return (
                 <tr key={agent.id} className="hover:bg-slate-800/20">
                   <td className="px-6 py-4 font-medium text-slate-200">
@@ -64,8 +90,8 @@ export function AgentsView() {
                   </td>
                   <td className="px-6 py-4 text-right text-xs text-slate-500">{agent.proof}</td>
                   <td className="px-6 py-4 text-center">
-                    <button disabled className="text-slate-600">
-                      <MoreHorizontal className="mx-auto h-5 w-5" />
+                    <button onClick={() => goTo(agent.target)} className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-800">
+                      {ready ? 'ใช้งาน' : 'ดู proof'}
                     </button>
                   </td>
                 </tr>
@@ -79,13 +105,13 @@ export function AgentsView() {
         <h3 className="mb-2 flex items-center gap-2 font-semibold text-slate-200">
           <Key className="h-4 w-4 text-slate-400" /> Runtime API key
         </h3>
-        <p className="mb-4 text-sm text-slate-500">No runtime key is displayed in this UI. Keys must be bound server-side and proven by Step 16 runtime evidence before execution is enabled.</p>
+        <p className="mb-4 text-sm text-slate-500">ผู้ใช้ได้ประโยชน์จากการเห็น boundary: key ไม่โชว์ใน UI, action ถูกผูกผ่าน server และหลักฐานออกมาเป็น PR/proof เท่านั้น.</p>
         <div className="flex gap-3">
-          <div className="flex flex-1 cursor-not-allowed items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-2 font-mono text-sm text-slate-600">
-            not-bound-in-ui
+          <div className="flex flex-1 items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-2 font-mono text-sm text-slate-500">
+            server-side only
           </div>
-          <button disabled className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-600">
-            <Copy className="h-4 w-4" /> Copy disabled
+          <button onClick={() => goTo('executions')} className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-200 hover:bg-slate-800">
+            ดูหลักฐาน
           </button>
         </div>
       </div>

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -1,58 +1,91 @@
 'use client';
 
-import React from 'react';
-import { Activity, AlertTriangle, FileText, ShieldCheck, Terminal, Zap } from 'lucide-react';
+import React, { useState } from 'react';
+import { AlertTriangle, ArrowRight, Clipboard, FileText, ShieldCheck, Terminal } from 'lucide-react';
 
 const readinessItems = [
   {
-    label: 'Step 15 App Builder backend',
-    value: 'Present',
-    detail: 'Goal lock, PRD, plan, gate, approval, and handoff routes exist in repo.',
+    label: 'App Builder backend',
+    value: 'พร้อมใช้',
+    detail: 'สร้าง goal, PRD, plan, gate, approval และ runtime handoff ได้จาก API จริง',
     icon: FileText,
   },
   {
-    label: 'Action execution proof',
-    value: 'Missing',
-    detail: 'No shell/file/deploy execution proof is claimed from this dashboard.',
+    label: 'สร้าง PR',
+    value: 'พร้อมหลังอนุมัติ',
+    detail: 'สร้าง GitHub branch และ PR ก่อน ยังไม่ใช้ Vercel quota',
     icon: Terminal,
   },
   {
-    label: 'Production readiness claim',
-    value: 'Blocked',
-    detail: 'Requires CI, deployment, runtime proof ids, replay proof, and completion gate evidence.',
+    label: 'Production proof',
+    value: 'ใช้เมื่อจำเป็น',
+    detail: 'ค่อยใช้ Vercel preview/production เฉพาะรอบตรวจหลักฐานจริง',
     icon: AlertTriangle,
   },
   {
-    label: 'User protection boundary',
-    value: 'Visible',
-    detail: 'Missing evidence is shown as missing instead of converted into success metrics.',
+    label: 'User protection',
+    value: 'เปิดใช้งาน',
+    detail: 'หลักฐานที่ยังไม่มีจะแสดงว่ายังไม่มี ไม่แทนด้วยข้อมูลปลอม',
     icon: ShieldCheck,
   },
 ];
 
 const proofRows = [
-  ['Locked goal', 'Available after user creates App Builder job'],
-  ['PRD draft', 'Generated only after a job exists and plan is requested'],
-  ['Plan gate', 'PASS / REVIEW / BLOCK from Step 15 gate logic'],
-  ['Approval hash', 'Missing until user approves a visible plan'],
-  ['Runtime handoff', 'Authorization data only; not command execution'],
-  ['Execution evidence', 'Missing until Step 16 runtime records it'],
+  ['Locked goal', 'ได้หลังผู้ใช้สร้าง App Builder job'],
+  ['PRD draft', 'ได้หลังผู้ใช้กดสร้างแผน'],
+  ['Plan gate', 'PASS / REVIEW / BLOCK จาก gate logic'],
+  ['Approval hash', 'ได้หลังผู้ใช้อนุมัติแผนที่เห็นได้'],
+  ['Runtime handoff', 'เป็น authorization data ยังไม่ใช่ deploy'],
+  ['PR evidence', 'ได้หลังสร้าง GitHub PR สำเร็จ'],
 ];
 
+function goTo(hash: string) {
+  window.location.hash = hash;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
 export function DashboardView() {
+  const [copied, setCopied] = useState(false);
+
+  async function copyChecklist() {
+    const text = [
+      'DSG ONE customer delivery checklist',
+      '- Start from Build app',
+      '- Generate plan',
+      '- Approve visible plan',
+      '- Runtime handoff',
+      '- Create GitHub PR evidence',
+      '- Copy proof JSON',
+      '- Use Vercel only for preview/production proof when required',
+    ].join('\n');
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
   return (
     <div className="mx-auto max-w-6xl space-y-6">
-      <div>
-        <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Mission Control</h1>
-        <p className="mt-1 text-slate-500">User-safe overview of what is proven, what is missing, and what must not be claimed yet.</p>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">โปรเจกต์ของฉัน</h1>
+          <p className="mt-1 text-slate-500">เริ่มงานได้ทันที เห็นสถานะจริง และรู้ขั้นตอนถัดไปโดยไม่เสีย Vercel quota เกินจำเป็น</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => goTo('chat')} className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">
+            เริ่มสร้างแอป <ArrowRight className="h-4 w-4" />
+          </button>
+          <button onClick={() => void copyChecklist()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800">
+            <Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy checklist'}
+          </button>
+        </div>
       </div>
 
       <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-5 text-sm leading-7 text-amber-100">
         <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-amber-200">
-          <ShieldCheck className="h-4 w-4" /> No mock metrics
+          <ShieldCheck className="h-4 w-4" /> ใช้หลักฐานจริง ไม่ใช้ mock
         </div>
         <p className="mt-3">
-          This dashboard intentionally avoids fake execution counts, fake latency, fake 100% proof rates, and fake green readiness. Use the App Builder Agent tab to create real Step 15 records. Production readiness remains blocked until runtime evidence exists.
+          หน้า dashboard นี้ให้ประโยชน์กับลูกค้าโดยบอกว่าเริ่มตรงไหน ต้องกดอะไรต่อ และหลักฐานที่ได้คืออะไร: แผน, approval hash, runtime handoff และ GitHub PR ก่อนใช้ Vercel quota.
         </p>
       </div>
 
@@ -60,14 +93,14 @@ export function DashboardView() {
         {readinessItems.map((item) => {
           const Icon = item.icon;
           return (
-            <div key={item.label} className="rounded-xl border border-slate-800 bg-slate-900 p-5">
+            <button key={item.label} onClick={() => goTo(item.label === 'สร้าง PR' ? 'chat' : item.label === 'Production proof' ? 'proof' : 'executions')} className="rounded-xl border border-slate-800 bg-slate-900 p-5 text-left transition hover:border-indigo-500/40 hover:bg-slate-800/60">
               <div className="mb-3 flex items-start justify-between gap-3 text-slate-400">
                 <span className="text-sm font-medium">{item.label}</span>
                 <Icon className="h-4 w-4 text-indigo-400" />
               </div>
-              <div className="mb-2 text-2xl font-bold text-slate-200">{item.value}</div>
+              <div className="mb-2 text-xl font-bold text-slate-200">{item.value}</div>
               <div className="text-xs leading-5 text-slate-500">{item.detail}</div>
-            </div>
+            </button>
           );
         })}
       </div>
@@ -75,43 +108,43 @@ export function DashboardView() {
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div className="rounded-xl border border-slate-800 bg-slate-900 p-6 lg:col-span-2">
           <div className="mb-5 flex items-center justify-between gap-3">
-            <h3 className="font-semibold text-slate-200">Builder journey</h3>
-            <div className="rounded bg-slate-800 px-2 py-1 font-mono text-xs text-slate-400">/api/dsg/app-builder/*</div>
+            <h3 className="font-semibold text-slate-200">เส้นทางสร้างแอป</h3>
+            <button onClick={() => goTo('chat')} className="rounded bg-slate-800 px-3 py-1.5 text-xs font-bold text-slate-200 hover:bg-slate-700">เปิดหน้าใช้งาน</button>
           </div>
           <div className="space-y-3">
             {[
-              ['1', 'User goal', 'User describes what to build.'],
-              ['2', 'Goal lock', 'Server normalizes goal and records goalHash.'],
-              ['3', 'PRD + proposed plan', 'Server creates deterministic planning contract.'],
-              ['4', 'Gate + approval', 'Blocked plans cannot be approved. High-risk plans require approval.'],
-              ['5', 'Runtime handoff', 'Creates authorization data for Step 16. It does not execute actions.'],
+              ['1', 'บอกไอเดีย', 'ลูกค้าพิมพ์สิ่งที่อยากได้แบบภาษาคนทั่วไป'],
+              ['2', 'เลือกฟีเจอร์', 'ระบบช่วยตั้งค่าฟีเจอร์เริ่มต้นและแก้ได้ก่อนยืนยัน'],
+              ['3', 'สร้างแผน', 'API สร้าง PRD, proposed plan และ gate result'],
+              ['4', 'อนุมัติ', 'ผู้ใช้เห็นแผนก่อนกดอนุมัติ ไม่รันเองลับหลัง'],
+              ['5', 'สร้าง PR', 'สร้าง GitHub branch/PR เป็นหลักฐาน โดยยังไม่ deploy production'],
             ].map(([num, title, detail]) => (
-              <div key={num} className="grid grid-cols-[40px_1fr] gap-4 rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+              <button key={num} onClick={() => goTo('chat')} className="grid w-full grid-cols-[40px_1fr] gap-4 rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-left transition hover:border-indigo-500/30">
                 <div className="flex h-10 w-10 items-center justify-center rounded-full border border-indigo-500/30 bg-indigo-500/10 text-sm font-bold text-indigo-300">{num}</div>
                 <div>
                   <p className="font-semibold text-slate-200">{title}</p>
                   <p className="mt-1 text-sm text-slate-500">{detail}</p>
                 </div>
-              </div>
+              </button>
             ))}
           </div>
         </div>
 
         <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-          <h3 className="mb-4 font-semibold text-slate-200">Evidence ledger requirements</h3>
+          <h3 className="mb-4 font-semibold text-slate-200">สิ่งที่ลูกค้าจะจับต้องได้</h3>
           <div className="space-y-3">
             {proofRows.map(([label, detail]) => (
-              <div key={label} className="rounded border border-slate-800/70 bg-slate-950/50 p-3">
+              <button key={label} onClick={() => goTo(label === 'PR evidence' ? 'executions' : 'chat')} className="w-full rounded border border-slate-800/70 bg-slate-950/50 p-3 text-left transition hover:border-indigo-500/30">
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-sm font-medium text-slate-300">{label}</span>
-                  <span className="font-mono text-xs text-slate-500">tracked</span>
+                  <span className="font-mono text-xs text-slate-500">ดูได้</span>
                 </div>
                 <p className="mt-1 text-xs leading-5 text-slate-500">{detail}</p>
-              </div>
+              </button>
             ))}
           </div>
-          <button className="mt-4 w-full rounded-lg border border-slate-700 py-2 text-sm text-slate-300 transition hover:bg-slate-800">
-            Open App Builder Agent
+          <button onClick={() => goTo('chat')} className="mt-4 w-full rounded-lg border border-indigo-500/40 bg-indigo-500/10 py-2 text-sm font-bold text-indigo-200 transition hover:bg-indigo-500/20">
+            ไปสร้างแอปกับ Agent
           </button>
         </div>
       </div>

--- a/components/enterprise-proof-view.tsx
+++ b/components/enterprise-proof-view.tsx
@@ -1,74 +1,112 @@
 'use client';
 
-import React from 'react';
-import { FileText, CheckCircle2, Lock, Share2, DownloadCloud } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { CheckCircle2, Clipboard, DownloadCloud, FileText, Lock, Share2 } from 'lucide-react';
+
+function goTo(hash: string) {
+  window.location.hash = hash;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
 
 export function EnterpriseProofView() {
+  const [copied, setCopied] = useState(false);
+  const report = useMemo(() => ({
+    product: 'DSG ONE V1',
+    purpose: 'Customer handoff report for governed App Builder service',
+    safeClaim: 'Customer can create an approved app-builder plan and GitHub PR evidence before spending Vercel quota.',
+    notClaimedHere: ['PRODUCTION_VERIFIED', 'live generated-app runtime proof', 'Vercel production deploy from this UI change'],
+    userBenefit: [
+      'Start from a plain-language app idea',
+      'See feature choices before API calls',
+      'Approve a visible plan before runtime action',
+      'Receive GitHub PR evidence and copy/download proof',
+      'Use Vercel only when preview or production proof is actually required',
+    ],
+    nextSteps: [
+      'Use Build app screen',
+      'Generate and approve plan',
+      'Create PR evidence',
+      'Copy proof JSON from the evidence panel',
+      'Run preview/production proof only when needed',
+    ],
+  }), []);
+
+  const reportText = JSON.stringify(report, null, 2);
+
+  async function copyReport() {
+    await navigator.clipboard.writeText(reportText);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
+  function downloadReport() {
+    const blob = new Blob([reportText], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'dsg-one-customer-handoff-report.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
-      <div className="flex justify-between items-start">
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-100 items-center flex gap-2">
-            Enterprise Proof Surfaces
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">
+            ส่งมอบงานให้ลูกค้า
           </h1>
-          <p className="text-slate-500 mt-1">Audit-ready verification reports for both public and org-scoped evaluation.</p>
+          <p className="mt-1 text-slate-500">คัดลอกหรือดาวน์โหลดรายงาน proof boundary ได้ทันที โดยไม่ trigger Vercel deploy</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => goTo('chat')} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">สร้าง proof จากงานจริง</button>
+          <button onClick={() => void copyReport()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy report'}</button>
+          <button onClick={downloadReport} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><DownloadCloud className="h-4 w-4" /> Download JSON</button>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
-        
-        {/* Public Narrative */}
-        <div className="border border-slate-800 rounded-2xl bg-slate-900 p-8 flex flex-col items-start relative overflow-hidden group">
-          <div className="absolute top-0 right-0 p-32 bg-indigo-500/5 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none"></div>
-          
-          <div className="w-12 h-12 rounded-xl bg-slate-800 border border-slate-700 flex items-center justify-center mb-6">
-            <Share2 className="w-6 h-6 text-indigo-400" />
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="group relative flex flex-col items-start overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 p-8">
+          <div className="pointer-events-none absolute right-0 top-0 -mr-16 -mt-16 rounded-full bg-indigo-500/5 p-32 blur-3xl" />
+          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-xl border border-slate-700 bg-slate-800">
+            <Share2 className="h-6 w-6 text-indigo-400" />
           </div>
-          
-          <h2 className="text-xl font-bold text-slate-100 mb-2">Public Proof Narrative</h2>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            AI-readable narrative designed for customers, partners, and public evaluation. Safe to share externally and does not leak runtime secrets.
-          </p>
-          
-          <div className="mt-auto space-y-3 w-full">
-            <div className="bg-slate-950 px-4 py-3 rounded border border-slate-800 flex justify-between items-center text-sm">
-              <span className="font-mono text-slate-400">/enterprise-proof/report</span>
-              <span className="text-emerald-400 font-medium flex items-center gap-1.5"><CheckCircle2 className="w-4 h-4"/> Public</span>
+          <h2 className="mb-2 text-xl font-bold text-slate-100">Customer Proof Narrative</h2>
+          <p className="mb-6 text-sm leading-relaxed text-slate-400">รายงานที่ส่งให้ลูกค้าได้: อธิบายว่าใช้งานอะไรได้จริง, ขอบเขต claim อยู่ตรงไหน, และควรใช้ Vercel quota เมื่อไร.</p>
+          <div className="mt-auto w-full space-y-3">
+            <div className="flex items-center justify-between rounded border border-slate-800 bg-slate-950 px-4 py-3 text-sm">
+              <span className="font-mono text-slate-400">handoff-report.json</span>
+              <span className="flex items-center gap-1.5 font-medium text-emerald-400"><CheckCircle2 className="h-4 w-4"/> Ready</span>
             </div>
-            <button className="w-full py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg font-medium transition shadow-[0_0_15px_rgba(79,70,229,0.3)]">
-              Generate Public Proof
+            <button onClick={() => void copyReport()} className="w-full rounded-lg bg-indigo-600 py-2.5 font-medium text-white shadow-[0_0_15px_rgba(79,70,229,0.3)] transition hover:bg-indigo-500">
+              Copy Customer Report
             </button>
           </div>
         </div>
 
-        {/* Verified Proof */}
-        <div className="border border-slate-800 rounded-2xl bg-[#0b101e] p-8 flex flex-col items-start relative overflow-hidden ring-1 ring-inset ring-indigo-500/20">
-          <div className="absolute top-0 right-0 p-32 bg-emerald-500/5 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none"></div>
-          
-          <div className="w-12 h-12 rounded-xl bg-indigo-500/10 border border-indigo-500/30 flex items-center justify-center mb-6">
-            <Lock className="w-6 h-6 text-indigo-400" />
+        <div className="relative flex flex-col items-start overflow-hidden rounded-2xl border border-slate-800 bg-[#0b101e] p-8 ring-1 ring-inset ring-indigo-500/20">
+          <div className="pointer-events-none absolute right-0 top-0 -mr-16 -mt-16 rounded-full bg-emerald-500/5 p-32 blur-3xl" />
+          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-xl border border-indigo-500/30 bg-indigo-500/10">
+            <Lock className="h-6 w-6 text-indigo-400" />
           </div>
-          
-          <h2 className="text-xl font-bold text-slate-100 mb-2 flex items-center gap-2">
-            Verified Runtime Evidence
-          </h2>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            Org-scoped, authenticated evidence layer. Backed by real runtime execution logs, tampering checks, and complete policy decision traces.
-          </p>
-          
-          <div className="mt-auto space-y-3 w-full">
-            <div className="bg-slate-950 px-4 py-3 rounded border border-indigo-500/20 flex justify-between items-center text-sm">
-              <span className="font-mono text-slate-400">/enterprise-proof/verified</span>
-              <span className="text-indigo-400 font-medium flex items-center gap-1.5"><Lock className="w-4 h-4"/> Auth Required</span>
+          <h2 className="mb-2 flex items-center gap-2 text-xl font-bold text-slate-100">Verified Runtime Evidence</h2>
+          <p className="mb-6 text-sm leading-relaxed text-slate-400">ส่วนนี้พาผู้ใช้ไปเก็บหลักฐานจริงก่อน: PR, branch, generated files, auditWritten, แล้วค่อยใช้ preview/production proof เมื่อจำเป็น.</p>
+          <div className="mt-auto w-full space-y-3">
+            <div className="flex items-center justify-between rounded border border-indigo-500/20 bg-slate-950 px-4 py-3 text-sm">
+              <span className="font-mono text-slate-400">PR evidence first</span>
+              <span className="flex items-center gap-1.5 font-medium text-indigo-400"><Lock className="h-4 w-4"/> Quota safe</span>
             </div>
-            <button className="w-full py-2.5 bg-slate-800 hover:bg-slate-700 text-slate-200 border border-slate-700 rounded-lg font-medium transition flex items-center justify-center gap-2">
-              <DownloadCloud className="w-4 h-4" /> Download Runtime Audit
+            <button onClick={() => goTo('executions')} className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-800 py-2.5 font-medium text-slate-200 transition hover:bg-slate-700">
+              <FileText className="h-4 w-4" /> Open Evidence Map
             </button>
           </div>
         </div>
-
       </div>
 
+      <div className="rounded-xl border border-slate-800 bg-slate-900 p-6">
+        <h3 className="mb-3 font-semibold text-slate-200">รายงานที่ดาวน์โหลดได้</h3>
+        <pre className="max-h-80 overflow-auto rounded-xl border border-slate-800 bg-slate-950 p-4 text-xs leading-5 text-slate-400">{reportText}</pre>
+      </div>
     </div>
   );
 }

--- a/components/executions-view.tsx
+++ b/components/executions-view.tsx
@@ -1,24 +1,60 @@
 'use client';
 
-import React from 'react';
-import { AlertCircle, CheckCircle2, Clock, Search, ShieldCheck } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Clipboard, Download, Search, ShieldCheck } from 'lucide-react';
 
 const evidenceRows = [
-  { id: 'goal-lock', name: 'Goal lock record', state: 'Available through App Builder API', proof: 'goalHash' },
-  { id: 'prd-plan', name: 'PRD and proposed plan', state: 'Available after Generate PRD + plan', proof: 'proposed_plan + gate_result' },
-  { id: 'approval', name: 'Approval record', state: 'Available after user approves visible plan', proof: 'approvalHash' },
-  { id: 'handoff', name: 'Runtime handoff', state: 'Available after approval', proof: 'planHash + allowed tools' },
-  { id: 'execution', name: 'Action execution log', state: 'Missing until Step 16 runtime exists', proof: 'not claimed' },
-  { id: 'deploy', name: 'Preview or production deployment proof', state: 'Missing until deploy proof is recorded', proof: 'not claimed' },
+  { id: 'goal-lock', name: 'Goal lock record', state: 'ได้จาก App Builder API', proof: 'goalHash', action: 'สร้างงานในหน้า สร้างแอป' },
+  { id: 'prd-plan', name: 'PRD and proposed plan', state: 'ได้หลัง Generate plan', proof: 'proposed_plan + gate_result', action: 'ตรวจแผนก่อนอนุมัติ' },
+  { id: 'approval', name: 'Approval record', state: 'ได้หลังอนุมัติแผน', proof: 'approvalHash', action: 'กดอนุมัติแผน' },
+  { id: 'handoff', name: 'Runtime handoff', state: 'ได้หลัง approval', proof: 'planHash + allowed tools', action: 'ส่งเข้า runtime' },
+  { id: 'pr', name: 'GitHub PR evidence', state: 'ได้หลัง Create PR', proof: 'pullRequestUrl + branchName', action: 'สร้าง PR แล้ว copy proof JSON' },
+  { id: 'deploy', name: 'Preview/Production proof', state: 'ใช้เมื่อจำเป็นเท่านั้น', proof: 'ยังไม่ใช้ Vercel quota', action: 'deploy เฉพาะรอบ proof' },
 ];
 
+function goTo(hash: string) {
+  window.location.hash = hash;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
 export function ExecutionsView() {
+  const [query, setQuery] = useState('');
+  const [copied, setCopied] = useState(false);
+  const visibleRows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return evidenceRows;
+    return evidenceRows.filter((row) => `${row.name} ${row.state} ${row.proof} ${row.action}`.toLowerCase().includes(q));
+  }, [query]);
+
+  const proofText = useMemo(() => visibleRows.map((row) => `${row.name}: ${row.state} | ${row.proof} | next=${row.action}`).join('\n'), [visibleRows]);
+
+  async function copyEvidenceMap() {
+    await navigator.clipboard.writeText(proofText);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
+  function downloadEvidenceMap() {
+    const blob = new Blob([proofText], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'dsg-evidence-map.txt';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="mx-auto max-w-6xl space-y-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Execution & Evidence Boundary</h1>
-          <p className="mt-1 text-slate-500">No seeded execution rows. This view shows what proof exists or remains missing.</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">หลักฐานงาน</h1>
+          <p className="mt-1 text-slate-500">ค้นหา คัดลอก หรือดาวน์โหลดแผนที่หลักฐาน เพื่อส่งให้ลูกค้า/ทีมตรวจได้ทันที</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => goTo('chat')} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">สร้าง PR evidence</button>
+          <button onClick={() => void copyEvidenceMap()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy map'}</button>
+          <button onClick={downloadEvidenceMap} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Download className="h-4 w-4" /> Download</button>
         </div>
       </div>
 
@@ -27,7 +63,7 @@ export function ExecutionsView() {
           <AlertCircle className="h-4 w-4" /> Claim boundary
         </div>
         <p className="mt-3">
-          Previous seeded request ids and allowed/blocked outcomes were removed because they looked like real audit events. Real executions must come from runtime evidence, audit ledger rows, deployment proof, and replay proof.
+          หน้านี้ไม่แสดง execution ปลอม. สิ่งที่ผู้ใช้ทำได้จริงคือค้นหาแผนที่หลักฐาน, copy/download รายการ proof และกลับไปสร้าง GitHub PR ผ่าน flow ที่อนุมัติแล้ว.
         </p>
       </div>
 
@@ -36,14 +72,12 @@ export function ExecutionsView() {
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
           <input
             type="text"
-            placeholder="Search will connect to real evidence once Step 16 runtime evidence exists..."
-            disabled
-            className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-500 outline-none placeholder:text-slate-600"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="ค้นหา proof เช่น approval, PR, Vercel, handoff..."
+            className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-indigo-500/40"
           />
         </div>
-        <button disabled className="rounded-lg border border-slate-800 bg-slate-900 px-4 py-2 text-sm text-slate-600">
-          Export disabled until evidence exists
-        </button>
       </div>
 
       <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
@@ -53,22 +87,24 @@ export function ExecutionsView() {
               <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Evidence item</th>
               <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Current state</th>
               <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">Proof field</th>
-              <th className="px-6 py-4 text-right text-xs font-medium uppercase tracking-wider">Claim status</th>
+              <th className="px-6 py-4 text-xs font-medium uppercase tracking-wider">User action</th>
+              <th className="px-6 py-4 text-right text-xs font-medium uppercase tracking-wider">Status</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
-            {evidenceRows.map((row) => {
-              const missing = row.proof === 'not claimed';
+            {visibleRows.map((row) => {
+              const ready = row.id !== 'deploy';
               return (
                 <tr key={row.id} className="hover:bg-slate-800/20">
                   <td className="px-6 py-4 font-medium text-slate-200">{row.name}</td>
                   <td className="px-6 py-4 text-slate-400">{row.state}</td>
                   <td className="px-6 py-4 font-mono text-xs text-slate-500">{row.proof}</td>
+                  <td className="px-6 py-4 text-slate-400">{row.action}</td>
                   <td className="px-6 py-4 text-right">
-                    <span className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold ${missing ? 'border-amber-500/25 bg-amber-500/10 text-amber-200' : 'border-emerald-500/25 bg-emerald-500/10 text-emerald-300'}`}>
-                      {missing ? <Clock className="h-3.5 w-3.5" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
-                      {missing ? 'Missing' : 'Step 15 proof field'}
-                    </span>
+                    <button onClick={() => goTo(ready ? 'chat' : 'proof')} className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold ${ready ? 'border-emerald-500/25 bg-emerald-500/10 text-emerald-300' : 'border-amber-500/25 bg-amber-500/10 text-amber-200'}`}>
+                      {ready ? <CheckCircle2 className="h-3.5 w-3.5" /> : <AlertCircle className="h-3.5 w-3.5" />}
+                      {ready ? 'ไปทำต่อ' : 'รอ proof'}
+                    </button>
                   </td>
                 </tr>
               );
@@ -78,8 +114,8 @@ export function ExecutionsView() {
       </div>
 
       <div className="rounded-xl border border-slate-800 bg-slate-900 p-5 text-sm leading-7 text-slate-400">
-        <div className="flex items-center gap-2 font-bold text-slate-200"><ShieldCheck className="h-4 w-4 text-indigo-400" /> Consumer-safe rule</div>
-        <p className="mt-2">If evidence is missing, the UI must say missing. It must not convert demo data into production success, uptime, latency, audit completeness, or execution counts.</p>
+        <div className="flex items-center gap-2 font-bold text-slate-200"><ShieldCheck className="h-4 w-4 text-indigo-400" /> ประโยชน์ที่ผู้ใช้เห็นได้</div>
+        <p className="mt-2">ผู้ใช้รู้ว่าหลักฐานไหนต้องมี, ต้องกดอะไรต่อ, และสามารถคัดลอก/ดาวน์โหลดหลักฐานเพื่อส่งตรวจได้โดยไม่ต้องเดา.</p>
       </div>
     </div>
   );

--- a/components/governance-view.tsx
+++ b/components/governance-view.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React from 'react';
-import { AlertTriangle, Database, FileWarning, Key, Lock, RefreshCcw } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { AlertTriangle, Clipboard, Database, Download, FileWarning, Key, Lock, RefreshCcw, Search } from 'lucide-react';
 
 const policyFields = [
-  { id: 'policy_registry', name: 'Policy registry', state: 'Evidence missing', proof: 'No verified policy rows are connected to this UI yet.' },
-  { id: 'policy_infractions', name: 'Policy infractions', state: 'Not claimed', proof: 'No real 30-day violation ledger has been wired into this screen.' },
-  { id: 'rule_sync', name: 'Rule sync status', state: 'Not connected', proof: 'No sync job evidence or timestamp is available in this view.' },
+  { id: 'policy_registry', name: 'Policy registry', state: 'ต้องผูก evidence source', proof: 'Supabase/API row source สำหรับ policy, rule และ version history', next: 'ใช้หน้า สร้างแอป เพื่อสร้าง proof ก่อน' },
+  { id: 'policy_infractions', name: 'Policy infractions', state: 'ยังไม่เคลมตัวเลข', proof: 'ต้องมี audit rows พร้อม timestamp, actor, rule id, decision และ evidence hash', next: 'ดูหลักฐานที่ต้องเก็บ' },
+  { id: 'rule_sync', name: 'Rule sync status', state: 'รอ sync proof', proof: 'ต้องมี sync job id, status, source hash และ updated_at', next: 'ดาวน์โหลด governance checklist' },
 ];
 
 const requiredEvidence = [
@@ -15,52 +15,97 @@ const requiredEvidence = [
   { label: 'Sync proof', detail: 'Last sync job id, status, source hash, and updated_at proof.' },
 ];
 
+function goTo(hash: string) {
+  window.location.hash = hash;
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
 export function GovernanceView() {
+  const [query, setQuery] = useState('');
+  const [copied, setCopied] = useState(false);
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return policyFields;
+    return policyFields.filter((field) => `${field.name} ${field.state} ${field.proof} ${field.next}`.toLowerCase().includes(q));
+  }, [query]);
+
+  const checklist = useMemo(() => [
+    'DSG Governance proof checklist',
+    ...requiredEvidence.map((item) => `- ${item.label}: ${item.detail}`),
+    '',
+    'Rule: do not show policy counts, infraction counts, or green sync state until real evidence exists.',
+  ].join('\n'), []);
+
+  async function copyChecklist() {
+    await navigator.clipboard.writeText(checklist);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
+  function downloadChecklist() {
+    const blob = new Blob([checklist], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'dsg-governance-checklist.txt';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="mx-auto max-w-6xl space-y-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">Governance Policies</h1>
-          <p className="mt-1 text-slate-500">Shows only verified governance evidence. Missing data stays missing; no demo counts are displayed.</p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-100">กำกับดูแล</h1>
+          <p className="mt-1 text-slate-500">ผู้ใช้เห็นชัดว่าต้องมีหลักฐานอะไร ก่อนระบบจะแสดงตัวเลข policy หรือ claim สีเขียว</p>
         </div>
-        <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-bold uppercase tracking-wide text-amber-100">No mock metrics</span>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => goTo('executions')} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-bold text-white hover:bg-indigo-500">ดูหลักฐาน</button>
+          <button onClick={() => void copyChecklist()} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Clipboard className="h-4 w-4" /> {copied ? 'คัดลอกแล้ว' : 'Copy checklist'}</button>
+          <button onClick={downloadChecklist} className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-bold text-slate-200 hover:bg-slate-800"><Download className="h-4 w-4" /> Download</button>
+        </div>
       </div>
 
       <div className="rounded-2xl border border-rose-500/25 bg-rose-500/10 p-5 text-sm leading-7 text-rose-100">
         <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-rose-200">
           <AlertTriangle className="h-4 w-4" /> Truth boundary
         </div>
-        <p className="mt-3">The previous numbers such as active policy count, 30-day infractions, and synced status were unverified UI seed data. They are removed until real policy/audit/sync evidence exists.</p>
+        <p className="mt-3">ไม่แสดง active policy count, 30-day infractions หรือ synced status ถ้ายังไม่มี row/source จริง. ผู้ใช้กด copy/download checklist ไปใช้เก็บหลักฐานได้ทันที.</p>
       </div>
 
-      <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         {[
-          { label: 'Active Policies', val: 'Evidence missing', icon: Lock },
-          { label: 'Policy Infractions (30d)', val: 'Not claimed', icon: FileWarning, color: 'text-rose-400' },
-          { label: 'Rule Sync Status', val: 'Not connected', icon: RefreshCcw, color: 'text-amber-400' },
+          { label: 'Active Policies', val: 'รอ evidence source', icon: Lock },
+          { label: 'Policy Infractions', val: 'ยังไม่เคลม', icon: FileWarning, color: 'text-rose-400' },
+          { label: 'Rule Sync Status', val: 'รอ sync proof', icon: RefreshCcw, color: 'text-amber-400' },
         ].map((item) => {
           const Icon = item.icon;
           return (
-            <div key={item.label} className="rounded-xl border border-slate-800 bg-slate-900 p-5">
+            <button key={item.label} onClick={() => goTo('executions')} className="rounded-xl border border-slate-800 bg-slate-900 p-5 text-left transition hover:border-indigo-500/40 hover:bg-slate-800/60">
               <div className="mb-2 flex items-start justify-between text-slate-400">
                 <span className="text-sm font-medium">{item.label}</span>
                 <Icon className={`h-4 w-4 ${item.color || 'text-slate-500'}`} />
               </div>
               <div className="text-xl font-black text-slate-200">{item.val}</div>
-              <p className="mt-2 text-xs leading-5 text-slate-500">Connect real governance rows before showing counts or green status.</p>
-            </div>
+              <p className="mt-2 text-xs leading-5 text-slate-500">กดเพื่อดู evidence map ที่ต้องเก็บก่อนแสดงตัวเลข</p>
+            </button>
           );
         })}
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+        <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="ค้นหา governance proof เช่น policy, sync, audit..." className="w-full rounded-lg border border-slate-800 bg-slate-900 pl-10 pr-4 py-2 text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-indigo-500/40" />
       </div>
 
       <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
         <div className="flex items-center justify-between border-b border-slate-800 px-6 py-4">
           <h3 className="font-semibold text-slate-200">Governance evidence fields</h3>
-          <button disabled className="text-sm font-medium text-slate-600">Create Rule disabled</button>
+          <button onClick={() => goTo('chat')} className="text-sm font-bold text-indigo-300 hover:text-indigo-200">สร้าง proof จากงานจริง</button>
         </div>
         <div className="divide-y divide-slate-800">
-          {policyFields.map((field) => (
-            <div key={field.id} className="flex items-center justify-between gap-4 px-6 py-4">
+          {rows.map((field) => (
+            <div key={field.id} className="flex flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
               <div className="flex items-center gap-4">
                 <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-700 bg-slate-800">
                   <Key className="h-5 w-5 text-indigo-400" />
@@ -70,7 +115,7 @@ export function GovernanceView() {
                   <p className="mt-1 text-xs leading-5 text-slate-500">{field.proof}</p>
                 </div>
               </div>
-              <span className="rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wider text-amber-100">{field.state}</span>
+              <button onClick={() => goTo(field.id === 'policy_registry' ? 'chat' : 'executions')} className="rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wider text-amber-100 hover:bg-amber-500/20">{field.state}</button>
             </div>
           ))}
         </div>
@@ -82,10 +127,10 @@ export function GovernanceView() {
         </div>
         <div className="mt-4 grid gap-3 md:grid-cols-3">
           {requiredEvidence.map((item) => (
-            <div key={item.label} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+            <button key={item.label} onClick={() => goTo('executions')} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-left transition hover:border-indigo-500/30">
               <p className="font-semibold text-slate-200">{item.label}</p>
               <p className="mt-2 text-xs leading-5 text-slate-500">{item.detail}</p>
-            </div>
+            </button>
           ))}
         </div>
       </div>

--- a/components/guided-app-builder-view.tsx
+++ b/components/guided-app-builder-view.tsx
@@ -1,7 +1,19 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { CheckCircle2, ExternalLink, Loader2, Send, XCircle } from 'lucide-react';
+import {
+  CheckCircle2,
+  Clipboard,
+  ExternalLink,
+  FileText,
+  GitBranch,
+  Loader2,
+  Play,
+  Send,
+  ShieldCheck,
+  Sparkles,
+  XCircle,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type ApiResult<T> = { ok: true; data: T } | { ok: false; error: { code?: string; message?: string } };
@@ -13,34 +25,59 @@ type BuilderJob = {
   status: string;
   claimStatus: string;
   goal?: { goalHash: string; normalizedGoal: string };
-  prd?: { summary: string };
+  prd?: { title?: string; summary: string };
   proposedPlan?: { steps: Array<{ id: string; title: string; phase: string; riskLevel: string; expectedEvidence: string[] }> };
-  gateResult?: { status: string; riskLevel: string };
+  gateResult?: { status: string; riskLevel: string; approvalRequired?: boolean };
+  planHash?: string;
   approvalHash?: string;
 };
 
 type Handoff = { runtimeStatus: string; planHash: string; approvalHash: string };
 type ToolCall = {
   status: string;
-  output: { pullRequestUrl: string; pullRequestNumber: number; repository: string; branchName: string; generatedFiles: unknown[] };
+  claimStatus: string;
+  output: {
+    pullRequestUrl: string;
+    pullRequestNumber: number;
+    repository: string;
+    branchName: string;
+    generatedFiles: Array<{ path: string; evidenceKind: string }>;
+  };
   evidence: { auditWritten: boolean; note: string };
+  notification?: { title: string; message: string; nextAction: string };
 };
 
 const TOOL_NAME = 'dsg.app_builder.launch_agent_runtime';
+const DEFAULT_WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
+const DEFAULT_ACTOR_ID = 'customer';
+
 const stylesBase = ['มือถือก่อน', 'อ่านง่าย', 'เรียบหรู', 'ทอง / แดง / เงิน'];
 const constraints = [
+  'ใช้เฉพาะ endpoint และข้อมูลจริงของระบบ',
   'ห้ามใช้ mock data เป็นหลักฐาน',
   'ห้ามเคลม production verified ถ้ายังไม่มี proof ครบ',
-  'ต้องแสดงเฉพาะข้อมูลจาก endpoint จริงหรือแหล่งที่อ้างอิงได้',
+  'ประหยัด Vercel quota: flow นี้สร้าง GitHub PR ก่อน ยังไม่ trigger production deploy',
   'ต้องออกแบบ mobile-first และอ่านง่าย',
-  'ใช้โทนสีทอง แดง และเงินสำหรับสถานะหลัก',
 ];
 
+const claimCopy: Record<string, { label: string; tone: 'muted' | 'gold' | 'red' | 'silver'; next: string }> = {
+  NOT_STARTED: { label: 'ยังไม่เริ่ม', tone: 'silver', next: 'เริ่มจากไอเดียแอปของคุณ' },
+  PLANNED_ONLY: { label: 'มีแผนแล้ว', tone: 'silver', next: 'ตรวจแผนและกดอนุมัติ' },
+  APPROVED_ONLY: { label: 'อนุมัติแล้ว', tone: 'gold', next: 'ส่งเข้า runtime เพื่อสร้าง branch/PR' },
+  ENVIRONMENT_READY: { label: 'runtime พร้อม', tone: 'gold', next: 'เริ่มสร้างแอปเป็น PR' },
+  IMPLEMENTED_UNVERIFIED: { label: 'สร้างโค้ดแล้ว รอตรวจ', tone: 'gold', next: 'รัน CI, apply migration, ตรวจ preview เฉพาะเมื่อจำเป็น เพื่อประหยัด Vercel quota' },
+  PREVIEW_READY: { label: 'preview พร้อมตรวจ', tone: 'gold', next: 'ตรวจ flow จริงก่อนยกระดับ claim' },
+  DEPLOYABLE: { label: 'พร้อม deploy', tone: 'gold', next: 'ใช้ production deploy เฉพาะรอบ proof สุดท้าย' },
+  PRODUCTION_BLOCKED: { label: 'ยังขาดหลักฐาน production', tone: 'red', next: 'แนบ live runtime proof, PR evidence, audit row และ production-flow proof' },
+  PRODUCTION_VERIFIED: { label: 'production verified', tone: 'gold', next: 'เก็บ proof artifact และ monitoring ต่อเนื่อง' },
+};
+
 function optionsFor(idea: string) {
-  const v = idea.toLowerCase();
-  if (/todo|task|งาน/.test(v)) return ['เพิ่มงาน', 'แก้งาน', 'ลบงาน', 'ติ๊กว่าเสร็จแล้ว', 'ค้นหางาน', 'กรองงานค้าง'];
-  if (/บัญชี|รายรับ|รายจ่าย|expense|income/.test(v)) return ['เพิ่มรายการ', 'แก้รายการ', 'ลบรายการ', 'แยกรายรับ/รายจ่าย', 'แสดงยอดรวม', 'กรองตามเดือน'];
-  if (/จอง|queue|booking|คิว/.test(v)) return ['สร้างคิว', 'แก้ไขคิว', 'ยกเลิกคิว', 'ดูตารางเวลา', 'สถานะการจอง', 'แจ้งเตือน'];
+  const value = idea.toLowerCase();
+  if (/todo|task|งาน/.test(value)) return ['เพิ่มงาน', 'แก้งาน', 'ลบงาน', 'ติ๊กว่าเสร็จแล้ว', 'ค้นหางาน', 'กรองงานค้าง'];
+  if (/บัญชี|รายรับ|รายจ่าย|expense|income/.test(value)) return ['เพิ่มรายการ', 'แก้รายการ', 'ลบรายการ', 'แยกรายรับ/รายจ่าย', 'แสดงยอดรวม', 'กรองตามเดือน'];
+  if (/จอง|queue|booking|คิว/.test(value)) return ['สร้างคิว', 'แก้ไขคิว', 'ยกเลิกคิว', 'ดูตารางเวลา', 'สถานะการจอง', 'แจ้งเตือน'];
+  if (/ร้าน|shop|store|สินค้า|ขาย/.test(value)) return ['เพิ่มสินค้า', 'แก้ไขสินค้า', 'ดูออเดอร์', 'ค้นหาสินค้า', 'สถานะคำสั่งซื้อ', 'รายงานยอดขาย'];
   return ['เพิ่มข้อมูล', 'แก้ข้อมูล', 'ลบข้อมูล', 'ดูรายการ', 'ค้นหา', 'แสดงสถานะ'];
 }
 
@@ -49,11 +86,28 @@ function readResult<T>(json: ApiResult<T>): T {
   return json.data;
 }
 
-function Chip({ ok, label, detail }: { ok: boolean; label: string; detail: string }) {
+function toneClass(tone: 'muted' | 'gold' | 'red' | 'silver') {
+  if (tone === 'gold') return 'border-[#d6a63a]/35 bg-[#d6a63a]/10 text-[#f5d27a]';
+  if (tone === 'red') return 'border-[#b4232b]/35 bg-[#b4232b]/10 text-[#ffb4b8]';
+  if (tone === 'silver') return 'border-[#c8c8c8]/20 bg-[#c8c8c8]/10 text-[#d9d9d9]';
+  return 'border-[#c8c8c8]/15 bg-[#111113] text-[#c8c8c8]';
+}
+
+function StatusPill({ status }: { status?: string }) {
+  const item = claimCopy[status || 'NOT_STARTED'] ?? { label: status || 'pending', tone: 'silver' as const, next: 'ตรวจรายละเอียดต่อ' };
   return (
-    <div className={cn('min-w-[116px] rounded-xl border px-3 py-2', ok ? 'border-[#d6a63a]/35 bg-[#d6a63a]/10 text-[#f5d27a]' : 'border-[#b4232b]/35 bg-[#b4232b]/10 text-[#ffb4b8]')}>
+    <span className={cn('inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-black', toneClass(item.tone))}>
+      {item.tone === 'red' ? <XCircle className="h-3.5 w-3.5" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+      {item.label}
+    </span>
+  );
+}
+
+function StepCard({ ok, label, detail }: { ok: boolean; label: string; detail: string }) {
+  return (
+    <div className={cn('min-w-[140px] rounded-xl border px-3 py-2', ok ? toneClass('gold') : toneClass('muted'))}>
       <div className="flex items-center justify-between gap-2 text-xs font-black">
-        <span>{label}</span>{ok ? <CheckCircle2 className="h-3.5 w-3.5" /> : <XCircle className="h-3.5 w-3.5" />}
+        <span>{label}</span>{ok ? <CheckCircle2 className="h-3.5 w-3.5" /> : <XCircle className="h-3.5 w-3.5 opacity-60" />}
       </div>
       <p className="mt-1 truncate text-[11px] opacity-80">{detail}</p>
     </div>
@@ -61,105 +115,264 @@ function Chip({ ok, label, detail }: { ok: boolean; label: string; detail: strin
 }
 
 function Pick({ active, text, onClick }: { active: boolean; text: string; onClick: () => void }) {
-  return <button onClick={onClick} className={cn('rounded-xl border px-3 py-2 text-xs font-bold', active ? 'border-[#d6a63a]/45 bg-[#d6a63a]/15 text-[#f5d27a]' : 'border-[#c8c8c8]/15 bg-[#111113] text-[#c8c8c8]')}>{active ? '✓ ' : '+ '}{text}</button>;
+  return (
+    <button onClick={onClick} className={cn('rounded-xl border px-3 py-2 text-xs font-bold transition-colors', active ? toneClass('gold') : toneClass('muted'))}>
+      {active ? '✓ ' : '+ '}{text}
+    </button>
+  );
 }
 
 export function GuidedAppBuilderView() {
-  const [workspaceId, setWorkspaceId] = useState('demo-workspace');
-  const [actorId, setActorId] = useState('operator');
   const [stage, setStage] = useState<Stage>('idea');
   const [input, setInput] = useState('');
   const [idea, setIdea] = useState('');
   const [features, setFeatures] = useState<string[]>([]);
   const [styles, setStyles] = useState<string[]>(stylesBase);
   const [notes, setNotes] = useState<string[]>([]);
-  const [messages, setMessages] = useState<Msg[]>([{ id: 'm0', role: 'agent', text: 'อยากสร้างแอปอะไรครับ? พิมพ์สั้น ๆ ก็ได้ เช่น Todo, รายรับรายจ่าย, จองคิว หรือร้านค้า เดี๋ยวผมถามต่อเอง' }]);
+  const [messages, setMessages] = useState<Msg[]>([{ id: 'm0', role: 'agent', text: 'อยากสร้างแอปอะไรครับ? พิมพ์สั้น ๆ เช่น Todo, รายรับรายจ่าย, จองคิว หรือร้านค้า แล้วผมจะช่วยจัดฟีเจอร์ให้' }]);
   const [job, setJob] = useState<BuilderJob | null>(null);
   const [handoff, setHandoff] = useState<Handoff | null>(null);
   const [toolCall, setToolCall] = useState<ToolCall | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const featureOptions = useMemo(() => optionsFor(idea), [idea]);
   const goal = useMemo(() => `สร้าง${idea || 'แอปใหม่'} โดยให้ผู้ใช้ทำงานหลักได้: ${(features.length ? features : ['ฟีเจอร์ที่ผู้ใช้เลือก']).join(', ')}. รูปแบบหน้าจอ: ${styles.join(', ')}. ต้องแสดงเฉพาะข้อมูลจริง มีหลักฐานการทำงาน และไม่ใช้ข้อมูลจำลอง.${notes.length ? ` หมายเหตุ: ${notes.join(' | ')}` : ''}`, [features, idea, notes, styles]);
-  const criteria = useMemo(() => [...(features.length ? features.map((f) => `ผู้ใช้${f}ได้`) : ['ผู้ใช้ทำงานหลักของแอปได้']), 'หน้าจออ่านง่ายบนมือถือ', 'มีผลลัพธ์หรือหลักฐานที่ตรวจสอบได้'], [features]);
+  const criteria = useMemo(() => [...(features.length ? features.map((feature) => `ผู้ใช้${feature}ได้`) : ['ผู้ใช้ทำงานหลักของแอปได้']), 'หน้าจออ่านง่ายบนมือถือ', 'มีผลลัพธ์หรือหลักฐานที่ตรวจสอบได้'], [features]);
+  const claim = claimCopy[job?.claimStatus || 'NOT_STARTED'] ?? claimCopy.NOT_STARTED;
 
   async function api<T>(path: string, init?: RequestInit) {
-    const res = await fetch(path, { ...init, headers: { 'content-type': 'application/json', 'x-dsg-workspace-id': workspaceId.trim(), 'x-dsg-actor-id': actorId.trim(), ...(init?.headers || {}) } });
+    const res = await fetch(path, {
+      ...init,
+      headers: {
+        'content-type': 'application/json',
+        'x-dsg-workspace-id': DEFAULT_WORKSPACE_ID,
+        'x-dsg-actor-id': DEFAULT_ACTOR_ID,
+        ...(init?.headers || {}),
+      },
+    });
     const json = await res.json().catch(() => ({ ok: false, error: { message: 'INVALID_JSON_RESPONSE' } })) as ApiResult<T>;
     if (!res.ok && json.ok) throw new Error(`HTTP_${res.status}`);
     return readResult(json);
   }
 
   async function run(name: string, fn: () => Promise<void>) {
-    setBusy(name); setError(null);
+    setBusy(name);
+    setError(null);
     try { await fn(); } catch (err) { setError(err instanceof Error ? err.message : 'REQUEST_FAILED'); } finally { setBusy(null); }
   }
 
-  function say(role: Msg['role'], text: string) { setMessages((m) => [...m, { id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, role, text }]); }
-  function toggle(value: string, list: string[], setter: (next: string[]) => void) { setter(list.includes(value) ? list.filter((x) => x !== value) : [...list, value]); }
+  function say(role: Msg['role'], text: string) {
+    setMessages((current) => [...current, { id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, role, text }]);
+  }
+
+  function toggle(value: string, list: string[], setter: (next: string[]) => void) {
+    setter(list.includes(value) ? list.filter((item) => item !== value) : [...list, value]);
+  }
 
   function send() {
     const text = input.trim();
     if (!text) return;
-    setInput(''); say('user', text);
+    setInput('');
+    say('user', text);
     if (stage === 'idea') {
       const picked = optionsFor(text).slice(0, 4);
-      setIdea(text); setFeatures(picked); setStage('features');
-      say('agent', `เข้าใจครับ: ${text}. ผมเลือกฟีเจอร์เริ่มต้นให้แล้ว กดเพิ่ม/ลบได้ หรือพิมพ์สิ่งที่อยากเพิ่มมาได้เลย`);
+      setIdea(text);
+      setFeatures(picked);
+      setStage('features');
+      say('agent', `รับทราบ: ${text}. ผมเลือกฟีเจอร์เริ่มต้นให้แล้ว คุณเพิ่ม/ลบได้ก่อนยืนยัน`);
       return;
     }
-    setNotes((n) => [...n, text]);
-    say('agent', 'รับทราบ ผมเพิ่มเข้า monitor แล้ว ถ้าโอเคให้กดยืนยันเรียก API ได้เลย');
+    setNotes((current) => [...current, text]);
+    say('agent', 'เพิ่มหมายเหตุให้แล้วครับ ตรวจด้านขวาแล้วค่อยกดยืนยันเรียก API');
   }
 
   const buildPlan = () => run('plan', async () => {
-    const created = await api<BuilderJob>('/api/dsg/app-builder/jobs', { method: 'POST', body: JSON.stringify({ goal, successCriteria: criteria, constraints, targetStack: { frontend: 'nextjs', backend: 'next-api', database: 'supabase-postgres', auth: 'none', deploy: 'vercel' } }) });
+    const created = await api<BuilderJob>('/api/dsg/app-builder/jobs', {
+      method: 'POST',
+      body: JSON.stringify({
+        goal,
+        successCriteria: criteria,
+        constraints,
+        targetStack: { frontend: 'nextjs', backend: 'next-api', database: 'supabase-postgres', auth: 'none', deploy: 'vercel' },
+      }),
+    });
     const planned = await api<BuilderJob>(`/api/dsg/app-builder/jobs/${created.id}/plan`, { method: 'POST' });
-    setJob(planned); setStage('planned'); say('agent', 'เรียก API แล้ว: สร้าง PRD และแผนให้แล้วครับ ตรวจใน monitor ถ้าโอเคกดอนุมัติแผน');
+    setJob(planned);
+    setStage('planned');
+    say('agent', 'สร้าง PRD และแผนผ่าน API จริงแล้วครับ ตรวจแผน แล้วกดอนุมัติถ้าพร้อม');
   });
 
   const approve = () => run('approval', async () => {
     if (!job?.proposedPlan) throw new Error('APP_BUILDER_PLAN_REQUIRED');
-    const approved = await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/approval`, { method: 'POST', body: JSON.stringify({ decision: 'APPROVE', reason: 'Approved visible guided plan before runtime action.' }) });
-    setJob(approved); setStage('approved'); say('agent', 'อนุมัติแผนแล้วครับ ขั้นต่อไปคือส่งเข้ารันไทม์');
+    const approved = await api<BuilderJob>(`/api/dsg/app-builder/jobs/${job.id}/approval`, {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'APPROVE', reason: 'Customer approved visible guided plan before runtime action.' }),
+    });
+    setJob(approved);
+    setStage('approved');
+    say('agent', 'อนุมัติแผนแล้วครับ ขั้นต่อไปคือส่งเข้า runtime');
   });
 
   const sendRuntime = () => run('handoff', async () => {
     if (!job?.approvalHash) throw new Error('APP_BUILDER_APPROVAL_REQUIRED');
-    const h = await api<Handoff>(`/api/dsg/app-builder/jobs/${job.id}/runtime-handoff`, { method: 'POST' });
-    setHandoff(h); setStage('runtime'); say('agent', 'ส่งเข้ารันไทม์แล้วครับ ถ้าพร้อมกดเริ่มสร้างแอป');
+    const data = await api<Handoff>(`/api/dsg/app-builder/jobs/${job.id}/runtime-handoff`, { method: 'POST' });
+    setHandoff(data);
+    setStage('runtime');
+    say('agent', 'runtime handoff พร้อมแล้วครับ ขั้นถัดไปจะสร้าง branch/PR ไม่ใช่ deploy production');
   });
 
   const launch = () => run('tool-call', async () => {
     if (!job?.approvalHash) throw new Error('APP_BUILDER_APPROVAL_REQUIRED');
-    const data = await api<{ job: BuilderJob; toolCall: ToolCall }>(`/api/dsg/app-builder/jobs/${job.id}/tool-call`, { method: 'POST', body: JSON.stringify({ toolName: TOOL_NAME, arguments: { mode: 'agent_runtime_fullstack_pr' } }) });
-    setJob(data.job); setToolCall(data.toolCall); setStage('done'); say('agent', 'สร้างแอปเสร็จแล้วครับ ดู PR และหลักฐานใน monitor ได้เลย');
+    const data = await api<{ job: BuilderJob; toolCall: ToolCall }>(`/api/dsg/app-builder/jobs/${job.id}/tool-call`, {
+      method: 'POST',
+      body: JSON.stringify({ toolName: TOOL_NAME, arguments: { mode: 'agent_runtime_fullstack_pr' } }),
+    });
+    setJob(data.job);
+    setToolCall(data.toolCall);
+    setStage('done');
+    say('agent', 'สร้างโค้ดเป็น GitHub PR แล้วครับ ยังไม่ใช้ Vercel quota จนกว่าจะต้องตรวจ preview/production proof');
   });
 
+  async function copyProof() {
+    const proof = {
+      jobId: job?.id,
+      status: job?.status,
+      claimStatus: job?.claimStatus,
+      planHash: handoff?.planHash || job?.planHash,
+      approvalHash: handoff?.approvalHash || job?.approvalHash,
+      pullRequestUrl: toolCall?.output.pullRequestUrl,
+      branchName: toolCall?.output.branchName,
+      repository: toolCall?.output.repository,
+      generatedFiles: toolCall?.output.generatedFiles,
+      auditWritten: toolCall?.evidence.auditWritten,
+      vercelQuotaPolicy: 'No production deploy from this UI flow. Use Vercel only for preview/proof when necessary.',
+    };
+    await navigator.clipboard.writeText(JSON.stringify(proof, null, 2));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
   const steps = [
-    { label: 'คุย requirement', ok: Boolean(idea), detail: idea || 'รอเริ่ม' },
+    { label: 'ไอเดีย', ok: Boolean(idea), detail: idea || 'รอเริ่ม' },
     { label: 'แผน', ok: Boolean(job?.proposedPlan), detail: job?.gateResult ? `${job.gateResult.status}/${job.gateResult.riskLevel}` : 'รอสร้าง' },
     { label: 'อนุมัติ', ok: Boolean(job?.approvalHash), detail: job?.approvalHash ? `${job.approvalHash.slice(0, 8)}…` : 'รอ' },
-    { label: 'รันไทม์', ok: Boolean(handoff), detail: handoff?.runtimeStatus ?? 'รอส่ง' },
-    { label: 'สร้างแอป', ok: Boolean(toolCall), detail: toolCall?.status ?? 'รอเริ่ม' },
+    { label: 'runtime', ok: Boolean(handoff), detail: handoff?.runtimeStatus ?? 'รอส่ง' },
+    { label: 'PR', ok: Boolean(toolCall), detail: toolCall?.status ?? 'ยังไม่สร้าง' },
   ];
 
-  return <div className="space-y-3 text-[#c8c8c8]">
-    <div className="flex gap-2 overflow-x-auto pb-1">{steps.map((s) => <Chip key={s.label} {...s} />)}</div>
-    {error ? <div className="rounded-xl border border-[#b4232b]/35 bg-[#b4232b]/10 p-3 text-sm text-[#ffb4b8]">{error}</div> : null}
-    <div className="grid min-h-[620px] gap-3 xl:grid-cols-[minmax(0,1fr)_360px]">
-      <section className="flex min-w-0 flex-col rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d]">
-        <div className="border-b border-[#c8c8c8]/15 px-3 py-2"><p className="text-sm font-black text-[#f2f2f2]">App Builder Agent</p><p className="text-xs text-[#8d8d8d]">คุยตกลงก่อน แล้วเอเจนต์ตั้งค่าให้ ก่อนเรียก API ต้องกดยืนยัน</p></div>
-        <div className="flex-1 space-y-3 overflow-y-auto p-3">
-          {messages.map((m) => <div key={m.id} className={cn('flex', m.role === 'user' ? 'justify-end' : 'justify-start')}><div className={cn('max-w-[86%] rounded-2xl border px-3 py-2 text-sm leading-6', m.role === 'user' ? 'border-[#d6a63a]/35 bg-[#d6a63a]/10 text-[#f5d27a]' : 'border-[#c8c8c8]/15 bg-[#111113] text-[#d9d9d9]')}><div className="mb-1 text-[10px] font-black uppercase opacity-70">{m.role === 'agent' ? 'Agent' : 'You'}</div>{m.text}</div></div>)}
-          {stage === 'features' ? <div className="rounded-2xl border border-[#c8c8c8]/15 bg-[#111113] p-3"><p className="text-xs font-black text-[#f2f2f2]">ฟีเจอร์ที่ต้องการ</p><div className="mt-2 flex flex-wrap gap-2">{featureOptions.map((f) => <Pick key={f} active={features.includes(f)} text={f} onClick={() => toggle(f, features, setFeatures)} />)}</div><button onClick={() => { setStage('style'); say('agent', 'ต่อไปเลือกสไตล์หน้าจอครับ'); }} className="mt-3 rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 py-2 text-xs font-black text-[#f5d27a]">ต่อไป: เลือกสไตล์</button></div> : null}
-          {stage === 'style' ? <div className="rounded-2xl border border-[#c8c8c8]/15 bg-[#111113] p-3"><p className="text-xs font-black text-[#f2f2f2]">สไตล์หน้าจอ</p><div className="mt-2 flex flex-wrap gap-2">{['มือถือก่อน', 'อ่านง่าย', 'เรียบหรู', 'ทอง / แดง / เงิน', 'จอมอนิเตอร์สด'].map((s) => <Pick key={s} active={styles.includes(s)} text={s} onClick={() => toggle(s, styles, setStyles)} />)}</div><button onClick={() => { setStage('confirm'); say('agent', 'ผมสรุปคำสั่งงานให้แล้ว ตรวจใน monitor ถ้าโอเคกดยืนยันเรียก API'); }} className="mt-3 rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 py-2 text-xs font-black text-[#f5d27a]">สรุปให้ตรวจ</button></div> : null}
-          {stage === 'confirm' ? <div className="rounded-2xl border border-[#d6a63a]/30 bg-[#d6a63a]/5 p-3"><p className="text-sm font-black text-[#f5d27a]">แบบนี้โอเคไหม?</p><p className="mt-2 text-xs leading-5 text-[#d9d9d9]">ปุ่มนี้จะเรียก API จริง: POST /api/dsg/app-builder/jobs และ POST /api/dsg/app-builder/jobs/:id/plan</p><button onClick={buildPlan} disabled={!!busy} className="mt-3 inline-flex items-center gap-2 rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 py-2 text-xs font-black text-[#f5d27a] disabled:opacity-50">{busy === 'plan' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} ยืนยันและเรียก API สร้างแผน</button></div> : null}
-        </div>
-        <div className="border-t border-[#c8c8c8]/15 p-3"><div className="flex gap-2"><input value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') send(); }} placeholder={stage === 'idea' ? 'พิมพ์สั้น ๆ เช่น Todo' : 'พิมพ์สิ่งที่อยากเพิ่มหรือแก้...'} className="h-11 min-w-0 flex-1 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] px-3 text-sm text-[#f2f2f2] outline-none placeholder:text-[#666] focus:border-[#d6a63a]/50" /><button onClick={send} disabled={!input.trim()} className="inline-flex h-11 items-center gap-2 rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 text-xs font-black text-[#f5d27a] disabled:opacity-50"><Send className="h-4 w-4" /> ส่ง</button></div></div>
-      </section>
-      <aside className="space-y-3 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3"><section className="rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3"><p className="text-xs font-black uppercase tracking-[0.16em] text-[#d6a63a]">Agent settings monitor</p><div className="mt-3 space-y-2"><div className="rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-2"><p className="text-[10px] font-black uppercase text-[#8d8d8d]">Goal</p><p className="mt-1 text-xs leading-5 text-[#d9d9d9]">{goal}</p></div><div className="rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-2"><p className="text-[10px] font-black uppercase text-[#8d8d8d]">Success criteria</p><ul className="mt-1 space-y-1 text-xs leading-5 text-[#d9d9d9]">{criteria.map((c) => <li key={c}>• {c}</li>)}</ul></div><div className="rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-2"><p className="text-[10px] font-black uppercase text-[#8d8d8d]">Constraints</p><ul className="mt-1 space-y-1 text-xs leading-5 text-[#d9d9d9]">{constraints.map((c) => <li key={c}>• {c}</li>)}</ul></div></div></section><div className="grid grid-cols-2 gap-2 text-xs"><label>Workspace<input value={workspaceId} onChange={(e) => setWorkspaceId(e.target.value)} className="mt-1 h-9 w-full rounded-lg border border-[#c8c8c8]/15 bg-[#0c0c0d] px-2 text-[#f2f2f2]" /></label><label>Actor<input value={actorId} onChange={(e) => setActorId(e.target.value)} className="mt-1 h-9 w-full rounded-lg border border-[#c8c8c8]/15 bg-[#0c0c0d] px-2 text-[#f2f2f2]" /></label></div><div className="flex flex-wrap gap-2"><button onClick={approve} disabled={!!busy || !job?.proposedPlan} className="rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 py-2 text-xs font-black text-[#f5d27a] disabled:opacity-40">อนุมัติแผน</button><button onClick={sendRuntime} disabled={!!busy || !job?.approvalHash} className="rounded-xl border border-[#c8c8c8]/20 px-3 py-2 text-xs font-black text-[#d9d9d9] disabled:opacity-40">ส่งเข้ารันไทม์</button><button onClick={launch} disabled={!!busy || !job?.approvalHash || job.status !== 'READY_FOR_RUNTIME'} className="rounded-xl border border-[#d6a63a]/35 bg-[#d6a63a]/10 px-3 py-2 text-xs font-black text-[#f5d27a] disabled:opacity-40">เริ่มสร้างแอป</button></div>{job?.prd?.summary ? <section className="rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3"><p className="text-xs font-black text-[#f2f2f2]">PRD summary</p><p className="mt-2 text-xs leading-5">{job.prd.summary}</p></section> : null}{job?.proposedPlan ? <section className="space-y-2 rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3"><p className="text-xs font-black text-[#f2f2f2]">Plan steps</p>{job.proposedPlan.steps.map((s) => <div key={s.id} className="rounded-lg border border-[#c8c8c8]/10 p-2"><p className="text-[11px] text-[#8d8d8d]">{s.id} · {s.phase} · {s.riskLevel}</p><p className="mt-1 text-xs font-bold text-[#d9d9d9]">{s.title}</p></div>)}</section> : null}{toolCall ? <section className="rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3 text-xs leading-5 text-[#f5d27a]"><p className="font-black">สร้างแอปเสร็จแล้ว</p><p>Audit written: {String(toolCall.evidence.auditWritten)}</p><p>{toolCall.evidence.note}</p></section> : null}{toolCall?.output ? <section className="rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3 text-xs leading-5 text-[#f5d27a]"><p className="font-black">ผลลัพธ์</p><p>Repo: {toolCall.output.repository}</p><p>Branch: {toolCall.output.branchName}</p><p>Files: {toolCall.output.generatedFiles.length}</p><a href={toolCall.output.pullRequestUrl} target="_blank" rel="noreferrer" className="mt-2 inline-flex items-center gap-1 underline">เปิด PR #{toolCall.output.pullRequestNumber}<ExternalLink className="h-3.5 w-3.5" /></a></section> : null}</aside>
+  return (
+    <div className="space-y-3 text-[#c8c8c8]">
+      <div className="flex gap-2 overflow-x-auto pb-1">{steps.map((step) => <StepCard key={step.label} {...step} />)}</div>
+      {error ? <div className="rounded-xl border border-[#b4232b]/35 bg-[#b4232b]/10 p-3 text-sm text-[#ffb4b8]">{error}</div> : null}
+
+      <div className="grid min-h-[620px] gap-3 xl:grid-cols-[minmax(0,1fr)_380px]">
+        <section className="flex min-w-0 flex-col rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d]">
+          <div className="border-b border-[#c8c8c8]/15 px-4 py-3">
+            <div className="flex items-center gap-2 text-[#f2f2f2]"><Sparkles className="h-4 w-4 text-[#d6a63a]" /><p className="text-sm font-black">สร้างแอปกับ DSG Agent</p></div>
+            <p className="mt-1 text-xs text-[#8d8d8d]">ลูกค้าคุยง่าย ระบบสร้างแผนก่อน และทุก action สำคัญต้องกดยืนยัน</p>
+          </div>
+
+          <div className="flex-1 space-y-3 overflow-y-auto p-3">
+            {messages.map((message) => (
+              <div key={message.id} className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}>
+                <div className={cn('max-w-[86%] rounded-2xl border px-3 py-2 text-sm leading-6', message.role === 'user' ? toneClass('gold') : toneClass('muted'))}>
+                  <div className="mb-1 text-[10px] font-black uppercase opacity-70">{message.role === 'agent' ? 'DSG Agent' : 'คุณ'}</div>
+                  {message.text}
+                </div>
+              </div>
+            ))}
+
+            {stage === 'features' ? (
+              <div className="rounded-2xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+                <p className="text-xs font-black text-[#f2f2f2]">เลือกฟีเจอร์ที่ลูกค้าจะได้ใช้จริง</p>
+                <div className="mt-2 flex flex-wrap gap-2">{featureOptions.map((feature) => <Pick key={feature} active={features.includes(feature)} text={feature} onClick={() => toggle(feature, features, setFeatures)} />)}</div>
+                <button onClick={() => { setStage('style'); say('agent', 'ต่อไปเลือกสไตล์หน้าจอครับ'); }} className={cn('mt-3 rounded-xl border px-3 py-2 text-xs font-black', toneClass('gold'))}>ต่อไป: เลือกสไตล์</button>
+              </div>
+            ) : null}
+
+            {stage === 'style' ? (
+              <div className="rounded-2xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+                <p className="text-xs font-black text-[#f2f2f2]">สไตล์หน้าจอ</p>
+                <div className="mt-2 flex flex-wrap gap-2">{['มือถือก่อน', 'อ่านง่าย', 'เรียบหรู', 'ทอง / แดง / เงิน', 'จอมอนิเตอร์สด'].map((style) => <Pick key={style} active={styles.includes(style)} text={style} onClick={() => toggle(style, styles, setStyles)} />)}</div>
+                <button onClick={() => { setStage('confirm'); say('agent', 'ผมสรุปคำสั่งงานให้แล้ว ตรวจด้านขวา ถ้าโอเคกดยืนยันเรียก API'); }} className={cn('mt-3 rounded-xl border px-3 py-2 text-xs font-black', toneClass('gold'))}>สรุปให้ตรวจ</button>
+              </div>
+            ) : null}
+
+            {stage === 'confirm' ? (
+              <div className="rounded-2xl border border-[#d6a63a]/30 bg-[#d6a63a]/5 p-3">
+                <p className="text-sm font-black text-[#f5d27a]">ตรวจแล้วค่อยเรียก API</p>
+                <p className="mt-2 text-xs leading-5 text-[#d9d9d9]">ขั้นนี้สร้าง job และ plan เท่านั้น ยังไม่ deploy และไม่ใช้ Vercel quota</p>
+                <button onClick={buildPlan} disabled={!!busy} className={cn('mt-3 inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-black disabled:opacity-50', toneClass('gold'))}>{busy === 'plan' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} ยืนยันและสร้างแผน</button>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="border-t border-[#c8c8c8]/15 p-3">
+            <div className="flex gap-2">
+              <input value={input} onChange={(event) => setInput(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') send(); }} placeholder={stage === 'idea' ? 'พิมพ์สั้น ๆ เช่น เว็บจองคิวร้านกาแฟ' : 'พิมพ์สิ่งที่อยากเพิ่มหรือแก้...'} className="h-11 min-w-0 flex-1 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] px-3 text-sm text-[#f2f2f2] outline-none placeholder:text-[#666] focus:border-[#d6a63a]/50" />
+              <button onClick={send} disabled={!input.trim()} className={cn('inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-xs font-black disabled:opacity-50', toneClass('gold'))}><Send className="h-4 w-4" /> ส่ง</button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="space-y-3 rounded-xl border border-[#c8c8c8]/15 bg-[#111113] p-3">
+          <section className="rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-[#d6a63a]">Customer evidence monitor</p>
+                <p className="mt-1 text-xs leading-5 text-[#c8c8c8]">สร้าง PR ก่อน ประหยัด Vercel quota และไม่แสดงหลักฐานปลอม</p>
+              </div>
+              <StatusPill status={job?.claimStatus} />
+            </div>
+            <div className="mt-3 rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-3 text-xs leading-5 text-[#d9d9d9]">
+              <p className="font-black text-[#f2f2f2]">ขั้นต่อไป</p>
+              <p>{claim.next}</p>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3">
+            <p className="text-xs font-black text-[#f2f2f2]">Goal</p>
+            <p className="mt-2 text-xs leading-5 text-[#d9d9d9]">{goal}</p>
+          </section>
+
+          <section className="grid gap-2 text-xs">
+            <div className="rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-3">
+              <p className="font-black text-[#8d8d8d]">Success criteria</p>
+              <ul className="mt-1 space-y-1 leading-5 text-[#d9d9d9]">{criteria.map((criterion) => <li key={criterion}>• {criterion}</li>)}</ul>
+            </div>
+            <div className="rounded-lg border border-[#c8c8c8]/10 bg-[#0c0c0d] p-3">
+              <p className="font-black text-[#8d8d8d]">Constraints</p>
+              <ul className="mt-1 space-y-1 leading-5 text-[#d9d9d9]">{constraints.map((constraint) => <li key={constraint}>• {constraint}</li>)}</ul>
+            </div>
+          </section>
+
+          <div className="flex flex-wrap gap-2">
+            <button onClick={approve} disabled={!!busy || !job?.proposedPlan} className={cn('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-black disabled:opacity-40', toneClass('gold'))}><ShieldCheck className="h-4 w-4" /> อนุมัติแผน</button>
+            <button onClick={sendRuntime} disabled={!!busy || !job?.approvalHash} className={cn('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-black disabled:opacity-40', toneClass('silver'))}><GitBranch className="h-4 w-4" /> ส่งเข้า runtime</button>
+            <button onClick={launch} disabled={!!busy || !job?.approvalHash || job.status !== 'READY_FOR_RUNTIME'} className={cn('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-black disabled:opacity-40', toneClass('gold'))}>{busy === 'tool-call' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />} สร้าง PR</button>
+          </div>
+
+          {job?.prd?.summary ? <section className="rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3"><p className="text-xs font-black text-[#f2f2f2]">PRD summary</p><p className="mt-2 text-xs leading-5 text-[#d9d9d9]">{job.prd.summary}</p></section> : null}
+
+          {job?.proposedPlan ? <section className="space-y-2 rounded-xl border border-[#c8c8c8]/15 bg-[#0c0c0d] p-3"><p className="text-xs font-black text-[#f2f2f2]">Plan steps</p>{job.proposedPlan.steps.map((step) => <div key={step.id} className="rounded-lg border border-[#c8c8c8]/10 p-2"><p className="text-[11px] text-[#8d8d8d]">{step.id} · {step.phase} · {step.riskLevel}</p><p className="mt-1 text-xs font-bold text-[#d9d9d9]">{step.title}</p></div>)}</section> : null}
+
+          {toolCall?.output ? (
+            <section className="space-y-3 rounded-xl border border-[#d6a63a]/25 bg-[#d6a63a]/5 p-3 text-xs leading-5 text-[#f5d27a]">
+              <div className="flex items-center gap-2 font-black"><FileText className="h-4 w-4" /> PR Evidence</div>
+              <p>Repo: {toolCall.output.repository}</p>
+              <p>Branch: {toolCall.output.branchName}</p>
+              <p>Files: {toolCall.output.generatedFiles.length}</p>
+              <p>Audit written: {String(toolCall.evidence.auditWritten)}</p>
+              <div className="flex flex-wrap gap-2">
+                <a href={toolCall.output.pullRequestUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 rounded-lg border border-[#d6a63a]/35 px-2 py-1 underline">เปิด PR #{toolCall.output.pullRequestNumber}<ExternalLink className="h-3.5 w-3.5" /></a>
+                <button onClick={() => void copyProof()} className="inline-flex items-center gap-1 rounded-lg border border-[#d6a63a]/35 px-2 py-1"><Clipboard className="h-3.5 w-3.5" /> {copied ? 'คัดลอกแล้ว' : 'Copy proof JSON'}</button>
+              </div>
+            </section>
+          ) : null}
+        </aside>
+      </div>
     </div>
-  </div>;
+  );
 }

--- a/docs/dsg-action-layer/README.md
+++ b/docs/dsg-action-layer/README.md
@@ -1,0 +1,45 @@
+# DSG Action Layer GED
+
+Customer-facing studio orchestration layer for DSG ONE V1.
+
+## Purpose
+
+This layer turns a user goal into:
+
+1. a stable visible plan,
+2. explicit permission checkpoints,
+3. approved execution stages,
+4. visible evidence collection,
+5. a final review boundary.
+
+It is a **contract and UX control layer**, not a remote-browser executor by itself.
+
+## Use in DSG ONE V1
+
+- Plan Pane: render the goal, architecture, stages, risks, permissions, and definition of success before execution.
+- Execution Pane: render running state, current stage, evidence, checkpoints, and next action after approval.
+- Browser Operator: define browser-first behavior, visible evidence discipline, and login/takeover pauses.
+- Local Ops Controller: define what the studio may do automatically after approval.
+
+## Truth boundary
+
+Remote browser automation remains `connector_required` until a real executor is wired, such as Playwright, Puppeteer, Browserbase, Steel, or another browser session service.
+
+## Imported source files
+
+These docs are based on the uploaded action-layer references:
+
+- `SKILL.md`
+- `openai.yaml`
+- `browser-operator.md`
+- `deterministic-studio-rules.md`
+- `execution-pane-json-contract.md`
+- `execution-pane-schema.md`
+- `local-ops-controller.md`
+- `plan-pane-json-contract.md`
+- `plan-panel.md`
+- `plan-pane-schema.md`
+
+## Production rule
+
+Do not trigger Vercel deployment from these docs. They define behavior and UI contracts only.

--- a/docs/dsg-action-layer/execution-pane-contract.md
+++ b/docs/dsg-action-layer/execution-pane-contract.md
@@ -1,0 +1,80 @@
+# Execution Pane Contract
+
+## Purpose
+
+The execution pane is the user-facing live operations view after the user approves a plan.
+
+It should answer:
+
+1. what is running now,
+2. what already finished,
+3. what is blocked or failed,
+4. what the user needs to do next.
+
+## Rendering order
+
+Always render in this order:
+
+1. `run_status`
+2. `current_goal`
+3. `current_stage`
+4. `stage_list`
+5. `evidence`
+6. `checkpoints`
+7. `next_action`
+
+## JSON shape
+
+```json
+{
+  "execution_pane": {
+    "run_status": {
+      "state": "draft | ready for approval | approved | running | blocked | completed | failed | canceled",
+      "summary": "string"
+    },
+    "current_goal": {
+      "text": "string"
+    },
+    "current_stage": {
+      "id": "string",
+      "title": "string",
+      "state": "pending | running | completed | blocked | failed | skipped",
+      "summary": "string"
+    },
+    "stage_list": [
+      {
+        "id": "string",
+        "title": "string",
+        "state": "pending | running | completed | blocked | failed | skipped",
+        "evidence_hint": "string"
+      }
+    ],
+    "evidence": [
+      {
+        "type": "screenshot | page_state | status_label | confirmation | artifact | log_excerpt",
+        "title": "string",
+        "detail": "string"
+      }
+    ],
+    "checkpoints": [
+      {
+        "type": "external app | login | consent | takeover | privileged action",
+        "state": "pending | active | resolved",
+        "instruction": "string"
+      }
+    ],
+    "next_action": {
+      "owner": "studio | user",
+      "instruction": "string"
+    }
+  }
+}
+```
+
+## Rules
+
+- Update `current_stage` first when execution moves.
+- Then update the matching item in `stage_list`.
+- Add evidence only when it is visible and user-relevant.
+- Create checkpoints only for real user-facing blockers.
+- `blocked` returns to `running` only after the blocker is resolved.

--- a/docs/dsg-action-layer/plan-pane-contract.md
+++ b/docs/dsg-action-layer/plan-pane-contract.md
@@ -1,0 +1,82 @@
+# Plan Pane Contract
+
+## Purpose
+
+The plan pane is the visible, user-facing planning view before execution. It is not hidden reasoning.
+
+The user should quickly understand:
+
+1. the goal,
+2. how the systems connect,
+3. what stages will run,
+4. what risks matter,
+5. where permission or takeover may be required,
+6. what success looks like.
+
+## Rendering order
+
+Always render in this order:
+
+1. `goal`
+2. `architecture`
+3. `stages`
+4. `risks`
+5. `permissions`
+6. `definition_of_success`
+
+## JSON shape
+
+```json
+{
+  "plan_pane": {
+    "goal": {
+      "text": "string",
+      "constraints": ["string"]
+    },
+    "architecture": {
+      "systems": [
+        { "name": "string", "role": "string" }
+      ],
+      "flow_summary": ["string"]
+    },
+    "stages": [
+      {
+        "id": "string",
+        "title": "string",
+        "purpose": "string",
+        "type": "inspect | decide | execute | verify",
+        "external_boundary": true,
+        "approval_required": false
+      }
+    ],
+    "risks": [
+      {
+        "level": "low | medium | high",
+        "title": "string",
+        "impact": "string",
+        "mitigation": "string"
+      }
+    ],
+    "permissions": [
+      {
+        "target": "string",
+        "decision": "allow | needs user takeover | deny",
+        "reason": "string",
+        "user_next_step": "string"
+      }
+    ],
+    "definition_of_success": {
+      "outcomes": ["string"],
+      "evidence": ["string"]
+    }
+  }
+}
+```
+
+## Rules
+
+- Freeze the goal before expanding the plan.
+- Keep stage IDs stable across revisions.
+- Keep permissions focused on user-relevant checkpoints.
+- Do not silently change success criteria after the user starts reviewing.
+- Do not execute until the user explicitly approves the plan.

--- a/docs/dsg-skills/README.md
+++ b/docs/dsg-skills/README.md
@@ -1,0 +1,29 @@
+# DSG Skills Registry
+
+This folder stores imported DSG skill specifications as governance and UX contracts for DSG ONE V1.
+
+## Included skills
+
+1. `github-controller`
+   - Controls repo/branch/PR behavior.
+   - Requires evidence before claims.
+   - Useful for safe GitHub automation.
+
+2. `graphify-context`
+   - Turns repo/files into a context graph.
+   - Separates facts, claims, and evidence.
+   - Useful before planning or execution.
+
+3. `multi-governance-orchestrator`
+   - Master governance, UI/UX, audit, and action reference.
+   - Used as design guidance and checklist.
+
+## Boundary
+
+These skills are **contracts and rules**, not direct executors.
+
+Do not claim that a skill is connected to a live executor unless the corresponding API/tool is implemented and evidence is available.
+
+## Vercel quota policy
+
+Adding or reviewing these docs must not trigger Vercel production deploy. Use preview/production only for proof gates when required.

--- a/docs/dsg-skills/github-controller/README.md
+++ b/docs/dsg-skills/github-controller/README.md
@@ -1,0 +1,45 @@
+# DSG GitHub Controller Skill
+
+## Purpose
+
+Govern GitHub repository changes with a truth-first workflow.
+
+Use this skill when an agent needs to inspect, patch, branch, or open PRs in DSG ONE V1.
+
+## Operating rules
+
+1. Inspect real repo files before proposing or changing code.
+2. Never create fake evidence, fake deploy URLs, or fake PR links.
+3. Prefer branch + draft PR before merge.
+4. Keep production deploy separate from code review.
+5. State blockers instead of guessing.
+6. Keep user benefit visible in every repo action.
+
+## Safe workflow
+
+```txt
+inspect repo
+lock goal
+classify risk
+prepare patch
+commit to branch
+open draft PR
+attach evidence
+wait for review
+```
+
+## Do not do
+
+- Do not merge without explicit instruction.
+- Do not run deploy to spend Vercel quota unless proof requires it.
+- Do not label mock output as production proof.
+- Do not alter backend/runtime when the task is UI-only.
+
+## DSG ONE V1 mapping
+
+This skill maps to the current branch/PR work:
+
+- branch: `customer-workspace-ui`
+- PR mode: draft review first
+- production deploy: not triggered
+- Vercel quota: preserved

--- a/docs/dsg-skills/graphify-context/README.md
+++ b/docs/dsg-skills/graphify-context/README.md
@@ -1,0 +1,41 @@
+# DSG Graphify Context Skill
+
+## Purpose
+
+Create a repo/context graph before planning or execution.
+
+This skill helps the studio avoid guessing by turning files, routes, components, APIs, claims, and evidence into a structured graph.
+
+## Use cases
+
+- Inspect repo structure before changing code.
+- Map routes to components and API endpoints.
+- Separate facts from inferred claims.
+- Attach evidence IDs to plan and execution stages.
+- Detect missing proof before allowing production claims.
+
+## Context graph pipeline
+
+```txt
+scan files
+classify nodes
+classify edges
+attach evidence
+list claims
+mark missing proof
+feed plan pane
+```
+
+## Node examples
+
+- route
+- component
+- API endpoint
+- runtime service
+- database migration
+- evidence artifact
+- claim
+
+## Truth boundary
+
+A graph node is not proof by itself. It must reference real files, API responses, logs, screenshots, or visible UI state before being used as evidence.

--- a/lib/dsg/agent-runtime/service-registry.ts
+++ b/lib/dsg/agent-runtime/service-registry.ts
@@ -1,0 +1,113 @@
+import {
+  APP_BUILDER_AGENT_RUNTIME_TOOL_NAME,
+  APP_BUILDER_BUILD_TOOL_NAME,
+} from '@/lib/dsg/app-builder/build-tools';
+
+export type AgentRuntimeServiceStatus =
+  | 'available'
+  | 'approval_required'
+  | 'connector_required'
+  | 'quota_gated';
+
+export type AgentRuntimeServiceImplementation =
+  | 'server_tool_call'
+  | 'server_runtime_contract'
+  | 'client_browser_action'
+  | 'not_implemented_in_repo';
+
+export type AgentRuntimeService = {
+  id: string;
+  label: string;
+  description: string;
+  status: AgentRuntimeServiceStatus;
+  implementation: AgentRuntimeServiceImplementation;
+  action: string;
+  endpoint?: string;
+  requiredSecrets: string[];
+  evidence: string[];
+  userBenefit: string;
+  truthBoundary: string;
+};
+
+function remoteBrowserContractStatus(): AgentRuntimeServiceStatus {
+  return process.env.DSG_REMOTE_BROWSER_ENABLED === 'true' ? 'connector_required' : 'connector_required';
+}
+
+export function listAgentRuntimeServices(): AgentRuntimeService[] {
+  return [
+    {
+      id: APP_BUILDER_AGENT_RUNTIME_TOOL_NAME,
+      label: 'Launch App Builder agent runtime',
+      description: 'Runs after a visible plan is approved. It prepares runtime environment, action-layer contract, audit event, and notification payload.',
+      status: 'approval_required',
+      implementation: 'server_tool_call',
+      action: 'Use from the App Builder flow after approval.',
+      endpoint: '/api/dsg/app-builder/jobs/:jobId/tool-call',
+      requiredSecrets: ['GITHUB_TOKEN'],
+      evidence: ['runtime-environment-manifest', 'action-layer-contract', 'audit-event', 'notification-payload'],
+      userBenefit: 'The user sees a controlled execution path instead of hidden automation.',
+      truthBoundary: 'This creates runtime/PR evidence only. It is not production deployment proof.',
+    },
+    {
+      id: APP_BUILDER_BUILD_TOOL_NAME,
+      label: 'Generate full-stack GitHub PR',
+      description: 'Writes generated frontend, API route, Supabase migration, and runbook files to a GitHub branch and opens a pull request.',
+      status: 'approval_required',
+      implementation: 'server_tool_call',
+      action: 'Use from the App Builder flow after runtime handoff.',
+      endpoint: '/api/dsg/app-builder/jobs/:jobId/tool-call',
+      requiredSecrets: ['GITHUB_TOKEN'],
+      evidence: ['pullRequestUrl', 'pullRequestNumber', 'branchName', 'generatedFiles'],
+      userBenefit: 'The user receives a real PR they can inspect, review, and merge later.',
+      truthBoundary: 'The PR is implementation evidence. CI, migration apply, preview, and production proof are separate steps.',
+    },
+    {
+      id: 'dsg.environment.provision',
+      label: 'Provision runtime environment manifest',
+      description: 'Creates or reuses a GitHub branch and writes an environment manifest before the build tool runs.',
+      status: 'approval_required',
+      implementation: 'server_runtime_contract',
+      action: 'Executed by the approved App Builder runtime tool.',
+      requiredSecrets: ['GITHUB_TOKEN'],
+      evidence: ['branchCreatedOrReused', 'manifestWritten', 'manifestPath'],
+      userBenefit: 'The user sees what environment and permissions were prepared before code generation.',
+      truthBoundary: 'Environment readiness is not build, deployment, or production proof.',
+    },
+    {
+      id: 'browser.local.open_url',
+      label: 'Open generated app in this browser',
+      description: 'Client-side action that opens a target URL in the user browser for manual visual proof collection.',
+      status: 'available',
+      implementation: 'client_browser_action',
+      action: 'Open URL from the Agent Services screen.',
+      requiredSecrets: [],
+      evidence: ['manual-screenshot', 'user-visible-url', 'customer-observed-result'],
+      userBenefit: 'The user can immediately inspect a generated app route or proof page without spending extra automation quota.',
+      truthBoundary: 'This is not remote browser automation. It is local browser inspection only.',
+    },
+    {
+      id: 'remote.browser.session',
+      label: 'Remote browser session',
+      description: 'Manus-style remote browser automation contract for future executor integration.',
+      status: remoteBrowserContractStatus(),
+      implementation: 'not_implemented_in_repo',
+      action: 'Connect a real remote browser executor before enabling autonomous browsing.',
+      requiredSecrets: ['DSG_REMOTE_BROWSER_ENABLED', 'REMOTE_BROWSER_ENDPOINT_OR_VENDOR_TOKEN'],
+      evidence: ['browser-session-id', 'screenshot-url', 'navigation-log', 'task-result'],
+      userBenefit: 'Once connected, the agent can inspect web pages and return browser proof without the user manually clicking through.',
+      truthBoundary: 'Search found no Playwright/Puppeteer/remote-browser executor in this repo yet, so the UI must not claim autonomous browser control.',
+    },
+    {
+      id: 'vercel.preview.proof',
+      label: 'Vercel preview / production proof',
+      description: 'Quota-gated proof step for preview or production verification after PR and CI are ready.',
+      status: 'quota_gated',
+      implementation: 'not_implemented_in_repo',
+      action: 'Use only when proof is required, not for every UI edit.',
+      requiredSecrets: ['VERCEL_TOKEN', 'VERCEL_ORG_ID', 'VERCEL_PROJECT_ID'],
+      evidence: ['deployment-url', 'deployment-id', 'production-flow-proof'],
+      userBenefit: 'The user preserves Vercel quota and spends it only on proof that matters.',
+      truthBoundary: 'Do not trigger production deploy from customer UI changes.',
+    },
+  ];
+}

--- a/lib/dsg/agent-runtime/service-registry.ts
+++ b/lib/dsg/agent-runtime/service-registry.ts
@@ -2,6 +2,7 @@ import {
   APP_BUILDER_AGENT_RUNTIME_TOOL_NAME,
   APP_BUILDER_BUILD_TOOL_NAME,
 } from '@/lib/dsg/app-builder/build-tools';
+import { getOpenAIAdapterStatus } from '@/lib/dsg/ai/openai-adapter';
 
 export type AgentRuntimeServiceStatus =
   | 'available'
@@ -12,6 +13,7 @@ export type AgentRuntimeServiceStatus =
 export type AgentRuntimeServiceImplementation =
   | 'server_tool_call'
   | 'server_runtime_contract'
+  | 'server_ai_adapter'
   | 'client_browser_action'
   | 'not_implemented_in_repo';
 
@@ -33,8 +35,26 @@ function remoteBrowserContractStatus(): AgentRuntimeServiceStatus {
   return process.env.DSG_REMOTE_BROWSER_ENABLED === 'true' ? 'connector_required' : 'connector_required';
 }
 
+function openAIAdapterServiceStatus(): AgentRuntimeServiceStatus {
+  return getOpenAIAdapterStatus().configured ? 'available' : 'connector_required';
+}
+
 export function listAgentRuntimeServices(): AgentRuntimeService[] {
+  const openAIStatus = getOpenAIAdapterStatus();
   return [
+    {
+      id: 'openai.responses.generate',
+      label: 'OpenAI Responses adapter',
+      description: 'Server-side OpenAI adapter for governed agent text generation and planning support.',
+      status: openAIAdapterServiceStatus(),
+      implementation: 'server_ai_adapter',
+      action: 'Call /api/dsg/ai/openai/chat from server-backed UI actions after policy allows it.',
+      endpoint: '/api/dsg/ai/openai/chat',
+      requiredSecrets: ['OPENAI_API_KEY'],
+      evidence: ['responseId', 'model', 'usage', 'outputText'],
+      userBenefit: 'The user can get AI-generated summaries, plans, and copy without exposing API keys in the browser.',
+      truthBoundary: openAIStatus.truthBoundary,
+    },
     {
       id: APP_BUILDER_AGENT_RUNTIME_TOOL_NAME,
       label: 'Launch App Builder agent runtime',
@@ -95,7 +115,7 @@ export function listAgentRuntimeServices(): AgentRuntimeService[] {
       requiredSecrets: ['DSG_REMOTE_BROWSER_ENABLED', 'REMOTE_BROWSER_ENDPOINT_OR_VENDOR_TOKEN'],
       evidence: ['browser-session-id', 'screenshot-url', 'navigation-log', 'task-result'],
       userBenefit: 'Once connected, the agent can inspect web pages and return browser proof without the user manually clicking through.',
-      truthBoundary: 'Search found no Playwright/Puppeteer/remote-browser executor in this repo yet, so the UI must not claim autonomous browser control.',
+      truthBoundary: 'Remote browser contract and APIs exist, but autonomous browser control remains connector-required until a verified provider adapter is wired.',
     },
     {
       id: 'vercel.preview.proof',

--- a/lib/dsg/ai/openai-adapter.ts
+++ b/lib/dsg/ai/openai-adapter.ts
@@ -1,0 +1,119 @@
+export type OpenAIAdapterStatus = {
+  configured: boolean;
+  status: 'configured' | 'missing_env';
+  baseUrl: string;
+  model: string;
+  requiredEnv: string[];
+  optionalEnv: string[];
+  truthBoundary: string;
+};
+
+export type OpenAIChatMessage = {
+  role: 'system' | 'developer' | 'user' | 'assistant';
+  content: string;
+};
+
+export type OpenAIAdapterInput = {
+  input?: string;
+  messages?: OpenAIChatMessage[];
+  model?: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+};
+
+export type OpenAIAdapterOutput = {
+  provider: 'openai';
+  model: string;
+  outputText: string;
+  responseId?: string;
+  usage?: unknown;
+};
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-4.1-mini';
+
+export function getOpenAIAdapterStatus(): OpenAIAdapterStatus {
+  const configured = Boolean(process.env.OPENAI_API_KEY?.trim());
+  return {
+    configured,
+    status: configured ? 'configured' : 'missing_env',
+    baseUrl: process.env.OPENAI_API_BASE?.trim() || DEFAULT_BASE_URL,
+    model: process.env.OPENAI_MODEL?.trim() || DEFAULT_MODEL,
+    requiredEnv: ['OPENAI_API_KEY'],
+    optionalEnv: ['OPENAI_API_BASE', 'OPENAI_MODEL'],
+    truthBoundary: configured
+      ? 'OpenAI adapter is configured server-side. The API key must never be exposed to client code.'
+      : 'OPENAI_API_KEY is missing from the server environment. Adapter calls are blocked until the key exists in Vercel or the runtime environment.',
+  };
+}
+
+function normalizeMessages(input: OpenAIAdapterInput): OpenAIChatMessage[] {
+  if (input.messages?.length) return input.messages.filter((message) => message.content.trim());
+  const text = input.input?.trim();
+  if (!text) throw new Error('OPENAI_INPUT_REQUIRED');
+  return [{ role: 'user', content: text }];
+}
+
+function extractOutputText(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return '';
+  const record = payload as Record<string, unknown>;
+  if (typeof record.output_text === 'string') return record.output_text;
+
+  const output = record.output;
+  if (!Array.isArray(output)) return '';
+
+  const parts: string[] = [];
+  for (const item of output) {
+    if (!item || typeof item !== 'object') continue;
+    const content = (item as Record<string, unknown>).content;
+    if (!Array.isArray(content)) continue;
+    for (const contentItem of content) {
+      if (!contentItem || typeof contentItem !== 'object') continue;
+      const text = (contentItem as Record<string, unknown>).text;
+      if (typeof text === 'string') parts.push(text);
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+export async function runOpenAIAdapter(input: OpenAIAdapterInput): Promise<OpenAIAdapterOutput> {
+  const status = getOpenAIAdapterStatus();
+  if (!status.configured) throw new Error('OPENAI_API_KEY_MISSING');
+
+  const messages = normalizeMessages(input);
+  const model = input.model?.trim() || status.model;
+  const maxOutputTokens = Math.min(Math.max(input.maxOutputTokens ?? 800, 1), 4096);
+  const temperature = typeof input.temperature === 'number' ? input.temperature : 0.2;
+
+  const response = await fetch(`${status.baseUrl.replace(/\/$/, '')}/responses`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      input: messages.map((message) => ({ role: message.role, content: message.content })),
+      max_output_tokens: maxOutputTokens,
+      temperature,
+    }),
+  });
+
+  const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+  if (!response.ok) {
+    const error = payload?.error;
+    const message = error && typeof error === 'object' && typeof (error as Record<string, unknown>).message === 'string'
+      ? (error as Record<string, string>).message
+      : `OPENAI_HTTP_${response.status}`;
+    throw new Error(message);
+  }
+
+  const outputText = extractOutputText(payload);
+  return {
+    provider: 'openai',
+    model,
+    outputText,
+    responseId: typeof payload?.id === 'string' ? payload.id : undefined,
+    usage: payload?.usage,
+  };
+}

--- a/lib/dsg/remote-browser/provider-registry.ts
+++ b/lib/dsg/remote-browser/provider-registry.ts
@@ -1,0 +1,56 @@
+import type { RemoteBrowserProvider, RemoteBrowserProviderId } from './types';
+
+function hasAllEnv(names: string[]) {
+  return names.every((name) => Boolean(process.env[name]?.trim()));
+}
+
+function providerStatus(requiredEnv: string[]) {
+  return hasAllEnv(requiredEnv) ? 'adapter_pending' as const : 'missing_env' as const;
+}
+
+export function listRemoteBrowserProviders(): RemoteBrowserProvider[] {
+  const playwrightEnv = ['PLAYWRIGHT_CDP_WS_ENDPOINT'];
+  const browserbaseEnv = ['BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID'];
+  const steelEnv = ['STEEL_API_KEY'];
+
+  return [
+    {
+      id: 'playwright',
+      label: 'Playwright CDP/WS endpoint',
+      status: providerStatus(playwrightEnv),
+      requiredEnv: playwrightEnv,
+      optionalEnv: ['PLAYWRIGHT_DEFAULT_CONTEXT_ID'],
+      capabilities: ['navigate', 'inspect', 'screenshot', 'navigation_log', 'takeover_checkpoint'],
+      evidence: ['browser-session-id', 'navigation-log', 'screenshot-artifact', 'page-state'],
+      truthBoundary: 'Env can point to an existing CDP/WS browser endpoint, but this repo does not import Playwright yet. Adapter remains pending until executor code is added and verified.',
+    },
+    {
+      id: 'browserbase',
+      label: 'Browserbase remote browser',
+      status: providerStatus(browserbaseEnv),
+      requiredEnv: browserbaseEnv,
+      optionalEnv: ['BROWSERBASE_REGION', 'BROWSERBASE_PROJECT_NAME'],
+      capabilities: ['session_create', 'navigate', 'screenshot', 'session_replay', 'takeover_checkpoint'],
+      evidence: ['browserbase-session-id', 'screenshot-url', 'navigation-log', 'replay-url'],
+      truthBoundary: 'Browserbase needs its real API adapter before autonomous browser control can be claimed.',
+    },
+    {
+      id: 'steel',
+      label: 'Steel remote browser',
+      status: providerStatus(steelEnv),
+      requiredEnv: steelEnv,
+      optionalEnv: ['STEEL_BASE_URL'],
+      capabilities: ['session_create', 'navigate', 'screenshot', 'navigation_log', 'takeover_checkpoint'],
+      evidence: ['steel-session-id', 'screenshot-url', 'navigation-log'],
+      truthBoundary: 'Steel needs its real API adapter before autonomous browser control can be claimed.',
+    },
+  ];
+}
+
+export function getRemoteBrowserProvider(id: RemoteBrowserProviderId | undefined) {
+  const providers = listRemoteBrowserProviders();
+  if (!id) return providers.find((provider) => provider.status !== 'missing_env') ?? providers[0];
+  const provider = providers.find((candidate) => candidate.id === id);
+  if (!provider) throw new Error('REMOTE_BROWSER_PROVIDER_NOT_FOUND');
+  return provider;
+}

--- a/lib/dsg/remote-browser/session-store.ts
+++ b/lib/dsg/remote-browser/session-store.ts
@@ -1,0 +1,132 @@
+import type {
+  RemoteBrowserArtifact,
+  RemoteBrowserCheckpoint,
+  RemoteBrowserCreateSessionInput,
+  RemoteBrowserNavigationEvent,
+  RemoteBrowserSession,
+} from './types';
+import { getRemoteBrowserProvider } from './provider-registry';
+
+const sessions = new Map<string, RemoteBrowserSession>();
+
+function now() {
+  return new Date().toISOString();
+}
+
+function id(prefix: string) {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function event(input: Omit<RemoteBrowserNavigationEvent, 'id' | 'at'>): RemoteBrowserNavigationEvent {
+  return { id: id('nav'), at: now(), ...input };
+}
+
+export function createRemoteBrowserSession(input: RemoteBrowserCreateSessionInput): RemoteBrowserSession {
+  const provider = getRemoteBrowserProvider(input.providerId);
+  const createdAt = now();
+  const session: RemoteBrowserSession = {
+    id: id('rb'),
+    providerId: provider.id,
+    status: provider.status === 'missing_env' ? 'blocked' : 'created',
+    goal: input.goal,
+    startUrl: input.startUrl,
+    currentUrl: input.startUrl,
+    createdAt,
+    updatedAt: createdAt,
+    navigationLog: [
+      event({
+        action: 'session.create',
+        status: provider.status === 'missing_env' ? 'blocked' : 'completed',
+        url: input.startUrl,
+        detail: provider.status === 'missing_env'
+          ? `Provider ${provider.id} is missing required env: ${provider.requiredEnv.join(', ')}`
+          : `Provider ${provider.id} has env but executor adapter is pending. Session contract created only.`,
+      }),
+    ],
+    artifacts: [],
+    checkpoints: provider.status === 'missing_env'
+      ? [{
+          id: id('checkpoint'),
+          type: 'takeover',
+          state: 'active',
+          instruction: `Configure required env for ${provider.label}: ${provider.requiredEnv.join(', ')}`,
+          createdAt,
+        }]
+      : [],
+  };
+  sessions.set(session.id, session);
+  return session;
+}
+
+export function listRemoteBrowserSessions(): RemoteBrowserSession[] {
+  return Array.from(sessions.values()).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function getRemoteBrowserSession(sessionId: string): RemoteBrowserSession {
+  const session = sessions.get(sessionId);
+  if (!session) throw new Error('REMOTE_BROWSER_SESSION_NOT_FOUND');
+  return session;
+}
+
+export function appendRemoteBrowserNavigation(input: {
+  sessionId: string;
+  action: RemoteBrowserNavigationEvent['action'];
+  status: RemoteBrowserNavigationEvent['status'];
+  url?: string;
+  detail: string;
+}): RemoteBrowserSession {
+  const session = getRemoteBrowserSession(input.sessionId);
+  session.navigationLog.push(event({ action: input.action, status: input.status, url: input.url, detail: input.detail }));
+  session.currentUrl = input.url ?? session.currentUrl;
+  session.status = input.status === 'blocked' ? 'blocked' : input.status === 'failed' ? 'failed' : session.status;
+  session.updatedAt = now();
+  sessions.set(session.id, session);
+  return session;
+}
+
+export function addRemoteBrowserArtifact(input: Omit<RemoteBrowserArtifact, 'id' | 'createdAt'> & { sessionId: string }): RemoteBrowserSession {
+  const session = getRemoteBrowserSession(input.sessionId);
+  session.artifacts.push({
+    id: id('artifact'),
+    type: input.type,
+    status: input.status,
+    title: input.title,
+    detail: input.detail,
+    url: input.url,
+    createdAt: now(),
+  });
+  session.navigationLog.push(event({ action: 'screenshot.request', status: input.status === 'available' ? 'completed' : input.status, detail: input.detail, url: input.url }));
+  session.updatedAt = now();
+  sessions.set(session.id, session);
+  return session;
+}
+
+export function addRemoteBrowserCheckpoint(input: Omit<RemoteBrowserCheckpoint, 'id' | 'createdAt'> & { sessionId: string }): RemoteBrowserSession {
+  const session = getRemoteBrowserSession(input.sessionId);
+  session.checkpoints.push({
+    id: id('checkpoint'),
+    type: input.type,
+    state: input.state,
+    instruction: input.instruction,
+    resolvedAt: input.resolvedAt,
+    createdAt: now(),
+  });
+  session.status = input.state === 'active' ? 'blocked' : session.status;
+  session.navigationLog.push(event({ action: 'checkpoint.create', status: input.state === 'active' ? 'blocked' : 'completed', detail: input.instruction }));
+  session.updatedAt = now();
+  sessions.set(session.id, session);
+  return session;
+}
+
+export function resolveRemoteBrowserCheckpoint(input: { sessionId: string; checkpointId: string; detail?: string }): RemoteBrowserSession {
+  const session = getRemoteBrowserSession(input.sessionId);
+  const checkpoint = session.checkpoints.find((item) => item.id === input.checkpointId);
+  if (!checkpoint) throw new Error('REMOTE_BROWSER_CHECKPOINT_NOT_FOUND');
+  checkpoint.state = 'resolved';
+  checkpoint.resolvedAt = now();
+  session.status = 'running';
+  session.navigationLog.push(event({ action: 'checkpoint.resolve', status: 'completed', detail: input.detail ?? checkpoint.instruction }));
+  session.updatedAt = now();
+  sessions.set(session.id, session);
+  return session;
+}

--- a/lib/dsg/remote-browser/types.ts
+++ b/lib/dsg/remote-browser/types.ts
@@ -1,0 +1,76 @@
+export type RemoteBrowserProviderId = 'playwright' | 'browserbase' | 'steel';
+
+export type RemoteBrowserProviderStatus =
+  | 'configured'
+  | 'missing_env'
+  | 'adapter_pending';
+
+export type RemoteBrowserSessionStatus =
+  | 'created'
+  | 'running'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+  | 'closed';
+
+export type RemoteBrowserCheckpointType = 'login' | 'captcha' | 'consent' | 'takeover' | 'privileged_action';
+export type RemoteBrowserCheckpointState = 'pending' | 'active' | 'resolved';
+
+export type RemoteBrowserProvider = {
+  id: RemoteBrowserProviderId;
+  label: string;
+  status: RemoteBrowserProviderStatus;
+  requiredEnv: string[];
+  optionalEnv: string[];
+  capabilities: string[];
+  evidence: string[];
+  truthBoundary: string;
+};
+
+export type RemoteBrowserNavigationEvent = {
+  id: string;
+  at: string;
+  action: 'session.create' | 'navigate' | 'inspect' | 'screenshot.request' | 'checkpoint.create' | 'checkpoint.resolve' | 'session.close' | 'note';
+  status: 'running' | 'completed' | 'blocked' | 'failed';
+  url?: string;
+  detail: string;
+};
+
+export type RemoteBrowserArtifact = {
+  id: string;
+  type: 'screenshot' | 'page_state' | 'navigation_log' | 'manual_note';
+  status: 'available' | 'blocked' | 'failed';
+  title: string;
+  detail: string;
+  url?: string;
+  createdAt: string;
+};
+
+export type RemoteBrowserCheckpoint = {
+  id: string;
+  type: RemoteBrowserCheckpointType;
+  state: RemoteBrowserCheckpointState;
+  instruction: string;
+  createdAt: string;
+  resolvedAt?: string;
+};
+
+export type RemoteBrowserSession = {
+  id: string;
+  providerId: RemoteBrowserProviderId;
+  status: RemoteBrowserSessionStatus;
+  goal: string;
+  startUrl: string;
+  currentUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  navigationLog: RemoteBrowserNavigationEvent[];
+  artifacts: RemoteBrowserArtifact[];
+  checkpoints: RemoteBrowserCheckpoint[];
+};
+
+export type RemoteBrowserCreateSessionInput = {
+  providerId?: RemoteBrowserProviderId;
+  goal: string;
+  startUrl: string;
+};


### PR DESCRIPTION
## Summary

Refines the App Builder UI into a customer-facing workspace while preserving the existing production-ready backend/runtime flow.

## What changed

- Reworded the guided App Builder flow for customer service usage.
- Removed visible Workspace/Actor input fields from the customer UI.
- Uses stable header values internally instead of asking customers to type technical IDs.
- Adds claim-status copy that maps to the existing evidence boundary.
- Adds Vercel quota policy copy: this UI flow creates a GitHub PR first and does not trigger production deploy.
- Adds PR evidence panel with repository, branch, generated file count, audit status, PR link, and Copy proof JSON.
- Keeps all existing endpoints unchanged:
  - `POST /api/dsg/app-builder/jobs`
  - `POST /api/dsg/app-builder/jobs/:jobId/plan`
  - `POST /api/dsg/app-builder/jobs/:jobId/approval`
  - `POST /api/dsg/app-builder/jobs/:jobId/runtime-handoff`
  - `POST /api/dsg/app-builder/jobs/:jobId/tool-call`

## Truth boundary

This PR does **not** claim production verification and does **not** trigger Vercel deploy. It only changes customer-facing UI/UX language and evidence display.

## Vercel quota note

No Vercel deploy was triggered from this work. Review via GitHub first; use preview/production deployment only when evidence proof is required.
