### PR TITLE
Add enterprise accessibility QA readiness kit

### DIFF
--- a/app/api/dsg/marketplace/accessibility-qa/route.ts
+++ b/app/api/dsg/marketplace/accessibility-qa/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getAccessibilityQaReport } from '@/lib/dsg/marketplace/accessibility-qa';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getAccessibilityQaReport());
+}

--- a/app/enterprise/accessibility/page.tsx
+++ b/app/enterprise/accessibility/page.tsx
@@ -1,0 +1,61 @@
+import { getAccessibilityQaReport } from '@/lib/dsg/marketplace/accessibility-qa';
+
+const tone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export const dynamic = 'force-dynamic';
+
+export default function EnterpriseAccessibilityPage() {
+  const report = getAccessibilityQaReport();
+
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-6xl">
+        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-cyan-200">Enterprise Accessibility QA</p>
+          <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h1 className="font-serif text-4xl font-black tracking-tight md:text-6xl">Accessibility and QA Evidence</h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">Evidence checklist for accessibility and QA review. PASS requires attached review notes or smoke output.</p>
+            </div>
+            <span className={`w-fit rounded-full border px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.18em] ${tone[report.verdict]}`}>{report.verdict}</span>
+          </div>
+          <p className="mt-4 rounded-2xl border border-white/10 bg-black/25 p-4 font-mono text-xs leading-6 text-slate-400">{report.noMockPolicy.rule}</p>
+        </header>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          {report.checks.map((check) => (
+            <article key={check.id} className="rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-slate-500">{check.id}</p>
+                  <h2 className="mt-2 text-2xl font-black text-white">{check.title}</h2>
+                </div>
+                <span className={`rounded-full border px-3 py-1 font-mono text-xs font-bold ${tone[check.status]}`}>{check.status}</span>
+              </div>
+              <p className="mt-4 text-sm leading-7 text-slate-300">{check.userBenefit}</p>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/5 p-4">
+                  <h3 className="font-bold text-emerald-200">Evidence</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {(check.evidence.length ? check.evidence : ['No attached evidence yet']).map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                  <h3 className="font-bold text-amber-200">Required</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {check.requiredBeforePass.map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4 text-sm leading-6 text-slate-300">Next: {check.nextAction}</p>
+            </article>
+          ))}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/docs/ENTERPRISE_ACCESSIBILITY_QA_KIT.md
+++ b/docs/ENTERPRISE_ACCESSIBILITY_QA_KIT.md
@@ -1,0 +1,49 @@
+# Enterprise Accessibility QA Kit
+
+Date: 2026-05-11
+Branch: `enterprise-accessibility-qa-kit`
+
+## Purpose
+
+This kit adds an evidence frame for accessibility and QA readiness. It does not claim WCAG approval, marketplace approval, or full QA completion by itself.
+
+## Added routes
+
+- `GET /api/dsg/marketplace/accessibility-qa`
+- `GET /enterprise/accessibility`
+
+## Added script
+
+```bash
+APP_URL=https://your-preview-or-production-url.example npm run smoke:accessibility-qa
+```
+
+The script validates that the accessibility QA endpoint returns a valid evidence report with gate statuses and a no-mock policy.
+
+## External standards used as checklist inputs
+
+- WCAG 2.2: keyboard access, focus visible, labels, headings, status clarity, and predictable navigation.
+- OWASP ASVS: access control, logging, input validation, and secure API verification as inputs to enterprise security review.
+- Marketplace SaaS review expectations: customer-visible support, terms, privacy, technical review, and operational evidence.
+
+## Current status
+
+`accessibility-qa` is moved from `BLOCKED` to `REVIEW` because this PR adds:
+
+- accessibility QA model
+- accessibility QA API endpoint
+- accessibility QA page
+- smoke script
+
+It is not `PASS` yet because the following evidence is still missing:
+
+1. smoke output against a deployed `APP_URL`
+2. manual keyboard navigation notes
+3. heading/label/landmark review notes
+4. visual contrast and focus-visible review notes
+5. fresh-account first-value smoke test evidence
+6. lint result or explicit lint waiver
+
+## No false claim rule
+
+Do not mark this gate `PASS` until real review notes, smoke output, or deployment evidence are attached to the release packet.

--- a/lib/dsg/marketplace/accessibility-qa.ts
+++ b/lib/dsg/marketplace/accessibility-qa.ts
@@ -1,0 +1,81 @@
+export type AccessibilityQaStatus = 'PASS' | 'REVIEW' | 'BLOCKED';
+
+export type AccessibilityQaCheck = {
+  id: string;
+  title: string;
+  status: AccessibilityQaStatus;
+  userBenefit: string;
+  evidence: string[];
+  requiredBeforePass: string[];
+  nextAction: string;
+};
+
+export type AccessibilityQaReport = {
+  ok: true;
+  kit: 'enterprise-accessibility-qa-kit';
+  generatedAt: string;
+  verdict: AccessibilityQaStatus;
+  scope: string[];
+  checks: AccessibilityQaCheck[];
+  noMockPolicy: { enforced: true; rule: string };
+};
+
+const checks: AccessibilityQaCheck[] = [
+  {
+    id: 'keyboard-navigation',
+    title: 'Keyboard navigation',
+    status: 'BLOCKED',
+    userBenefit: 'Core flows must be usable without a mouse.',
+    evidence: [],
+    requiredBeforePass: ['Keyboard traversal notes', 'Focus order notes', 'Primary action review'],
+    nextAction: 'Attach keyboard review notes before PASS.',
+  },
+  {
+    id: 'semantic-structure',
+    title: 'Semantic structure',
+    status: 'BLOCKED',
+    userBenefit: 'Core pages must expose clear headings, labels, landmarks, and state text.',
+    evidence: [],
+    requiredBeforePass: ['Heading order review', 'Form label review', 'Landmark review', 'State wording review'],
+    nextAction: 'Attach semantic structure review notes before PASS.',
+  },
+  {
+    id: 'visual-clarity',
+    title: 'Visual clarity',
+    status: 'BLOCKED',
+    userBenefit: 'Users must be able to read verdicts, states, and next actions clearly.',
+    evidence: [],
+    requiredBeforePass: ['Contrast review', 'Focus-visible review', 'Mobile viewport review'],
+    nextAction: 'Attach visual review evidence before PASS.',
+  },
+  {
+    id: 'qa-smoke',
+    title: 'QA smoke',
+    status: 'REVIEW',
+    userBenefit: 'Reviewers need a real endpoint, page, and smoke script before submission.',
+    evidence: ['Endpoint: /api/dsg/marketplace/accessibility-qa', 'Page: /enterprise/accessibility', 'Script: smoke:accessibility-qa'],
+    requiredBeforePass: ['Run smoke:accessibility-qa', 'Run smoke:marketplace-readiness', 'Run smoke:app-builder-flow-proof'],
+    nextAction: 'Run smoke scripts against preview or production and attach output before PASS.',
+  },
+];
+
+function deriveVerdict(items: AccessibilityQaCheck[]): AccessibilityQaStatus {
+  if (items.some((item) => item.status === 'BLOCKED')) return 'BLOCKED';
+  if (items.some((item) => item.status === 'REVIEW')) return 'REVIEW';
+  return 'PASS';
+}
+
+export function getAccessibilityQaReport(): AccessibilityQaReport {
+  return {
+    ok: true,
+    kit: 'enterprise-accessibility-qa-kit',
+    generatedAt: new Date().toISOString(),
+    verdict: deriveVerdict(checks),
+    scope: ['/dsg/app-builder', '/enterprise/readiness', '/enterprise/terms', '/enterprise/privacy', '/enterprise/security', '/enterprise/support'],
+    checks,
+    noMockPolicy: {
+      enforced: true,
+      rule: 'Do not mark checks PASS until real review notes, smoke output, or deployment evidence are attached.',
+    },
+  };
+}

--- a/lib/dsg/marketplace/readiness.ts
+++ b/lib/dsg/marketplace/readiness.ts
@@ -109,16 +109,21 @@ const gates: MarketplaceReadinessGate[] = [
   {
     id: 'accessibility-qa',
     title: 'Accessibility and QA proof',
-    status: 'BLOCKED',
+    status: 'REVIEW',
     userBenefit: 'ผู้ใช้ทำงานได้ด้วย keyboard/screen reader และทีมขายมีหลักฐานคุณภาพก่อนส่ง marketplace',
-    verifiedEvidence: [],
+    verifiedEvidence: [
+      'Customer-facing route: /enterprise/accessibility',
+      'Endpoint: /api/dsg/marketplace/accessibility-qa',
+      'Smoke script: smoke:accessibility-qa',
+    ],
     requiredEvidence: [
       'Lint result or explicit lint waiver',
-      'WCAG 2.2 AA checklist for core pages',
+      'WCAG 2.2 checklist evidence for core pages',
       'Keyboard navigation proof',
+      'Smoke output from deployed APP_URL',
       'E2E smoke for first-time user get-started flow',
     ],
-    nextAction: 'Add automated smoke coverage and a manual accessibility checklist for /dsg/app-builder.',
+    nextAction: 'Run accessibility and marketplace smoke checks against deployed APP_URL, attach review notes, then request owner review before moving this gate to PASS.',
   },
 ];
 
@@ -140,7 +145,7 @@ export function getEnterpriseMarketplaceReadinessReport(): MarketplaceReadinessR
     summary:
       verdict === 'PASS'
         ? 'All marketplace readiness gates have attached evidence.'
-        : 'Marketplace readiness is not a full pass yet. Existing deployment and app-builder proof can be attached, but security, entitlement, accessibility, QA evidence, and owner approvals are still required.',
+        : 'Marketplace readiness is not a full pass yet. Existing deployment, app-builder, legal/support, and accessibility/QA proof scaffolds can be attached, but security, entitlement, smoke output, and owner approvals are still required.',
     gates,
     noMockPolicy: {
       enforced: true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dsg:verify": "npm run dsg:claim-gate && npm run dsg:runtime-check && npm run dsg:typecheck && npm run lint",
     "smoke:memory-api": "bash scripts/dsg-memory-api-smoke.sh",
     "smoke:app-builder-flow-proof": "node scripts/dsg-app-builder-flow-proof-smoke.mjs",
-    "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs"
+    "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs",
+    "smoke:accessibility-qa": "node scripts/dsg-accessibility-qa-check.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-accessibility-qa-check.mjs
+++ b/scripts/dsg-accessibility-qa-check.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const appUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+
+if (!appUrl) {
+  console.error('BLOCK: APP_URL or DSG_ONE_V1_PRODUCTION_URL is required');
+  process.exit(1);
+}
+
+if (!appUrl.startsWith('https://')) {
+  console.error('BLOCK: accessibility QA check requires an https URL');
+  process.exit(1);
+}
+
+const endpoint = `${appUrl.replace(/\/$/, '')}/api/dsg/marketplace/accessibility-qa`;
+const response = await fetch(endpoint, {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    'user-agent': 'dsg-accessibility-qa-check/1.0',
+  },
+  cache: 'no-store',
+});
+
+const text = await response.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  console.error('BLOCK: accessibility QA endpoint returned non-json');
+  console.error(text.slice(0, 500));
+  process.exit(1);
+}
+
+if (!response.ok || json?.ok !== true) {
+  console.error('BLOCK: accessibility QA endpoint failed');
+  console.error(JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+const checks = Array.isArray(json.checks) ? json.checks : [];
+const validStatuses = checks.every((check) => ['PASS', 'REVIEW', 'BLOCKED'].includes(check.status));
+const blocked = checks.filter((check) => check.status === 'BLOCKED');
+const review = checks.filter((check) => check.status === 'REVIEW');
+const pass = checks.filter((check) => check.status === 'PASS');
+const noMockRulePresent = json.noMockPolicy?.enforced === true && typeof json.noMockPolicy?.rule === 'string';
+
+if (!validStatuses || !noMockRulePresent || checks.length === 0) {
+  console.error('BLOCK: accessibility QA report schema is invalid');
+  console.error(JSON.stringify({ validStatuses, noMockRulePresent, checks: checks.length }, null, 2));
+  process.exit(1);
+}
+
+if (json.verdict === 'PASS' && blocked.length > 0) {
+  console.error('BLOCK: verdict cannot be PASS while blocked checks exist');
+  process.exit(1);
+}
+
+console.log('PASS: accessibility QA endpoint responded with a valid evidence report');
+console.log(JSON.stringify({
+  endpoint,
+  verdict: json.verdict,
+  checks: checks.length,
+  pass: pass.length,
+  review: review.length,
+  blocked: blocked.length,
+  scope: json.scope,
+}, null, 2));


### PR DESCRIPTION
## Summary
- Adds accessibility QA readiness model.
- Adds `GET /api/dsg/marketplace/accessibility-qa`.
- Adds `/enterprise/accessibility`.
- Adds `npm run smoke:accessibility-qa`.
- Documents the kit in `docs/ENTERPRISE_ACCESSIBILITY_QA_KIT.md`.
- Moves `accessibility-qa` from `BLOCKED` to `REVIEW`, not PASS.

## Evidence boundary
This PR adds review scaffolding only. It does not claim WCAG approval, final QA approval, or marketplace acceptance. PASS still requires deployed smoke output and review notes.

## Verification
- Read latest readiness model before editing.
- Read package.json before updating scripts.
- Compared with main: ahead 7, behind 0.
- No dependency, config, build-flow, or runtime-core changes.

## Next evidence before PASS
- Run smoke checks against deployed APP_URL.
- Attach keyboard review notes.
- Attach semantic structure review notes.
- Attach visual clarity review notes.