### PR TITLE
Add enterprise legal and support readiness pages

### DIFF
--- a/app/enterprise/privacy/page.tsx
+++ b/app/enterprise/privacy/page.tsx
@@ -1,0 +1,43 @@
+const sections = [
+  {
+    title: 'Data handling boundary',
+    body: 'DSG ONE V1 should only process customer data required to operate the app-builder, readiness, proof, and governance workflows. Sensitive or regulated data must be classified before use.',
+  },
+  {
+    title: 'Evidence and audit data',
+    body: 'Readiness proof, audit events, generated PRDs, and operational logs may be retained to support traceability and customer review. Retention periods must be finalized before marketplace submission.',
+  },
+  {
+    title: 'No sale of customer data',
+    body: 'Customer data should not be sold to third parties. Any subprocessors or integrated services must be documented before enterprise marketplace approval.',
+  },
+  {
+    title: 'Customer controls',
+    body: 'Customers should be able to request deletion, export, or review of their workspace data according to the final support and data retention process.',
+  },
+];
+
+export default function EnterprisePrivacyPage() {
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-5xl rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl">
+        <p className="font-mono text-xs uppercase tracking-[0.24em] text-emerald-200">Enterprise Privacy</p>
+        <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">Privacy Notice</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          Status: review draft. This page creates a customer-visible privacy boundary. It must be approved and matched to real data flows before marketplace submission.
+        </p>
+        <div className="mt-6 grid gap-4">
+          {sections.map((section) => (
+            <article key={section.title} className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+              <h2 className="text-xl font-black text-white">{section.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{section.body}</p>
+            </article>
+          ))}
+        </div>
+        <a href="/enterprise/readiness" className="mt-6 inline-flex rounded-full border border-emerald-400/40 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-emerald-200">
+          Back to readiness
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/app/enterprise/security/page.tsx
+++ b/app/enterprise/security/page.tsx
@@ -1,0 +1,43 @@
+const controls = [
+  {
+    title: 'Evidence-first readiness gates',
+    body: 'Marketplace readiness gates remain REVIEW or BLOCKED until backed by a real route, test, deployment, customer-facing page, or audit proof.',
+  },
+  {
+    title: 'Access control expectations',
+    body: 'Enterprise deployment must prove server-side RBAC, organization isolation, deny-by-default behavior, and audit events for privileged actions before the security gate can pass.',
+  },
+  {
+    title: 'Secrets and production boundaries',
+    body: 'Secrets must stay in the deployment environment and must not be exposed through generated apps, client logs, public pages, or model prompts.',
+  },
+  {
+    title: 'Incident and vulnerability intake',
+    body: 'A customer-visible support path must exist for security reports, incident triage, remediation status, and coordinated disclosure before marketplace launch.',
+  },
+];
+
+export default function EnterpriseSecurityPage() {
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-5xl rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl">
+        <p className="font-mono text-xs uppercase tracking-[0.24em] text-cyan-200">Enterprise Security</p>
+        <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">Security Overview</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          Status: review draft. This page states the security control targets for marketplace review. It does not claim SOC 2, ISO, penetration-test, or compliance approval without external evidence.
+        </p>
+        <div className="mt-6 grid gap-4">
+          {controls.map((control) => (
+            <article key={control.title} className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+              <h2 className="text-xl font-black text-white">{control.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{control.body}</p>
+            </article>
+          ))}
+        </div>
+        <a href="/enterprise/readiness" className="mt-6 inline-flex rounded-full border border-cyan-400/40 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">
+          Back to readiness
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/app/enterprise/support/page.tsx
+++ b/app/enterprise/support/page.tsx
@@ -1,0 +1,43 @@
+const supportItems = [
+  {
+    title: 'Support intake',
+    body: 'Customers need a documented channel for product issues, security reports, billing questions, and marketplace installation blockers.',
+  },
+  {
+    title: 'Severity handling',
+    body: 'Incidents should be classified by severity, business impact, data exposure risk, and customer workaround availability before a response commitment is made.',
+  },
+  {
+    title: 'Operational runbook',
+    body: 'Support responses should reference deployment status, readiness gates, smoke-test output, rollback notes, and known blocked evidence before giving a customer decision.',
+  },
+  {
+    title: 'Marketplace handoff',
+    body: 'Submission should include demo script, first-time user checklist, escalation route, and owner for legal/security/support approval.',
+  },
+];
+
+export default function EnterpriseSupportPage() {
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-5xl rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl">
+        <p className="font-mono text-xs uppercase tracking-[0.24em] text-violet-200">Enterprise Support</p>
+        <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">Support and SLA Boundary</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          Status: review draft. This page defines the support boundary needed for marketplace readiness. It does not promise a final SLA until support owners and response times are approved.
+        </p>
+        <div className="mt-6 grid gap-4">
+          {supportItems.map((item) => (
+            <article key={item.title} className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+              <h2 className="text-xl font-black text-white">{item.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{item.body}</p>
+            </article>
+          ))}
+        </div>
+        <a href="/enterprise/readiness" className="mt-6 inline-flex rounded-full border border-violet-400/40 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-violet-200">
+          Back to readiness
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/app/enterprise/terms/page.tsx
+++ b/app/enterprise/terms/page.tsx
@@ -1,0 +1,43 @@
+const sections = [
+  {
+    title: 'Use of service',
+    body: 'DSG ONE V1 is provided as a governed app-builder and readiness workspace. Operators must verify generated plans, proofs, and deployment evidence before treating any output as production-ready.',
+  },
+  {
+    title: 'No unsupported production claim',
+    body: 'The service must not be represented as fully enterprise marketplace ready, compliance-approved, or autonomous-complete unless the required readiness evidence is attached and review gates are marked accordingly.',
+  },
+  {
+    title: 'Customer responsibilities',
+    body: 'Customers are responsible for verifying workspace access, data permissions, billing entitlements, and any regulated use case before deployment to end users.',
+  },
+  {
+    title: 'Availability and changes',
+    body: 'Operational readiness, deployment status, support coverage, and incident response commitments must be documented in the support page and validated before marketplace submission.',
+  },
+];
+
+export default function EnterpriseTermsPage() {
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-5xl rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl">
+        <p className="font-mono text-xs uppercase tracking-[0.24em] text-amber-200">Enterprise Terms</p>
+        <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">Terms of Service</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          Status: review draft. This page gives customers a visible operating boundary for marketplace review. It is not marked as legal-approved until counsel or the responsible operator approves it.
+        </p>
+        <div className="mt-6 grid gap-4">
+          {sections.map((section) => (
+            <article key={section.title} className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+              <h2 className="text-xl font-black text-white">{section.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{section.body}</p>
+            </article>
+          ))}
+        </div>
+        <a href="/enterprise/readiness" className="mt-6 inline-flex rounded-full border border-amber-400/40 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-amber-200">
+          Back to readiness
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/lib/dsg/marketplace/readiness.ts
+++ b/lib/dsg/marketplace/readiness.ts
@@ -88,17 +88,23 @@ const gates: MarketplaceReadinessGate[] = [
   {
     id: 'legal-support-package',
     title: 'Marketplace legal and support package',
-    status: 'BLOCKED',
+    status: 'REVIEW',
     userBenefit: 'ผู้ซื้อ enterprise มี Terms, Privacy, Security, Support และ data handling clarity ก่อนติดตั้ง',
-    verifiedEvidence: [],
+    verifiedEvidence: [
+      'Customer-facing route: /enterprise/terms',
+      'Customer-facing route: /enterprise/privacy',
+      'Customer-facing route: /enterprise/security',
+      'Customer-facing route: /enterprise/support',
+    ],
     requiredEvidence: [
       'Terms page',
       'Privacy page',
       'Security page',
       'Support/SLA page',
       'Data retention and subprocessors statement when applicable',
+      'Responsible owner approval before marketplace submission',
     ],
-    nextAction: 'Create customer-facing legal/support pages and link them from the readiness page.',
+    nextAction: 'Review the customer-facing legal/support draft pages and attach owner approval before moving this gate to PASS.',
   },
   {
     id: 'accessibility-qa',
@@ -134,7 +140,7 @@ export function getEnterpriseMarketplaceReadinessReport(): MarketplaceReadinessR
     summary:
       verdict === 'PASS'
         ? 'All marketplace readiness gates have attached evidence.'
-        : 'Marketplace readiness is not a full pass yet. Existing deployment and app-builder proof can be attached, but security, entitlement, legal/support, accessibility, and QA evidence are still required.',
+        : 'Marketplace readiness is not a full pass yet. Existing deployment and app-builder proof can be attached, but security, entitlement, accessibility, QA evidence, and owner approvals are still required.',
     gates,
     noMockPolicy: {
       enforced: true,


### PR DESCRIPTION
## Summary
- Adds customer-facing enterprise draft pages:
  - `/enterprise/terms`
  - `/enterprise/privacy`
  - `/enterprise/security`
  - `/enterprise/support`
- Updates the marketplace readiness model so `legal-support-package` moves from `BLOCKED` to `REVIEW`, not PASS.

## Evidence-first boundary
- These pages are review drafts.
- This PR does not claim legal approval, SOC 2, ISO, penetration test approval, final SLA, or marketplace acceptance.
- Gate remains `REVIEW` until owner/legal/security/support approval is attached.

## Verification
- Read existing readiness model before editing.
- Diff checked against `main`: ahead by 5, behind by 0.
- Changed files: 5.
- No package/config/build/runtime-core changes.

## Next required evidence before PASS
- Owner approval for Terms/Privacy/Security/Support pages.
- Data retention and subprocessors statement, if applicable.
- Support owner and response-time approval.
- Security owner approval for claims shown on `/enterprise/security`.