### PR TITLE
Add enterprise security RBAC evidence kit

### DIFF
--- a/app/api/dsg/marketplace/security-rbac/route.ts
+++ b/app/api/dsg/marketplace/security-rbac/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getSecurityRbacReport } from '@/lib/dsg/marketplace/security-rbac';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getSecurityRbacReport());
+}

--- a/app/enterprise/security-rbac/page.tsx
+++ b/app/enterprise/security-rbac/page.tsx
@@ -1,0 +1,60 @@
+import { getSecurityRbacReport } from '@/lib/dsg/marketplace/security-rbac';
+
+const tone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export const dynamic = 'force-dynamic';
+
+export default function EnterpriseSecurityRbacPage() {
+  const report = getSecurityRbacReport();
+
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-6xl">
+        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-rose-200">Enterprise Security Evidence</p>
+          <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h1 className="font-serif text-4xl font-black tracking-tight md:text-6xl">Security RBAC Evidence</h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">Evidence checklist for server-side RBAC, organization isolation, audit events, and deny-by-default review. PASS requires real enforcement and negative tests.</p>
+            </div>
+            <span className={`w-fit rounded-full border px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.18em] ${tone[report.verdict]}`}>{report.verdict}</span>
+          </div>
+          <p className="mt-4 rounded-2xl border border-white/10 bg-black/25 p-4 font-mono text-xs leading-6 text-slate-400">{report.noMockPolicy.rule}</p>
+        </header>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          {report.checks.map((check) => (
+            <article key={check.id} className="rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-slate-500">{check.id}</p>
+                  <h2 className="mt-2 text-2xl font-black text-white">{check.title}</h2>
+                </div>
+                <span className={`rounded-full border px-3 py-1 font-mono text-xs font-bold ${tone[check.status]}`}>{check.status}</span>
+              </div>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/5 p-4">
+                  <h3 className="font-bold text-emerald-200">Evidence</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {(check.evidence.length ? check.evidence : ['No attached evidence yet']).map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                  <h3 className="font-bold text-amber-200">Required</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {check.requiredBeforePass.map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4 text-sm leading-6 text-slate-300">Next: {check.nextAction}</p>
+            </article>
+          ))}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/docs/ENTERPRISE_SECURITY_RBAC_EVIDENCE_KIT.md
+++ b/docs/ENTERPRISE_SECURITY_RBAC_EVIDENCE_KIT.md
@@ -1,0 +1,49 @@
+# Enterprise Security RBAC Evidence Kit
+
+Date: 2026-05-11
+Branch: `enterprise-security-rbac-evidence-kit`
+
+## Purpose
+
+This kit adds a review surface for enterprise security, RBAC, organization isolation, and audit-event readiness.
+
+It does not claim that server-side RBAC, tenant isolation, or audit logging are fully implemented.
+
+## Added routes
+
+- `GET /api/dsg/marketplace/security-rbac`
+- `GET /enterprise/security-rbac`
+
+## Added script
+
+```bash
+APP_URL=https://your-preview-or-production-url.example npm run smoke:security-rbac
+```
+
+The script validates that the security RBAC endpoint returns a valid evidence report with status gates and no-mock policy.
+
+## Current status
+
+The marketplace `security-rbac-org-isolation` gate is moved from `BLOCKED` to `REVIEW` because this PR adds:
+
+- security RBAC evidence model
+- security RBAC API endpoint
+- security RBAC customer/operator page
+- smoke script
+
+It is not `PASS` yet.
+
+## Required before PASS
+
+1. Server-side RBAC source of truth
+2. Allowed-role test
+3. Denied-role test
+4. Cross-org denial test
+5. Audit event schema
+6. Privileged action audit event test
+7. Runtime enforcement proof
+8. Owner approval
+
+## No false claim rule
+
+Do not mark this gate `PASS` until real server-side enforcement, negative tests, and audit evidence are attached.

--- a/lib/dsg/marketplace/readiness.ts
+++ b/lib/dsg/marketplace/readiness.ts
@@ -60,16 +60,21 @@ const gates: MarketplaceReadinessGate[] = [
   {
     id: 'security-rbac-org-isolation',
     title: 'Security, RBAC, and organization isolation',
-    status: 'BLOCKED',
+    status: 'REVIEW',
     userBenefit: 'ผู้ใช้ enterprise ต้องมั่นใจว่าสิทธิ์และข้อมูลข้ามองค์กรไม่รั่ว',
-    verifiedEvidence: [],
+    verifiedEvidence: [
+      'Customer-facing route: /enterprise/security-rbac',
+      'Endpoint: /api/dsg/marketplace/security-rbac',
+      'Smoke script: smoke:security-rbac',
+    ],
     requiredEvidence: [
       'Server-side RBAC proof for critical read/write routes',
       'Cross-org access denial test',
       'Audit event for privileged actions',
       'Deny-by-default error contract',
+      'Runtime enforcement proof before PASS',
     ],
-    nextAction: 'Add or attach tests proving unauthorized role and cross-org access are denied server-side.',
+    nextAction: 'Run security RBAC smoke check, attach enforcement tests, and keep PASS blocked until server-side authorization proof exists.',
   },
   {
     id: 'commercial-entitlement',
@@ -145,7 +150,7 @@ export function getEnterpriseMarketplaceReadinessReport(): MarketplaceReadinessR
     summary:
       verdict === 'PASS'
         ? 'All marketplace readiness gates have attached evidence.'
-        : 'Marketplace readiness is not a full pass yet. Existing deployment, app-builder, legal/support, and accessibility/QA proof scaffolds can be attached, but security, entitlement, smoke output, and owner approvals are still required.',
+        : 'Marketplace readiness is not a full pass yet. Existing deployment, app-builder, legal/support, accessibility/QA, and security/RBAC proof scaffolds can be attached, but entitlement, smoke output, enforcement tests, and owner approvals are still required.',
     gates,
     noMockPolicy: {
       enforced: true,

--- a/lib/dsg/marketplace/security-rbac.ts
+++ b/lib/dsg/marketplace/security-rbac.ts
@@ -1,0 +1,74 @@
+export type SecurityRbacStatus = 'PASS' | 'REVIEW' | 'BLOCKED';
+
+export type SecurityRbacCheck = {
+  id: string;
+  title: string;
+  status: SecurityRbacStatus;
+  evidence: string[];
+  requiredBeforePass: string[];
+  nextAction: string;
+};
+
+export type SecurityRbacReport = {
+  ok: true;
+  kit: 'enterprise-security-rbac-evidence-kit';
+  generatedAt: string;
+  verdict: SecurityRbacStatus;
+  checks: SecurityRbacCheck[];
+  noMockPolicy: { enforced: true; rule: string };
+};
+
+const checks: SecurityRbacCheck[] = [
+  {
+    id: 'server-rbac',
+    title: 'Server-side RBAC proof',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Role source of truth', 'Allowed role test', 'Denied role test', 'Critical route coverage'],
+    nextAction: 'Add route-level RBAC checks and negative tests before PASS.',
+  },
+  {
+    id: 'org-isolation',
+    title: 'Organization isolation proof',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Org id source of truth', 'Cross-org denial test', 'Tenant scoped data access review'],
+    nextAction: 'Add cross-org denial tests before PASS.',
+  },
+  {
+    id: 'audit-events',
+    title: 'Audit event proof',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Audit event schema', 'Privileged action event test', 'Event retention owner'],
+    nextAction: 'Add audit event schema and proof tests before PASS.',
+  },
+  {
+    id: 'deny-default-contract',
+    title: 'Deny-by-default contract',
+    status: 'REVIEW',
+    evidence: ['Endpoint: /api/dsg/marketplace/security-rbac', 'Page: /enterprise/security-rbac', 'Script: smoke:security-rbac'],
+    requiredBeforePass: ['Runtime enforcement proof', 'Negative access tests', 'Owner review'],
+    nextAction: 'Attach enforcement proof before PASS.',
+  },
+];
+
+function deriveVerdict(items: SecurityRbacCheck[]): SecurityRbacStatus {
+  if (items.some((item) => item.status === 'BLOCKED')) return 'BLOCKED';
+  if (items.some((item) => item.status === 'REVIEW')) return 'REVIEW';
+  return 'PASS';
+}
+
+export function getSecurityRbacReport(): SecurityRbacReport {
+  return {
+    ok: true,
+    kit: 'enterprise-security-rbac-evidence-kit',
+    generatedAt: new Date().toISOString(),
+    verdict: deriveVerdict(checks),
+    checks,
+    noMockPolicy: {
+      enforced: true,
+      rule: 'Do not mark security or RBAC checks PASS until real enforcement, tests, and audit evidence are attached.',
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "smoke:memory-api": "bash scripts/dsg-memory-api-smoke.sh",
     "smoke:app-builder-flow-proof": "node scripts/dsg-app-builder-flow-proof-smoke.mjs",
     "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs",
-    "smoke:accessibility-qa": "node scripts/dsg-accessibility-qa-check.mjs"
+    "smoke:accessibility-qa": "node scripts/dsg-accessibility-qa-check.mjs",
+    "smoke:security-rbac": "node scripts/dsg-security-rbac-check.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-security-rbac-check.mjs
+++ b/scripts/dsg-security-rbac-check.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const appUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+
+if (!appUrl) {
+  console.error('BLOCK: APP_URL or DSG_ONE_V1_PRODUCTION_URL is required');
+  process.exit(1);
+}
+
+if (!appUrl.startsWith('https://')) {
+  console.error('BLOCK: security RBAC check requires an https URL');
+  process.exit(1);
+}
+
+const endpoint = `${appUrl.replace(/\/$/, '')}/api/dsg/marketplace/security-rbac`;
+const response = await fetch(endpoint, {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    'user-agent': 'dsg-security-rbac-check/1.0',
+  },
+  cache: 'no-store',
+});
+
+const text = await response.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  console.error('BLOCK: security RBAC endpoint returned non-json');
+  console.error(text.slice(0, 500));
+  process.exit(1);
+}
+
+if (!response.ok || json?.ok !== true) {
+  console.error('BLOCK: security RBAC endpoint failed');
+  console.error(JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+const checks = Array.isArray(json.checks) ? json.checks : [];
+const validStatuses = checks.every((check) => ['PASS', 'REVIEW', 'BLOCKED'].includes(check.status));
+const blocked = checks.filter((check) => check.status === 'BLOCKED');
+const review = checks.filter((check) => check.status === 'REVIEW');
+const pass = checks.filter((check) => check.status === 'PASS');
+const noMockRulePresent = json.noMockPolicy?.enforced === true && typeof json.noMockPolicy?.rule === 'string';
+
+if (!validStatuses || !noMockRulePresent || checks.length === 0) {
+  console.error('BLOCK: security RBAC report schema is invalid');
+  console.error(JSON.stringify({ validStatuses, noMockRulePresent, checks: checks.length }, null, 2));
+  process.exit(1);
+}
+
+if (json.verdict === 'PASS' && blocked.length > 0) {
+  console.error('BLOCK: verdict cannot be PASS while blocked checks exist');
+  process.exit(1);
+}
+
+console.log('PASS: security RBAC endpoint responded with a valid evidence report');
+console.log(JSON.stringify({
+  endpoint,
+  verdict: json.verdict,
+  checks: checks.length,
+  pass: pass.length,
+  review: review.length,
+  blocked: blocked.length,
+}, null, 2));


### PR DESCRIPTION
## Summary
- Adds security RBAC evidence model.
- Adds `GET /api/dsg/marketplace/security-rbac`.
- Adds `/enterprise/security-rbac`.
- Adds `npm run smoke:security-rbac`.
- Documents the kit in `docs/ENTERPRISE_SECURITY_RBAC_EVIDENCE_KIT.md`.
- Moves `security-rbac-org-isolation` from `BLOCKED` to `REVIEW`, not PASS.

## Evidence boundary
This PR adds review scaffolding only. It does not claim server-side RBAC, tenant isolation, or audit logging are fully implemented. PASS still requires enforcement proof and negative tests.

## Verification
- Read latest readiness model before editing.
- Searched repo for RBAC/auth/org isolation/audit files before adding scaffold.
- Read package.json before updating scripts.
- Compared with main: ahead 7, behind 0.
- No dependency, config, build-flow, or runtime-core changes.

## Next evidence before PASS
- Add role source of truth.
- Add allowed-role and denied-role tests.
- Add cross-org denial test.
- Add audit event schema and privileged action event test.