### PR TITLE
Add enterprise marketplace readiness audit kit

### DIFF
--- a/app/api/dsg/marketplace/readiness/route.ts
+++ b/app/api/dsg/marketplace/readiness/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getEnterpriseMarketplaceReadinessReport } from '@/lib/dsg/marketplace/readiness';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getEnterpriseMarketplaceReadinessReport());
+}

--- a/app/enterprise/readiness/page.tsx
+++ b/app/enterprise/readiness/page.tsx
@@ -1,0 +1,76 @@
+import { getEnterpriseMarketplaceReadinessReport } from '@/lib/dsg/marketplace/readiness';
+
+const statusTone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export const dynamic = 'force-dynamic';
+
+export default function EnterpriseReadinessPage() {
+  const report = getEnterpriseMarketplaceReadinessReport();
+
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-7xl">
+        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.24em] text-amber-200">Enterprise Marketplace Audit Kit</p>
+              <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">DSG ONE V1 readiness review</h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">{report.summary}</p>
+            </div>
+            <span className={`w-fit rounded-full border px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.18em] ${statusTone[report.verdict]}`}>
+              {report.verdict}
+            </span>
+          </div>
+          <div className="mt-5 rounded-2xl border border-white/10 bg-black/25 p-4 font-mono text-xs leading-6 text-slate-400">
+            <p>kit: {report.kit}</p>
+            <p>generatedAt: {report.generatedAt}</p>
+            <p>policy: {report.noMockPolicy.rule}</p>
+          </div>
+        </header>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          {report.gates.map((gate) => (
+            <article key={gate.id} className="rounded-[2rem] border border-white/10 bg-[#111827]/80 p-5 backdrop-blur-xl">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-slate-500">{gate.id}</p>
+                  <h2 className="mt-2 text-2xl font-black text-white">{gate.title}</h2>
+                </div>
+                <span className={`rounded-full border px-3 py-1 font-mono text-xs font-bold ${statusTone[gate.status]}`}>{gate.status}</span>
+              </div>
+              <p className="mt-4 text-sm leading-7 text-slate-300">{gate.userBenefit}</p>
+
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/5 p-4">
+                  <h3 className="font-bold text-emerald-200">Verified evidence</h3>
+                  {gate.verifiedEvidence.length > 0 ? (
+                    <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                      {gate.verifiedEvidence.map((item) => <li key={item}>✓ {item}</li>)}
+                    </ul>
+                  ) : (
+                    <p className="mt-3 text-sm text-slate-500">No attached proof yet.</p>
+                  )}
+                </div>
+                <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                  <h3 className="font-bold text-amber-200">Required evidence</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {gate.requiredEvidence.map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
+                <h3 className="font-bold text-cyan-200">Next action</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">{gate.nextAction}</p>
+              </div>
+            </article>
+          ))}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/docs/ENTERPRISE_MARKETPLACE_READINESS_AUDIT_KIT.md
+++ b/docs/ENTERPRISE_MARKETPLACE_READINESS_AUDIT_KIT.md
@@ -1,0 +1,81 @@
+# Enterprise Marketplace Readiness Audit Kit
+
+Date: 2026-05-11
+Branch: `enterprise-marketplace-readiness-audit-kit`
+
+## Purpose
+
+This kit turns marketplace readiness into an evidence-gated review instead of a marketing claim.
+
+It follows the uploaded execution baseline:
+
+- verify real files, routes, deployments, and logs before trusting a claim
+- keep demo-only work out of the production release path
+- mark unverified items as `REVIEW` or `BLOCKED`, never `PASS`
+- give the user a visible next action for every blocked state
+
+## Added routes
+
+- `GET /api/dsg/marketplace/readiness`
+  - Returns the machine-readable readiness report.
+  - Source: `lib/dsg/marketplace/readiness.ts`
+
+- `GET /enterprise/readiness`
+  - Customer/operator-facing readiness page.
+  - Shows verdict, gate status, verified evidence, required evidence, and next action.
+
+## Added smoke script
+
+```bash
+APP_URL=https://your-production-url.example npm run smoke:marketplace-readiness
+```
+
+The script fails if:
+
+- `APP_URL` or `DSG_ONE_V1_PRODUCTION_URL` is missing
+- URL is not HTTPS
+- endpoint does not return JSON
+- readiness schema is invalid
+- a `PASS` verdict conflicts with blocked gates
+
+## Gate status rules
+
+### PASS
+
+Only allowed when the required evidence is attached and can be traced to a real file, route, test, deployment, or customer-facing page.
+
+### REVIEW
+
+Allowed when there is partial evidence, but the marketplace-ready claim is not fully proven.
+
+### BLOCKED
+
+Required when the evidence does not exist yet.
+
+## Current default verdict
+
+`BLOCKED`
+
+Reason: production deployment and app-builder proof routes exist, but enterprise marketplace readiness still needs proof for:
+
+1. server-side RBAC and organization isolation
+2. entitlement, plan, seat, and quota behavior
+3. customer-facing Terms, Privacy, Security, Support pages
+4. accessibility and QA evidence
+5. full get-started smoke test from a fresh account
+
+## No-mock policy
+
+No gate may be marked `PASS` using mock data, localStorage-only state, memory-only stores, guessed metrics, or unverified claims.
+
+## How this fits the release flow
+
+This kit is not the final marketplace submission. It is the review frame that blocks false readiness claims and shows exactly what evidence is missing.
+
+Recommended next PRs:
+
+1. Add customer-facing legal/support pages.
+2. Add RBAC/org-isolation negative tests.
+3. Add entitlement/quota gate proof.
+4. Add accessibility checklist and smoke test evidence.
+5. Attach production deployment proof hashes to release notes.

--- a/lib/dsg/marketplace/readiness.ts
+++ b/lib/dsg/marketplace/readiness.ts
@@ -1,0 +1,144 @@
+export type MarketplaceReadinessStatus = 'PASS' | 'REVIEW' | 'BLOCKED';
+
+export type MarketplaceReadinessGate = {
+  id: string;
+  title: string;
+  status: MarketplaceReadinessStatus;
+  userBenefit: string;
+  verifiedEvidence: string[];
+  requiredEvidence: string[];
+  nextAction: string;
+};
+
+export type MarketplaceReadinessReport = {
+  ok: true;
+  product: 'DSG ONE V1';
+  kit: 'enterprise-marketplace-readiness-audit-kit';
+  generatedAt: string;
+  verdict: MarketplaceReadinessStatus;
+  summary: string;
+  gates: MarketplaceReadinessGate[];
+  noMockPolicy: {
+    enforced: true;
+    rule: string;
+  };
+};
+
+const gates: MarketplaceReadinessGate[] = [
+  {
+    id: 'deployment-proof',
+    title: 'Production deployment proof',
+    status: 'REVIEW',
+    userBenefit: 'ผู้ใช้มั่นใจได้ว่าแอปเปิดได้จริงใน production ไม่ใช่แค่โค้ดใน repo',
+    verifiedEvidence: [
+      'Existing package script: dsg:production-flow-check',
+      'Existing Vercel deployment proof must be attached from deployment logs before marketplace submission',
+    ],
+    requiredEvidence: [
+      'Latest production deployment READY proof',
+      'Production URL returns 2xx without unexpected auth wall for intended audience',
+      'Body/proof hash from scripts/dsg-production-flow-check.mjs',
+    ],
+    nextAction: 'Run dsg:production-flow-check with the exact production URL and attach proofHash to the release note.',
+  },
+  {
+    id: 'app-builder-proof',
+    title: 'App Builder governed flow proof',
+    status: 'REVIEW',
+    userBenefit: 'ผู้ใช้เห็น PRD, plan, proof และ blocked state โดยไม่ถูกหลอกว่า production-ready ก่อนมีหลักฐานครบ',
+    verifiedEvidence: [
+      'Existing endpoint: /api/dsg/app-builder/proof',
+      'Existing smoke script: smoke:app-builder-flow-proof',
+    ],
+    requiredEvidence: [
+      'GET /api/dsg/app-builder/proof returns ok=true and status=PASS',
+      'Smoke assertion proves runtime remains blocked without executor proof',
+      'Claim boundary keeps productionReadyClaim=false until evidence exists',
+    ],
+    nextAction: 'Run smoke:app-builder-flow-proof against the production APP_URL and store the output in the audit packet.',
+  },
+  {
+    id: 'security-rbac-org-isolation',
+    title: 'Security, RBAC, and organization isolation',
+    status: 'BLOCKED',
+    userBenefit: 'ผู้ใช้ enterprise ต้องมั่นใจว่าสิทธิ์และข้อมูลข้ามองค์กรไม่รั่ว',
+    verifiedEvidence: [],
+    requiredEvidence: [
+      'Server-side RBAC proof for critical read/write routes',
+      'Cross-org access denial test',
+      'Audit event for privileged actions',
+      'Deny-by-default error contract',
+    ],
+    nextAction: 'Add or attach tests proving unauthorized role and cross-org access are denied server-side.',
+  },
+  {
+    id: 'commercial-entitlement',
+    title: 'Billing, entitlement, seat, and quota gates',
+    status: 'BLOCKED',
+    userBenefit: 'ผู้ใช้รู้ขอบเขตแพ็กเกจชัดเจน และระบบไม่เปิด bypass ฟรีในเส้นทางสำคัญ',
+    verifiedEvidence: [],
+    requiredEvidence: [
+      'Plan/seat/quota source-of-truth',
+      'Quota exceeded behavior with clear message',
+      'Upgrade path proof',
+      'Entitlement denial test for restricted action',
+    ],
+    nextAction: 'Wire entitlement checks to production source-of-truth and add a negative test for quota/seat denial.',
+  },
+  {
+    id: 'legal-support-package',
+    title: 'Marketplace legal and support package',
+    status: 'BLOCKED',
+    userBenefit: 'ผู้ซื้อ enterprise มี Terms, Privacy, Security, Support และ data handling clarity ก่อนติดตั้ง',
+    verifiedEvidence: [],
+    requiredEvidence: [
+      'Terms page',
+      'Privacy page',
+      'Security page',
+      'Support/SLA page',
+      'Data retention and subprocessors statement when applicable',
+    ],
+    nextAction: 'Create customer-facing legal/support pages and link them from the readiness page.',
+  },
+  {
+    id: 'accessibility-qa',
+    title: 'Accessibility and QA proof',
+    status: 'BLOCKED',
+    userBenefit: 'ผู้ใช้ทำงานได้ด้วย keyboard/screen reader และทีมขายมีหลักฐานคุณภาพก่อนส่ง marketplace',
+    verifiedEvidence: [],
+    requiredEvidence: [
+      'Lint result or explicit lint waiver',
+      'WCAG 2.2 AA checklist for core pages',
+      'Keyboard navigation proof',
+      'E2E smoke for first-time user get-started flow',
+    ],
+    nextAction: 'Add automated smoke coverage and a manual accessibility checklist for /dsg/app-builder.',
+  },
+];
+
+function deriveVerdict(items: MarketplaceReadinessGate[]): MarketplaceReadinessStatus {
+  if (items.some((item) => item.status === 'BLOCKED')) return 'BLOCKED';
+  if (items.some((item) => item.status === 'REVIEW')) return 'REVIEW';
+  return 'PASS';
+}
+
+export function getEnterpriseMarketplaceReadinessReport(): MarketplaceReadinessReport {
+  const verdict = deriveVerdict(gates);
+
+  return {
+    ok: true,
+    product: 'DSG ONE V1',
+    kit: 'enterprise-marketplace-readiness-audit-kit',
+    generatedAt: new Date().toISOString(),
+    verdict,
+    summary:
+      verdict === 'PASS'
+        ? 'All marketplace readiness gates have attached evidence.'
+        : 'Marketplace readiness is not a full pass yet. Existing deployment and app-builder proof can be attached, but security, entitlement, legal/support, accessibility, and QA evidence are still required.',
+    gates,
+    noMockPolicy: {
+      enforced: true,
+      rule: 'No gate may be marked PASS unless the required evidence is generated by a real file, route, test, deployment, or customer-facing page in this repository or production environment.',
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dsg:product-ready": "node scripts/dsg-product-ready-check.mjs",
     "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint",
     "smoke:memory-api": "bash scripts/dsg-memory-api-smoke.sh",
-    "smoke:app-builder-flow-proof": "node scripts/dsg-app-builder-flow-proof-smoke.mjs"
+    "smoke:app-builder-flow-proof": "node scripts/dsg-app-builder-flow-proof-smoke.mjs",
+    "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-marketplace-readiness-check.mjs
+++ b/scripts/dsg-marketplace-readiness-check.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const appUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+
+if (!appUrl) {
+  console.error('BLOCK: APP_URL or DSG_ONE_V1_PRODUCTION_URL is required');
+  process.exit(1);
+}
+
+if (!appUrl.startsWith('https://')) {
+  console.error('BLOCK: marketplace readiness check requires an https URL');
+  process.exit(1);
+}
+
+const endpoint = `${appUrl.replace(/\/$/, '')}/api/dsg/marketplace/readiness`;
+const response = await fetch(endpoint, {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    'user-agent': 'dsg-marketplace-readiness-check/1.0',
+  },
+  cache: 'no-store',
+});
+
+const text = await response.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  console.error('BLOCK: readiness endpoint returned non-json');
+  console.error(text.slice(0, 500));
+  process.exit(1);
+}
+
+if (!response.ok || json?.ok !== true) {
+  console.error('BLOCK: readiness endpoint failed');
+  console.error(JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+const gates = Array.isArray(json.gates) ? json.gates : [];
+const blocked = gates.filter((gate) => gate.status === 'BLOCKED');
+const review = gates.filter((gate) => gate.status === 'REVIEW');
+const pass = gates.filter((gate) => gate.status === 'PASS');
+const validStatuses = gates.every((gate) => ['PASS', 'REVIEW', 'BLOCKED'].includes(gate.status));
+const noMockRulePresent = json.noMockPolicy?.enforced === true && typeof json.noMockPolicy?.rule === 'string';
+
+if (!validStatuses || !noMockRulePresent || gates.length === 0) {
+  console.error('BLOCK: readiness report schema is invalid');
+  console.error(JSON.stringify({ validStatuses, noMockRulePresent, gates: gates.length }, null, 2));
+  process.exit(1);
+}
+
+console.log('PASS: marketplace readiness endpoint responded with a valid audit report');
+console.log(JSON.stringify({
+  endpoint,
+  verdict: json.verdict,
+  gates: gates.length,
+  pass: pass.length,
+  review: review.length,
+  blocked: blocked.length,
+  noMockPolicy: json.noMockPolicy,
+}, null, 2));
+
+if (json.verdict === 'PASS' && blocked.length > 0) {
+  console.error('BLOCK: verdict cannot be PASS while blocked gates exist');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Adds an evidence-first enterprise marketplace readiness audit kit.
- Adds a machine-readable readiness endpoint: `GET /api/dsg/marketplace/readiness`.
- Adds an operator/customer-facing readiness page: `/enterprise/readiness`.
- Adds smoke script: `npm run smoke:marketplace-readiness`.
- Documents the no-mock/no-guess gate policy in `docs/ENTERPRISE_MARKETPLACE_READINESS_AUDIT_KIT.md`.

## Evidence-first behavior
- Default verdict is intentionally `BLOCKED`, not PASS.
- Gates without real proof remain `BLOCKED`.
- Partial deployment/app-builder proof remains `REVIEW` until smoke output is attached.
- No mock, guessed, or local-only evidence is accepted as marketplace readiness proof.

## Files changed
- `lib/dsg/marketplace/readiness.ts`
- `app/api/dsg/marketplace/readiness/route.ts`
- `app/enterprise/readiness/page.tsx`
- `scripts/dsg-marketplace-readiness-check.mjs`
- `docs/ENTERPRISE_MARKETPLACE_READINESS_AUDIT_KIT.md`
- `package.json`

## Verification from repo inspection
- Existing scripts read before change: `dsg:verify`, `dsg:production-flow-check`, `dsg:product-ready`, `smoke:app-builder-flow-proof`.
- Existing proof endpoint read before change: `/api/dsg/app-builder/proof`.
- `tsconfig.json` supports `@/*` path alias and JSON module resolution.
- Branch is ahead of `main` by 6 and behind by 0.

## Not claimed
- This PR does not claim full enterprise marketplace readiness.
- This PR does not add mock data.
- This PR does not mark RBAC, entitlement, legal/support, accessibility, or fresh-account smoke tests as PASS without evidence.