### PR TITLE
Add enterprise entitlement evidence kit

### DIFF
--- a/app/api/dsg/marketplace/entitlement/route.ts
+++ b/app/api/dsg/marketplace/entitlement/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getEntitlementReport } from '@/lib/dsg/marketplace/entitlement';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getEntitlementReport());
+}

--- a/app/enterprise/entitlement/page.tsx
+++ b/app/enterprise/entitlement/page.tsx
@@ -1,0 +1,56 @@
+import { getEntitlementReport } from '@/lib/dsg/marketplace/entitlement';
+
+const tone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export const dynamic = 'force-dynamic';
+
+export default function EnterpriseEntitlementPage() {
+  const report = getEntitlementReport();
+
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-6xl">
+        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-amber-200">Enterprise Commercial Evidence</p>
+          <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h1 className="font-serif text-4xl font-black tracking-tight md:text-6xl">Entitlement Evidence</h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">Evidence checklist for plan, seat, quota, upgrade, and denial behavior. PASS requires real enforcement proof.</p>
+            </div>
+            <span className={`w-fit rounded-full border px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.18em] ${tone[report.verdict]}`}>{report.verdict}</span>
+          </div>
+        </header>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          {report.checks.map((check) => (
+            <article key={check.id} className="rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <h2 className="text-2xl font-black text-white">{check.title}</h2>
+                <span className={`rounded-full border px-3 py-1 font-mono text-xs font-bold ${tone[check.status]}`}>{check.status}</span>
+              </div>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/5 p-4">
+                  <h3 className="font-bold text-emerald-200">Evidence</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {(check.evidence.length ? check.evidence : ['No attached evidence yet']).map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                  <h3 className="font-bold text-amber-200">Required</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+                    {check.requiredBeforePass.map((item) => <li key={item}>• {item}</li>)}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4 text-sm leading-6 text-slate-300">Next: {check.nextAction}</p>
+            </article>
+          ))}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/docs/ENTERPRISE_ENTITLEMENT_EVIDENCE_KIT.md
+++ b/docs/ENTERPRISE_ENTITLEMENT_EVIDENCE_KIT.md
@@ -1,0 +1,50 @@
+# Enterprise Entitlement Evidence Kit
+
+Date: 2026-05-11
+Branch: `enterprise-entitlement-evidence-kit`
+
+## Purpose
+
+This kit adds a review surface for commercial entitlement, billing plan, seat, quota, upgrade, and denial readiness.
+
+It does not claim that billing or entitlement enforcement is fully implemented.
+
+## Added routes
+
+- `GET /api/dsg/marketplace/entitlement`
+- `GET /enterprise/entitlement`
+
+## Added script
+
+```bash
+APP_URL=https://your-preview-or-production-url.example npm run smoke:entitlement
+```
+
+The script validates that the entitlement endpoint returns a valid evidence report with status gates and no-mock policy.
+
+## Current status
+
+The marketplace `commercial-entitlement` gate is moved from `BLOCKED` to `REVIEW` because this PR adds:
+
+- entitlement evidence model
+- entitlement API endpoint
+- entitlement customer/operator page
+- smoke script
+
+It is not `PASS` yet.
+
+## Required before PASS
+
+1. Production plan source of truth
+2. Plan-to-feature mapping
+3. Seat limit source
+4. Quota counter source
+5. Quota exceeded denial test
+6. Checkout or upgrade route proof
+7. Billing portal route proof
+8. Failed payment behavior proof
+9. Owner approval
+
+## No false claim rule
+
+Do not mark this gate `PASS` until real plan, seat, quota, upgrade, and denial evidence are attached.

--- a/lib/dsg/marketplace/entitlement.ts
+++ b/lib/dsg/marketplace/entitlement.ts
@@ -1,0 +1,74 @@
+export type EntitlementStatus = 'PASS' | 'REVIEW' | 'BLOCKED';
+
+export type EntitlementCheck = {
+  id: string;
+  title: string;
+  status: EntitlementStatus;
+  evidence: string[];
+  requiredBeforePass: string[];
+  nextAction: string;
+};
+
+export type EntitlementReport = {
+  ok: true;
+  kit: 'enterprise-entitlement-evidence-kit';
+  generatedAt: string;
+  verdict: EntitlementStatus;
+  checks: EntitlementCheck[];
+  noMockPolicy: { enforced: true; rule: string };
+};
+
+const checks: EntitlementCheck[] = [
+  {
+    id: 'plan-source-of-truth',
+    title: 'Plan source of truth',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Production plan table or billing provider contract', 'Plan id mapping', 'Allowed features per plan'],
+    nextAction: 'Attach production plan source before PASS.',
+  },
+  {
+    id: 'seat-quota-policy',
+    title: 'Seat and quota policy',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Seat limit source', 'Quota counter source', 'Quota exceeded denial test'],
+    nextAction: 'Add seat and quota enforcement proof before PASS.',
+  },
+  {
+    id: 'upgrade-path',
+    title: 'Upgrade and billing handoff',
+    status: 'BLOCKED',
+    evidence: [],
+    requiredBeforePass: ['Checkout or upgrade route', 'Billing portal route', 'Failed payment behavior'],
+    nextAction: 'Attach upgrade flow proof before PASS.',
+  },
+  {
+    id: 'review-scaffold',
+    title: 'Entitlement review scaffold',
+    status: 'REVIEW',
+    evidence: ['Endpoint: /api/dsg/marketplace/entitlement', 'Page: /enterprise/entitlement', 'Script: smoke:entitlement'],
+    requiredBeforePass: ['Runtime enforcement proof', 'Negative entitlement test', 'Owner approval'],
+    nextAction: 'Run smoke script and attach real enforcement evidence before PASS.',
+  },
+];
+
+function deriveVerdict(items: EntitlementCheck[]): EntitlementStatus {
+  if (items.some((item) => item.status === 'BLOCKED')) return 'BLOCKED';
+  if (items.some((item) => item.status === 'REVIEW')) return 'REVIEW';
+  return 'PASS';
+}
+
+export function getEntitlementReport(): EntitlementReport {
+  return {
+    ok: true,
+    kit: 'enterprise-entitlement-evidence-kit',
+    generatedAt: new Date().toISOString(),
+    verdict: deriveVerdict(checks),
+    checks,
+    noMockPolicy: {
+      enforced: true,
+      rule: 'Do not mark entitlement checks PASS until real plan, seat, quota, upgrade, and denial evidence are attached.',
+    },
+  };
+}

--- a/lib/dsg/marketplace/readiness.ts
+++ b/lib/dsg/marketplace/readiness.ts
@@ -79,16 +79,21 @@ const gates: MarketplaceReadinessGate[] = [
   {
     id: 'commercial-entitlement',
     title: 'Billing, entitlement, seat, and quota gates',
-    status: 'BLOCKED',
+    status: 'REVIEW',
     userBenefit: 'ผู้ใช้รู้ขอบเขตแพ็กเกจชัดเจน และระบบไม่เปิด bypass ฟรีในเส้นทางสำคัญ',
-    verifiedEvidence: [],
+    verifiedEvidence: [
+      'Customer-facing route: /enterprise/entitlement',
+      'Endpoint: /api/dsg/marketplace/entitlement',
+      'Smoke script: smoke:entitlement',
+    ],
     requiredEvidence: [
       'Plan/seat/quota source-of-truth',
       'Quota exceeded behavior with clear message',
       'Upgrade path proof',
       'Entitlement denial test for restricted action',
+      'Runtime enforcement proof before PASS',
     ],
-    nextAction: 'Wire entitlement checks to production source-of-truth and add a negative test for quota/seat denial.',
+    nextAction: 'Run entitlement smoke check, attach real billing/quota enforcement evidence, and keep PASS blocked until denial tests exist.',
   },
   {
     id: 'legal-support-package',
@@ -150,7 +155,7 @@ export function getEnterpriseMarketplaceReadinessReport(): MarketplaceReadinessR
     summary:
       verdict === 'PASS'
         ? 'All marketplace readiness gates have attached evidence.'
-        : 'Marketplace readiness is not a full pass yet. Existing deployment, app-builder, legal/support, accessibility/QA, and security/RBAC proof scaffolds can be attached, but entitlement, smoke output, enforcement tests, and owner approvals are still required.',
+        : 'Marketplace readiness is not a full pass yet. Evidence scaffolds exist for all major gates, but smoke output, runtime enforcement tests, production deployment proof, and owner approvals are still required before PASS.',
     gates,
     noMockPolicy: {
       enforced: true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "smoke:app-builder-flow-proof": "node scripts/dsg-app-builder-flow-proof-smoke.mjs",
     "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs",
     "smoke:accessibility-qa": "node scripts/dsg-accessibility-qa-check.mjs",
-    "smoke:security-rbac": "node scripts/dsg-security-rbac-check.mjs"
+    "smoke:security-rbac": "node scripts/dsg-security-rbac-check.mjs",
+    "smoke:entitlement": "node scripts/dsg-entitlement-check.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-entitlement-check.mjs
+++ b/scripts/dsg-entitlement-check.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const appUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+
+if (!appUrl) {
+  console.error('BLOCK: APP_URL or DSG_ONE_V1_PRODUCTION_URL is required');
+  process.exit(1);
+}
+
+if (!appUrl.startsWith('https://')) {
+  console.error('BLOCK: entitlement check requires an https URL');
+  process.exit(1);
+}
+
+const endpoint = `${appUrl.replace(/\/$/, '')}/api/dsg/marketplace/entitlement`;
+const response = await fetch(endpoint, {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    'user-agent': 'dsg-entitlement-check/1.0',
+  },
+  cache: 'no-store',
+});
+
+const text = await response.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  console.error('BLOCK: entitlement endpoint returned non-json');
+  console.error(text.slice(0, 500));
+  process.exit(1);
+}
+
+if (!response.ok || json?.ok !== true) {
+  console.error('BLOCK: entitlement endpoint failed');
+  console.error(JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+const checks = Array.isArray(json.checks) ? json.checks : [];
+const validStatuses = checks.every((check) => ['PASS', 'REVIEW', 'BLOCKED'].includes(check.status));
+const blocked = checks.filter((check) => check.status === 'BLOCKED');
+const review = checks.filter((check) => check.status === 'REVIEW');
+const pass = checks.filter((check) => check.status === 'PASS');
+const noMockRulePresent = json.noMockPolicy?.enforced === true && typeof json.noMockPolicy?.rule === 'string';
+
+if (!validStatuses || !noMockRulePresent || checks.length === 0) {
+  console.error('BLOCK: entitlement report schema is invalid');
+  console.error(JSON.stringify({ validStatuses, noMockRulePresent, checks: checks.length }, null, 2));
+  process.exit(1);
+}
+
+if (json.verdict === 'PASS' && blocked.length > 0) {
+  console.error('BLOCK: verdict cannot be PASS while blocked checks exist');
+  process.exit(1);
+}
+
+console.log('PASS: entitlement endpoint responded with a valid evidence report');
+console.log(JSON.stringify({
+  endpoint,
+  verdict: json.verdict,
+  checks: checks.length,
+  pass: pass.length,
+  review: review.length,
+  blocked: blocked.length,
+}, null, 2));


### PR DESCRIPTION
## Summary
- Adds entitlement evidence model.
- Adds `GET /api/dsg/marketplace/entitlement`.
- Adds `/enterprise/entitlement`.
- Adds `npm run smoke:entitlement`.
- Documents the kit in `docs/ENTERPRISE_ENTITLEMENT_EVIDENCE_KIT.md`.
- Moves `commercial-entitlement` from `BLOCKED` to `REVIEW`, not PASS.

## Evidence boundary
This PR adds review scaffolding only. It does not claim billing, plan, seat, quota, upgrade, or denial enforcement is fully implemented. PASS still requires real enforcement proof and negative tests.

## Verification
- Read latest readiness model before editing.
- Searched repo for billing/plan/quota/seat/entitlement implementation before adding scaffold.
- Read package.json before updating scripts.
- Compared with main: ahead 7, behind 0.
- No dependency, config, build-flow, or runtime-core changes.

## Next evidence before PASS
- Attach production plan source of truth.
- Add plan-to-feature mapping.
- Add seat/quota enforcement proof.
- Add quota exceeded denial test.
- Add upgrade or billing portal proof.