### PR TITLE
Add evidence-first app-builder features: outcome intake, proof panel, readiness scoring, audit packet, and enforcement contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## DSG repo rules
+
+- Read real files before editing.
+- Do not add mock production evidence.
+- Do not mark PASS without real file, route, test, deployment, or owner approval evidence.
+- Use PASS / REVIEW / BLOCKED for readiness states.
+- REVIEW and BLOCKED must include nextAction.
+- Preserve existing package scripts.
+- Do not add dependencies unless necessary.
+- Run:
+  - npm run lint
+  - npm run dsg:typecheck
+  - npm run build:termux
+  - npm run smoke:marketplace-readiness
+  - npm run smoke:app-builder-flow-proof
+  - npm run smoke:audit-packet
+  - npm run smoke:first-value-flow
+- If APP_URL is required, use:
+  export APP_URL="https://dsg-one-v1.vercel.app"

--- a/app/api/dsg/app-builder/outcome/route.ts
+++ b/app/api/dsg/app-builder/outcome/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { createDsgOutcomePlan, parseDsgOutcomeIntake } from '@/lib/dsg/app-builder/outcome-intake';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const parsed = parseDsgOutcomeIntake(body);
+  if ('error' in parsed) {
+    return NextResponse.json(parsed, { status: parsed.error.code === 'OUTCOME_GOAL_REQUIRED' ? 400 : 422 });
+  }
+  return NextResponse.json(createDsgOutcomePlan(parsed));
+}

--- a/app/api/dsg/market/agent-app-builder/route.ts
+++ b/app/api/dsg/market/agent-app-builder/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getAgentAppBuilderMarketReport } from '@/lib/dsg/market/agent-app-builder-market';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getAgentAppBuilderMarketReport());
+}

--- a/app/api/dsg/marketplace/audit-packet/route.ts
+++ b/app/api/dsg/marketplace/audit-packet/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { createDsgAuditPacket } from '@/lib/dsg/marketplace/audit-packet';
+
+export const dynamic = 'force-dynamic';
+
+function resolveCanonicalBase(reqUrl: URL): string {
+  if (!process.env.APP_URL) return reqUrl.origin;
+  return new URL(process.env.APP_URL).origin;
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  let canonicalBase: string;
+
+  try {
+    canonicalBase = resolveCanonicalBase(url);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'APP_URL is not a valid URL.';
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: 'INVALID_APP_URL_CONFIG', message },
+        nextAction: 'Set APP_URL to a valid absolute URL or unset APP_URL so the audit packet can use the request origin.',
+      },
+      { status: 500 },
+    );
+  }
+
+  const requestedBaseUrl = url.searchParams.get('baseUrl');
+
+  if (requestedBaseUrl) {
+    let requestedOrigin: string;
+    try {
+      requestedOrigin = new URL(requestedBaseUrl).origin;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'INVALID_BASE_URL';
+      return NextResponse.json(
+        {
+          ok: false,
+          error: { code: 'INVALID_BASE_URL', message },
+          nextAction: 'Remove the baseUrl query parameter or set it to the canonical APP_URL origin.',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (requestedOrigin !== canonicalBase) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: { code: 'BASE_URL_MISMATCH', message: 'baseUrl query parameter does not match the canonical base URL.' },
+          canonicalBase,
+          requestedBaseUrl: requestedOrigin,
+          nextAction: 'Use the canonical APP_URL/request origin for audit packets; arbitrary baseUrl overrides are blocked.',
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  return NextResponse.json(createDsgAuditPacket(canonicalBase));
+}

--- a/app/api/dsg/marketplace/readiness-score/route.ts
+++ b/app/api/dsg/marketplace/readiness-score/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getEnterpriseMarketplaceReadinessReport } from '@/lib/dsg/marketplace/readiness';
+import { createReadinessScore } from '@/lib/dsg/marketplace/readiness-score';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ ok: true, generatedAt: new Date().toISOString(), score: createReadinessScore(getEnterpriseMarketplaceReadinessReport()) });
+}

--- a/app/dsg/app-builder/page.tsx
+++ b/app/dsg/app-builder/page.tsx
@@ -1,5 +1,7 @@
 import { AppBuilderConsoleClient } from '@/components/dsg/app-builder/AppBuilderConsoleClient';
-import { DSG_APP_TEMPLATES } from '@/lib/dsg/app-builder/templates/template-registry';
+import { AppBuilderProofPanel, type ProofPanelItem } from '@/components/dsg/app-builder/AppBuilderProofPanel';
+import { OutcomeIntakePanel } from '@/components/dsg/app-builder/OutcomeIntakePanel';
+import { DSG_APP_TEMPLATES, DSG_MARKET_TEMPLATES } from '@/lib/dsg/app-builder/templates/template-registry';
 import type { DsgAppBuilderPrd } from '@/lib/dsg/app-builder/types/prd';
 
 const demoPrd: DsgAppBuilderPrd = {
@@ -61,6 +63,90 @@ const outcomeCards = [
   { value: '3', label: 'Proof', detail: 'อนุมัติ/บล็อกด้วยหลักฐานก่อนอ้าง production' },
 ];
 
+
+const proofPanelItems: ProofPanelItem[] = [
+  {
+    id: 'prd',
+    title: 'PRD',
+    status: 'REVIEW',
+    evidence: ['PRD viewer exists in the App Builder console'],
+    missingEvidence: ['Human-reviewed PRD approval for a specific generated app'],
+    nextAction: 'Generate and review the PRD for the selected outcome before execution.',
+  },
+  {
+    id: 'plan',
+    title: 'Plan',
+    status: 'REVIEW',
+    evidence: ['Plan observer panel exists in the App Builder console'],
+    missingEvidence: ['Executed plan proof and owner approval'],
+    nextAction: 'Run plan generation and attach observer output to the audit packet.',
+  },
+  {
+    id: 'observer',
+    title: 'Observer',
+    status: 'REVIEW',
+    evidence: ['Z3/observer boundary is represented in app-builder planning flow'],
+    missingEvidence: ['Runtime proof that observer findings were enforced'],
+    nextAction: 'Keep observer status REVIEW until enforcement output is attached.',
+  },
+  {
+    id: 'runtime-gate',
+    title: 'Runtime Gate',
+    status: 'BLOCKED',
+    evidence: ['Runtime gate UI component exists'],
+    missingEvidence: ['Live executor proof', 'Deployment proof', 'Database/auth proof'],
+    nextAction: 'Run the runtime gate only after generated code, build, deploy, and data/auth evidence exist.',
+  },
+  {
+    id: 'marketplace-readiness',
+    title: 'Marketplace Readiness',
+    status: 'REVIEW',
+    evidence: ['Endpoint: /api/dsg/marketplace/readiness'],
+    missingEvidence: ['Smoke output', 'Owner approvals', 'Production deployment evidence'],
+    nextAction: 'Run smoke:marketplace-readiness and attach production proof before PASS.',
+  },
+  {
+    id: 'security-rbac',
+    title: 'Security/RBAC',
+    status: 'BLOCKED',
+    evidence: ['Endpoint: /api/dsg/marketplace/security-rbac'],
+    missingEvidence: ['Server-side RBAC enforcement test', 'Cross-org denial test'],
+    nextAction: 'Implement and test authorization enforcement; keep fail-closed until proof exists.',
+  },
+  {
+    id: 'entitlement',
+    title: 'Entitlement',
+    status: 'BLOCKED',
+    evidence: ['Endpoint: /api/dsg/marketplace/entitlement'],
+    missingEvidence: ['Plan source of truth', 'Quota denial test', 'Upgrade path proof'],
+    nextAction: 'Attach billing or marketplace entitlement enforcement evidence before PASS.',
+  },
+  {
+    id: 'accessibility-qa',
+    title: 'Accessibility/QA',
+    status: 'BLOCKED',
+    evidence: ['Endpoint: /api/dsg/marketplace/accessibility-qa'],
+    missingEvidence: ['Keyboard review notes', 'Semantic review notes', 'Contrast review notes'],
+    nextAction: 'Complete accessibility review notes and smoke output before PASS.',
+  },
+  {
+    id: 'legal-support',
+    title: 'Legal/Support',
+    status: 'REVIEW',
+    evidence: ['/enterprise/terms', '/enterprise/privacy', '/enterprise/security', '/enterprise/support'],
+    missingEvidence: ['Owner approval', 'Data handling/support SLA review'],
+    nextAction: 'Review legal/support pages with owners before marketplace submission.',
+  },
+  {
+    id: 'deployment-proof',
+    title: 'Deployment Proof',
+    status: 'REVIEW',
+    evidence: ['APP_URL target documented for smoke tests'],
+    missingEvidence: ['Latest deployment READY proof', 'Smoke output against production URL'],
+    nextAction: 'Run production smoke scripts against APP_URL and attach outputs.',
+  },
+];
+
 const builderStages = [
   { stage: 'Capture', text: 'รับเป้าหมายผู้ใช้และ success criteria' },
   { stage: 'Design', text: 'สร้าง PRD และเลือก template ที่เหมาะกับงาน' },
@@ -87,6 +173,10 @@ export default function DsgAppBuilderPage() {
             Action Layer
           </a>
         </header>
+
+        <div className="mt-6">
+          <OutcomeIntakePanel />
+        </div>
 
         <section className="grid gap-6 py-8 lg:grid-cols-[minmax(0,1.05fr)_420px]">
           <div className="rounded-[2.6rem] border border-white/10 bg-[#0f151f]/82 p-6 shadow-[0_0_52px_rgba(0,0,0,0.25)] backdrop-blur-2xl sm:p-8">
@@ -145,6 +235,34 @@ export default function DsgAppBuilderPage() {
               <p className="mt-3 text-sm leading-7 text-slate-300">{pillar.body}</p>
             </article>
           ))}
+        </section>
+
+        <section className="mt-8">
+          <AppBuilderProofPanel items={proofPanelItems} productionReadyClaim={false} />
+        </section>
+
+        <section className="mt-8 rounded-[2rem] border border-white/10 bg-[#0f151f]/85 p-5">
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#f2ca50]">Template marketplace registry</p>
+          <h2 className="mt-2 text-2xl font-black text-white">Choose a business template and see missing proof</h2>
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            {DSG_MARKET_TEMPLATES.map((template) => (
+              <article key={template.id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">{template.category}</p>
+                    <h3 className="mt-1 font-bold text-white">{template.name}</h3>
+                  </div>
+                  <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-3 py-1 font-mono text-[11px] font-black text-amber-100">risk: {template.riskLevel}</span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">{template.businessOutcome}</p>
+                <p className="mt-3 text-xs leading-5 text-slate-400">Readiness gates: {template.readinessGates.join(', ')}</p>
+                <div className="mt-3 rounded-xl border border-rose-400/20 bg-rose-500/5 p-3">
+                  <h4 className="text-sm font-bold text-rose-100">Missing proof / blocked until</h4>
+                  <ul className="mt-2 space-y-1 text-xs leading-5 text-slate-300">{template.blockedUntil.map((item) => <li key={item}>• {item}</li>)}</ul>
+                </div>
+              </article>
+            ))}
+          </div>
         </section>
 
         <AppBuilderConsoleClient initialPrd={demoPrd} />

--- a/app/enterprise/accessibility/page.tsx
+++ b/app/enterprise/accessibility/page.tsx
@@ -1,4 +1,5 @@
 import { getAccessibilityQaReport } from '@/lib/dsg/marketplace/accessibility-qa';
+import { ACCESSIBILITY_REVIEW_CHECKLIST } from '@/lib/dsg/marketplace/accessibility-checklist';
 
 const tone = {
   PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
@@ -25,6 +26,22 @@ export default function EnterpriseAccessibilityPage() {
           </div>
           <p className="mt-4 rounded-2xl border border-white/10 bg-black/25 p-4 font-mono text-xs leading-6 text-slate-400">{report.noMockPolicy.rule}</p>
         </header>
+
+
+        <section className="mt-6 rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">Manual review checklist</p>
+          <h2 className="mt-2 text-2xl font-black text-white">Accessibility Review Notes must be filled by a reviewer</h2>
+          <p className="mt-3 text-sm leading-7 text-slate-300">This checklist stays REVIEW until real notes are attached. It does not mark WCAG PASS automatically.</p>
+          <div className="mt-5 grid gap-3 md:grid-cols-2">
+            {ACCESSIBILITY_REVIEW_CHECKLIST.map((item) => (
+              <article key={`${item.section}-${item.label}`} className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-amber-200">{item.section} · {item.status}</p>
+                <h3 className="mt-2 font-bold text-white">{item.label}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">Next: {item.nextAction}</p>
+              </article>
+            ))}
+          </div>
+        </section>
 
         <section className="mt-6 grid gap-4 lg:grid-cols-2">
           {report.checks.map((check) => (

--- a/app/enterprise/market/page.tsx
+++ b/app/enterprise/market/page.tsx
@@ -1,0 +1,64 @@
+import { getAgentAppBuilderMarketReport } from '@/lib/dsg/market/agent-app-builder-market';
+
+const tone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export const dynamic = 'force-dynamic';
+
+export default function EnterpriseMarketPage() {
+  const report = getAgentAppBuilderMarketReport();
+
+  return (
+    <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
+      <section className="mx-auto max-w-6xl">
+        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#f2ca50]">Market intelligence registry</p>
+          <h1 className="mt-3 font-serif text-4xl font-black tracking-tight md:text-6xl">Evidence-first AI app builder market map</h1>
+          <p className="mt-4 max-w-4xl text-sm leading-7 text-slate-300">{report.positioning}</p>
+          <p className="mt-4 rounded-2xl border border-white/10 bg-black/25 p-4 font-mono text-xs leading-6 text-slate-400">{report.noMockPolicy.rule}</p>
+        </header>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          {report.competitors.map((competitor) => (
+            <article key={competitor.id} className="rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-slate-500">{competitor.category}</p>
+              <h2 className="mt-2 text-2xl font-black text-white">{competitor.name}</h2>
+              <p className="mt-3 text-sm leading-7 text-slate-300">{competitor.positioning}</p>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/5 p-4">
+                  <h3 className="font-bold text-emerald-200">Strengths</h3>
+                  <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">{competitor.strengths.map((item) => <li key={item}>• {item}</li>)}</ul>
+                </div>
+                <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4">
+                  <h3 className="font-bold text-amber-200">DSG opportunity</h3>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{competitor.dsgOpportunity}</p>
+                </div>
+              </div>
+              <div className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
+                <h3 className="font-bold text-cyan-200">Source notes</h3>
+                <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">{competitor.sourceNotes.map((item) => <li key={item}>• {item}</li>)}</ul>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="mt-6 grid gap-4 lg:grid-cols-3">
+          {report.directions.map((direction) => (
+            <article key={direction.id} className="rounded-[2rem] border border-white/10 bg-[#111827] p-5">
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="text-xl font-black text-white">{direction.title}</h2>
+                <span className={`rounded-full border px-3 py-1 font-mono text-xs font-bold ${tone[direction.status]}`}>{direction.status}</span>
+              </div>
+              <p className="mt-3 text-sm leading-7 text-slate-300">{direction.customerNeed}</p>
+              <p className="mt-3 text-sm leading-7 text-slate-300"><strong className="text-white">Capability:</strong> {direction.requiredProductCapability}</p>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">{direction.evidenceRequired.map((item) => <li key={item}>• {item}</li>)}</ul>
+            </article>
+          ))}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/app/enterprise/readiness/page.tsx
+++ b/app/enterprise/readiness/page.tsx
@@ -1,4 +1,5 @@
 import { getEnterpriseMarketplaceReadinessReport } from '@/lib/dsg/marketplace/readiness';
+import { createReadinessScore } from '@/lib/dsg/marketplace/readiness-score';
 
 const statusTone = {
   PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
@@ -10,6 +11,7 @@ export const dynamic = 'force-dynamic';
 
 export default function EnterpriseReadinessPage() {
   const report = getEnterpriseMarketplaceReadinessReport();
+  const score = createReadinessScore(report);
 
   return (
     <main className="min-h-screen bg-[#090b0f] px-5 py-8 text-slate-100 md:px-10">
@@ -31,6 +33,31 @@ export default function EnterpriseReadinessPage() {
             <p>policy: {report.noMockPolicy.rule}</p>
           </div>
         </header>
+
+
+        <section className="mt-6 rounded-[2rem] border border-white/10 bg-[#111827]/80 p-5 backdrop-blur-xl">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">Readiness score</p>
+              <h2 className="mt-2 text-3xl font-black text-white">{score.overall}/100 · {score.verdict}</h2>
+              <p className="mt-3 text-sm leading-7 text-slate-300">Score is an operational gap map, not a marketplace PASS claim. Overall cannot become PASS without enforcement proof.</p>
+            </div>
+            <span className={`rounded-full border px-4 py-2 font-mono text-xs font-black ${statusTone[score.verdict]}`}>{score.verdict}</span>
+          </div>
+          {score.caps.length > 0 ? <ul className="mt-4 space-y-2 rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4 text-sm leading-6 text-amber-100">{score.caps.map((cap) => <li key={cap}>• {cap}</li>)}</ul> : null}
+          <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {score.categories.map((category) => (
+              <article key={category.id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="font-bold text-white">{category.title}</h3>
+                  <span className={`rounded-full border px-3 py-1 font-mono text-[11px] font-black ${statusTone[category.status]}`}>{category.score}</span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">Next: {category.nextAction}</p>
+                {category.blockers.length > 0 ? <p className="mt-2 text-xs leading-5 text-amber-100">Missing evidence: {category.blockers.length} item(s)</p> : null}
+              </article>
+            ))}
+          </div>
+        </section>
 
         <section className="mt-6 grid gap-4 lg:grid-cols-2">
           {report.gates.map((gate) => (

--- a/components/dsg/app-builder/AppBuilderProofPanel.tsx
+++ b/components/dsg/app-builder/AppBuilderProofPanel.tsx
@@ -1,0 +1,58 @@
+export type ProofPanelItem = {
+  id: string;
+  title: string;
+  status: 'PASS' | 'REVIEW' | 'BLOCKED';
+  evidence: string[];
+  missingEvidence: string[];
+  nextAction: string;
+};
+
+const tone = {
+  PASS: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  REVIEW: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  BLOCKED: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+} as const;
+
+export function AppBuilderProofPanel({ items, productionReadyClaim }: { items: ProofPanelItem[]; productionReadyClaim: boolean }) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-[#0f151f]/85 p-5 shadow-[0_0_44px_rgba(0,0,0,0.22)] backdrop-blur-xl">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-cyan-200">Proof panel</p>
+          <h2 className="mt-2 text-2xl font-black text-white">Marketplace proof stays fail-closed</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-7 text-slate-300">Every gate is PASS, REVIEW, or BLOCKED. REVIEW/BLOCKED always includes missing evidence and next action.</p>
+        </div>
+        <span className={`rounded-full border px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.16em] ${productionReadyClaim ? tone.PASS : tone.REVIEW}`}>
+          productionReadyClaim={String(productionReadyClaim)}
+        </span>
+      </div>
+      {!productionReadyClaim ? (
+        <p className="mt-4 rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4 text-sm leading-6 text-amber-100">No production-ready claim is displayed because deployment proof, enforcement tests, smoke outputs, and owner approvals are not all attached.</p>
+      ) : null}
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {items.map((item) => (
+          <article key={item.id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">{item.id}</p>
+                <h3 className="mt-1 font-bold text-white">{item.title}</h3>
+              </div>
+              <span className={`rounded-full border px-3 py-1 font-mono text-[11px] font-black ${tone[item.status]}`}>{item.status}</span>
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div>
+                <h4 className="text-sm font-bold text-emerald-200">Evidence</h4>
+                <ul className="mt-2 space-y-1 text-xs leading-5 text-slate-300">{(item.evidence.length ? item.evidence : ['No evidence attached']).map((entry) => <li key={entry}>• {entry}</li>)}</ul>
+              </div>
+              <div>
+                <h4 className="text-sm font-bold text-amber-200">Missing proof</h4>
+                <ul className="mt-2 space-y-1 text-xs leading-5 text-slate-300">{(item.missingEvidence.length ? item.missingEvidence : ['No missing proof listed']).map((entry) => <li key={entry}>• {entry}</li>)}</ul>
+              </div>
+            </div>
+            <p className="mt-4 rounded-xl border border-cyan-400/20 bg-cyan-500/5 p-3 text-xs leading-5 text-cyan-100">Next: {item.nextAction}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/dsg/app-builder/OutcomeIntakePanel.tsx
+++ b/components/dsg/app-builder/OutcomeIntakePanel.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import type { DsgOutcomePlan } from '@/lib/dsg/app-builder/outcome-intake';
+
+type OutcomeError = { ok: false; error: { code: string; message: string }; nextAction: string };
+
+export function OutcomeIntakePanel() {
+  const [goal, setGoal] = useState('');
+  const [targetUsers, setTargetUsers] = useState('operators, reviewers');
+  const [successOutcome, setSuccessOutcome] = useState('User can see a useful first workflow and the missing evidence before production.');
+  const [availableData, setAvailableData] = useState('existing customer or workflow data');
+  const [requiredIntegrations, setRequiredIntegrations] = useState('');
+  const [riskLevel, setRiskLevel] = useState<'low' | 'medium' | 'high' | 'regulated'>('medium');
+  const [productionIntent, setProductionIntent] = useState(false);
+  const [result, setResult] = useState<DsgOutcomePlan | OutcomeError | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function submitOutcome() {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/dsg/app-builder/outcome', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ goal, targetUsers, successOutcome, availableData, requiredIntegrations, riskLevel, productionIntent }),
+      });
+      const json = (await response.json()) as DsgOutcomePlan | OutcomeError;
+      setResult(json);
+    } catch (error) {
+      setResult({
+        ok: false,
+        error: {
+          code: 'OUTCOME_REQUEST_FAILED',
+          message: error instanceof Error ? error.message : 'Unable to reach outcome intake API.',
+        },
+        nextAction: 'Check the network/API route and retry; do not proceed as production-ready without a validated outcome plan.',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-[2rem] border border-[#f2ca50]/20 bg-[#0f151f]/90 p-5 shadow-[0_0_42px_rgba(242,202,80,0.10)]">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#f2ca50]">Outcome intake</p>
+          <h2 className="mt-2 text-2xl font-black text-white">อยากสร้างแอปอะไร?</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-7 text-slate-300">เริ่มจากผลลัพธ์ผู้ใช้ก่อน แล้วระบบจะแนะนำ template, PRD draft, readiness impact และ next action โดยไม่อ้างว่า production-ready</p>
+        </div>
+        <button onClick={submitOutcome} disabled={loading} className="rounded-full border border-[#f2ca50]/40 bg-[#f2ca50]/15 px-5 py-2 font-mono text-xs font-black uppercase tracking-[0.18em] text-[#ffe8a3] disabled:opacity-60">
+          {loading ? 'Checking…' : 'Create outcome plan'}
+        </button>
+      </div>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        <label className="block text-sm font-bold text-slate-200 lg:col-span-2">อยากสร้างแอปอะไร
+          <textarea value={goal} onChange={(event) => setGoal(event.target.value)} placeholder="เช่น สร้าง CRM ทีมเล็กที่บันทึกลูกค้า งาน และสถานะดีล" className="mt-2 min-h-24 w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white outline-none focus:border-[#f2ca50]/60" />
+        </label>
+        <label className="block text-sm font-bold text-slate-200">ใครใช้
+          <input value={targetUsers} onChange={(event) => setTargetUsers(event.target.value)} className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white outline-none focus:border-[#f2ca50]/60" />
+        </label>
+        <label className="block text-sm font-bold text-slate-200">ผลลัพธ์ที่ต้องเห็น
+          <input value={successOutcome} onChange={(event) => setSuccessOutcome(event.target.value)} className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white outline-none focus:border-[#f2ca50]/60" />
+        </label>
+        <label className="block text-sm font-bold text-slate-200">ข้อมูลที่มี
+          <input value={availableData} onChange={(event) => setAvailableData(event.target.value)} className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white outline-none focus:border-[#f2ca50]/60" />
+        </label>
+        <label className="block text-sm font-bold text-slate-200">ข้อจำกัดด้านความเสี่ยง / integrations
+          <input value={requiredIntegrations} onChange={(event) => setRequiredIntegrations(event.target.value)} placeholder="Stripe, SSO, email, marketplace entitlement" className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white outline-none focus:border-[#f2ca50]/60" />
+        </label>
+        <div className="flex flex-wrap gap-3 lg:col-span-2">
+          <select value={riskLevel} onChange={(event) => setRiskLevel(event.target.value as typeof riskLevel)} className="rounded-2xl border border-white/10 bg-black/50 p-3 text-sm text-white">
+            <option value="low">low</option><option value="medium">medium</option><option value="high">high</option><option value="regulated">regulated</option>
+          </select>
+          <label className="flex items-center gap-2 rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-slate-200">
+            <input type="checkbox" checked={productionIntent} onChange={(event) => setProductionIntent(event.target.checked)} /> production intent
+          </label>
+        </div>
+      </div>
+      {result ? (
+        <div className="mt-5 rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
+          {'ok' in result && result.ok ? (
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">Next action</p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">{result.nextAction}</p>
+              <p className="mt-3 text-sm text-slate-300">Suggested templates: {result.suggestedTemplateIds.join(', ')}</p>
+              <p className="mt-2 text-sm text-slate-300">Readiness impact: {Object.entries(result.readinessImpact).filter(([, value]) => value).map(([key]) => key).join(', ') || 'planning only'}</p>
+            </div>
+          ) : (
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-rose-200">{result.error.code}</p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">{result.error.message}</p>
+              <p className="mt-2 text-sm leading-6 text-amber-100">Next: {result.nextAction}</p>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/ENTERPRISE_ENFORCEMENT_CONTRACT.md
+++ b/docs/ENTERPRISE_ENFORCEMENT_CONTRACT.md
@@ -1,0 +1,32 @@
+# Enterprise Enforcement Contract
+
+This document defines the expected fail-closed contract for DSG authorization and entitlement decisions.
+
+## Boundary
+
+- This is a contract, not proof that RBAC or billing enforcement is complete.
+- No Stripe, Supabase, marketplace entitlement, or production billing integration is added here.
+- Marketplace readiness remains REVIEW/BLOCKED until runtime enforcement tests and owner approvals exist.
+
+## Authorization
+
+`decideDsgAuthorization` in `lib/dsg/security/authorization-contract.ts` fails closed when subject, org, org match, or policy evidence is missing.
+
+Required before PASS:
+
+- Server-side use on critical read/write routes.
+- Allowed and denied role tests.
+- Cross-org denial tests.
+- Audit event proof for privileged actions.
+
+## Entitlement
+
+`decideDsgEntitlement` in `lib/dsg/billing/entitlement-contract.ts` fails closed when plan, policy, feature access, quota, or billing evidence is missing.
+
+Required before PASS:
+
+- Plan/seat/quota source of truth.
+- Feature denial tests.
+- Quota exceeded tests.
+- Upgrade path proof.
+- Marketplace or billing provider evidence.

--- a/docs/evidence/ACCESSIBILITY_REVIEW_NOTES_TEMPLATE.md
+++ b/docs/evidence/ACCESSIBILITY_REVIEW_NOTES_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Accessibility Review Notes
+
+Date:
+Reviewer:
+URL:
+Viewport:
+Device:
+
+## Keyboard
+- Can tab to primary actions:
+- No keyboard trap:
+- Focus order logical:
+- Focus visible:
+
+## Semantic Structure
+- Page title:
+- Heading order:
+- Landmark:
+- Form labels:
+- Status text:
+
+## Visual
+- Contrast checked:
+- Mobile viewport:
+- Error/warning readable:
+- Status not color-only:
+
+## Result
+Verdict: PASS / REVIEW / BLOCKED
+Missing evidence:
+Next action:

--- a/docs/evidence/FIRST_VALUE_FLOW_CHECKLIST.md
+++ b/docs/evidence/FIRST_VALUE_FLOW_CHECKLIST.md
@@ -1,0 +1,23 @@
+# First Value Flow Checklist
+
+Use this checklist with `APP_URL="https://dsg-one-v1.vercel.app" npm run smoke:first-value-flow`.
+
+## Routes that must return 2xx
+
+- [ ] /dsg/app-builder
+- [ ] /enterprise/readiness
+- [ ] /enterprise/terms
+- [ ] /enterprise/privacy
+- [ ] /enterprise/security
+- [ ] /enterprise/support
+- [ ] /enterprise/entitlement
+- [ ] /enterprise/security-rbac
+- [ ] /enterprise/accessibility
+- [ ] /enterprise/market
+- [ ] /api/dsg/market/agent-app-builder
+- [ ] /api/dsg/marketplace/audit-packet
+- [ ] /api/dsg/marketplace/readiness-score
+
+## Evidence boundary
+
+Passing this smoke proves route accessibility only. It does not prove marketplace PASS, RBAC enforcement, billing enforcement, WCAG approval, or production readiness.

--- a/lib/dsg/app-builder/outcome-intake.ts
+++ b/lib/dsg/app-builder/outcome-intake.ts
@@ -1,0 +1,142 @@
+export type DsgOutcomeIntake = {
+  goal: string;
+  targetUsers: string[];
+  successOutcome: string;
+  availableData: string[];
+  requiredIntegrations: string[];
+  riskLevel: 'low' | 'medium' | 'high' | 'regulated';
+  productionIntent: boolean;
+};
+
+export type DsgOutcomePlan = {
+  ok: true;
+  intake: DsgOutcomeIntake;
+  suggestedTemplateIds: string[];
+  generatedPrdDraft: unknown;
+  readinessImpact: {
+    needsAuth: boolean;
+    needsDatabase: boolean;
+    needsBilling: boolean;
+    needsRBAC: boolean;
+    needsAuditLog: boolean;
+  };
+  nextAction: string;
+};
+
+export type DsgOutcomeIntakeError = {
+  ok: false;
+  error: { code: 'OUTCOME_GOAL_REQUIRED' | 'OUTCOME_INVALID_INPUT'; message: string };
+  nextAction: string;
+};
+
+const MAX_GOAL_LENGTH = 800;
+const MAX_SUCCESS_OUTCOME_LENGTH = 600;
+const MAX_ARRAY_ITEMS = 12;
+const MAX_ARRAY_ITEM_LENGTH = 140;
+
+function invalidInput(message: string): DsgOutcomeIntakeError {
+  return {
+    ok: false,
+    error: { code: 'OUTCOME_INVALID_INPUT', message },
+    nextAction: 'Shorten the outcome intake fields and retry. This planning API stays fail-closed when input exceeds reviewable limits.',
+  };
+}
+
+function toStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item).trim()).filter(Boolean);
+  if (typeof value === 'string') return value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean);
+  return [];
+}
+
+function validateStringLength(field: string, value: string, maxLength: number): DsgOutcomeIntakeError | null {
+  if (value.length > maxLength) return invalidInput(`${field} must be ${maxLength} characters or fewer.`);
+  return null;
+}
+
+function validateStringArray(field: string, values: string[]): DsgOutcomeIntakeError | null {
+  if (values.length > MAX_ARRAY_ITEMS) return invalidInput(`${field} may include at most ${MAX_ARRAY_ITEMS} items.`);
+  const tooLong = values.find((item) => item.length > MAX_ARRAY_ITEM_LENGTH);
+  if (tooLong) return invalidInput(`${field} items must be ${MAX_ARRAY_ITEM_LENGTH} characters or fewer.`);
+  return null;
+}
+
+function normalizeRiskLevel(value: unknown): DsgOutcomeIntake['riskLevel'] {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'regulated' ? value : 'medium';
+}
+
+export function parseDsgOutcomeIntake(input: unknown): DsgOutcomeIntake | DsgOutcomeIntakeError {
+  if (!input || typeof input !== 'object') {
+    return { ok: false, error: { code: 'OUTCOME_INVALID_INPUT', message: 'Request body must be a JSON object.' }, nextAction: 'Submit an outcome intake JSON object with a non-empty goal.' };
+  }
+
+  const body = input as Record<string, unknown>;
+  const goal = typeof body.goal === 'string' ? body.goal.trim() : '';
+  if (!goal) {
+    return { ok: false, error: { code: 'OUTCOME_GOAL_REQUIRED', message: 'goal is required and cannot be empty.' }, nextAction: 'Describe the app outcome you want to create before generating a plan.' };
+  }
+
+  const successOutcome = typeof body.successOutcome === 'string' ? body.successOutcome.trim() : '';
+  const targetUsers = toStringArray(body.targetUsers);
+  const availableData = toStringArray(body.availableData);
+  const requiredIntegrations = toStringArray(body.requiredIntegrations);
+
+  const validationError =
+    validateStringLength('goal', goal, MAX_GOAL_LENGTH) ||
+    validateStringLength('successOutcome', successOutcome, MAX_SUCCESS_OUTCOME_LENGTH) ||
+    validateStringArray('targetUsers', targetUsers) ||
+    validateStringArray('availableData', availableData) ||
+    validateStringArray('requiredIntegrations', requiredIntegrations);
+
+  if (validationError) return validationError;
+
+  return {
+    goal,
+    targetUsers,
+    successOutcome,
+    availableData,
+    requiredIntegrations,
+    riskLevel: normalizeRiskLevel(body.riskLevel),
+    productionIntent: body.productionIntent === true,
+  };
+}
+
+export function createDsgOutcomePlan(intake: DsgOutcomeIntake): DsgOutcomePlan {
+  const goalText = `${intake.goal} ${intake.successOutcome} ${intake.requiredIntegrations.join(' ')}`.toLowerCase();
+  const needsBilling = /billing|subscription|membership|payment|stripe|plan|quota|entitlement/.test(goalText);
+  const needsAuth = intake.productionIntent || intake.riskLevel !== 'low' || /login|member|customer|portal|approval|crm|support/.test(goalText);
+  const needsDatabase = intake.productionIntent || intake.availableData.length > 0 || /inventory|booking|crm|record|dashboard|portal|approval|customer/.test(goalText);
+  const needsRBAC = intake.riskLevel === 'high' || intake.riskLevel === 'regulated' || /approval|admin|role|team|org|customer data/.test(goalText);
+  const needsAuditLog = intake.productionIntent || intake.riskLevel === 'regulated' || /audit|compliance|approval|marketplace/.test(goalText);
+
+  const suggestedTemplateIds = [
+    /booking|appointment|schedule/.test(goalText) ? 'booking-appointment' : null,
+    /crm|customer|deal|lead/.test(goalText) ? 'crm-mini-app' : null,
+    /inventory|stock|warehouse/.test(goalText) ? 'inventory-tracker' : null,
+    /support|ticket|portal/.test(goalText) ? 'customer-support-portal' : null,
+    /approval|review|workflow/.test(goalText) ? 'approval-workflow' : null,
+    /compliance|audit|risk/.test(goalText) ? 'compliance-dashboard' : null,
+    /marketplace|listing/.test(goalText) ? 'marketplace-listing-kit' : null,
+    /assistant|ai/.test(goalText) ? 'ai-assistant-approval-gate' : null,
+    needsBilling ? 'membership-subscription-app' : null,
+  ].filter(Boolean) as string[];
+
+  if (suggestedTemplateIds.length === 0) suggestedTemplateIds.push('evidence-audit-portal');
+
+  return {
+    ok: true,
+    intake,
+    suggestedTemplateIds,
+    generatedPrdDraft: {
+      title: intake.goal,
+      summary: intake.successOutcome || 'Outcome intake captured. PRD draft requires human review before production work.',
+      targetUsers: intake.targetUsers,
+      availableData: intake.availableData,
+      requiredIntegrations: intake.requiredIntegrations,
+      riskLevel: intake.riskLevel,
+      productionReadyClaim: false,
+      evidenceBoundary: 'This draft is planning output only. It is not production-ready evidence.',
+    },
+    readinessImpact: { needsAuth, needsDatabase, needsBilling, needsRBAC, needsAuditLog },
+    nextAction: 'Review the suggested template and proof panel, then generate PRD/plan while keeping productionReadyClaim=false until real build, deploy, enforcement, and owner evidence exists.',
+  };
+}

--- a/lib/dsg/app-builder/templates/template-registry.ts
+++ b/lib/dsg/app-builder/templates/template-registry.ts
@@ -85,3 +85,176 @@ export function getDsgAppTemplatesForUseCase(useCase: string): DsgAppTemplate[] 
     template.useCases.some((candidate) => candidate.toLowerCase().includes(normalized) || normalized.includes(candidate.toLowerCase())),
   );
 }
+
+export type DsgMarketTemplate = {
+  id: string;
+  name: string;
+  category: string;
+  idealCustomer: string;
+  businessOutcome: string;
+  requiredPages: string[];
+  requiredApis: string[];
+  requiredData: string[];
+  requiredIntegrations: string[];
+  readinessGates: string[];
+  riskLevel: 'low' | 'medium' | 'high' | 'regulated';
+  smokeTests: string[];
+  blockedUntil: string[];
+};
+
+export const DSG_MARKET_TEMPLATES: DsgMarketTemplate[] = [
+  {
+    id: 'booking-appointment',
+    name: 'Booking / Appointment',
+    category: 'operations',
+    idealCustomer: 'Service businesses that need customer self-scheduling.',
+    businessOutcome: 'Customers request appointments and operators review booking state.',
+    requiredPages: ['/book', '/operator/bookings'],
+    requiredApis: ['/api/bookings', '/api/bookings/[id]/status'],
+    requiredData: ['customers', 'appointments', 'availability windows'],
+    requiredIntegrations: ['calendar optional', 'email optional'],
+    readinessGates: ['marketplace-readiness', 'security-rbac', 'accessibility-qa'],
+    riskLevel: 'medium',
+    smokeTests: ['smoke:app-builder-flow-proof', 'smoke:first-value-flow'],
+    blockedUntil: ['Database persistence proof', 'Server-side booking ownership checks', 'Deployment smoke output'],
+  },
+  {
+    id: 'crm-mini-app',
+    name: 'CRM mini app',
+    category: 'sales',
+    idealCustomer: 'Small teams tracking leads, contacts, notes, and tasks.',
+    businessOutcome: 'Team can manage customer follow-up from a protected workspace.',
+    requiredPages: ['/crm', '/crm/contacts', '/crm/tasks'],
+    requiredApis: ['/api/crm/contacts', '/api/crm/tasks'],
+    requiredData: ['contacts', 'notes', 'tasks', 'deal status'],
+    requiredIntegrations: ['email optional'],
+    readinessGates: ['security-rbac', 'accessibility-qa', 'deployment-proof'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:security-rbac', 'smoke:app-builder-flow-proof'],
+    blockedUntil: ['Auth proof', 'RBAC/org isolation enforcement test', 'Audit log proof for customer data changes'],
+  },
+  {
+    id: 'inventory-tracker',
+    name: 'Inventory tracker',
+    category: 'operations',
+    idealCustomer: 'Retail or warehouse teams that need simple stock visibility.',
+    businessOutcome: 'Operators update inventory and see low-stock signals.',
+    requiredPages: ['/inventory', '/inventory/items'],
+    requiredApis: ['/api/inventory/items', '/api/inventory/adjustments'],
+    requiredData: ['items', 'stock movements', 'locations'],
+    requiredIntegrations: ['barcode scanner optional'],
+    readinessGates: ['security-rbac', 'runtime-gate', 'accessibility-qa'],
+    riskLevel: 'medium',
+    smokeTests: ['smoke:app-builder-flow-proof'],
+    blockedUntil: ['Database write proof', 'Adjustment audit trail', 'Role-based write denial proof'],
+  },
+  {
+    id: 'customer-support-portal',
+    name: 'Customer support portal',
+    category: 'support',
+    idealCustomer: 'SaaS teams receiving and triaging customer requests.',
+    businessOutcome: 'Customers submit tickets and support agents manage status safely.',
+    requiredPages: ['/support/portal', '/support/agent'],
+    requiredApis: ['/api/support/tickets', '/api/support/tickets/[id]'],
+    requiredData: ['tickets', 'customers', 'messages', 'status history'],
+    requiredIntegrations: ['email', 'helpdesk optional'],
+    readinessGates: ['security-rbac', 'legal-support', 'accessibility-qa'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:security-rbac', 'smoke:first-value-flow'],
+    blockedUntil: ['Customer identity proof', 'Cross-customer isolation test', 'Support contact and SLA review'],
+  },
+  {
+    id: 'approval-workflow',
+    name: 'Approval workflow',
+    category: 'workflow',
+    idealCustomer: 'Teams routing requests through submit, approve, reject, or escalate states.',
+    businessOutcome: 'Requests move through traceable decisions with clear next actions.',
+    requiredPages: ['/requests', '/requests/[id]', '/approvals'],
+    requiredApis: ['/api/requests', '/api/requests/[id]/decision'],
+    requiredData: ['requests', 'decisions', 'actors', 'audit events'],
+    requiredIntegrations: ['identity provider optional'],
+    readinessGates: ['security-rbac', 'audit-log', 'runtime-gate'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:security-rbac', 'smoke:app-builder-flow-proof'],
+    blockedUntil: ['Server-side role enforcement', 'Decision audit event proof', 'Denied decision negative test'],
+  },
+  {
+    id: 'compliance-dashboard',
+    name: 'Compliance dashboard',
+    category: 'governance',
+    idealCustomer: 'Regulated teams reviewing controls, risks, evidence, and owners.',
+    businessOutcome: 'Reviewers see control status and missing evidence without false PASS claims.',
+    requiredPages: ['/compliance', '/compliance/controls'],
+    requiredApis: ['/api/compliance/controls', '/api/compliance/evidence'],
+    requiredData: ['controls', 'evidence', 'owners', 'reviews'],
+    requiredIntegrations: ['GRC optional', 'storage optional'],
+    readinessGates: ['marketplace-readiness', 'security-rbac', 'accessibility-qa', 'legal-support'],
+    riskLevel: 'regulated',
+    smokeTests: ['smoke:marketplace-readiness', 'smoke:accessibility-qa'],
+    blockedUntil: ['Owner approvals', 'Evidence retention policy', 'Audit export proof'],
+  },
+  {
+    id: 'marketplace-listing-kit',
+    name: 'Marketplace listing kit',
+    category: 'marketplace',
+    idealCustomer: 'Teams preparing SaaS listings for enterprise marketplaces.',
+    businessOutcome: 'Owners see pricing, support, legal, security, and evidence gaps before submission.',
+    requiredPages: ['/enterprise/readiness', '/enterprise/support', '/enterprise/security'],
+    requiredApis: ['/api/dsg/marketplace/readiness', '/api/dsg/marketplace/audit-packet'],
+    requiredData: ['readiness gates', 'smoke evidence', 'owner approvals'],
+    requiredIntegrations: ['marketplace portal manual submission'],
+    readinessGates: ['marketplace-readiness', 'entitlement', 'legal-support', 'deployment-proof'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:marketplace-readiness', 'smoke:audit-packet'],
+    blockedUntil: ['Real deployment proof', 'Owner approval evidence', 'Entitlement enforcement test'],
+  },
+  {
+    id: 'evidence-audit-portal',
+    name: 'Evidence/audit portal',
+    category: 'governance',
+    idealCustomer: 'Operators collecting proof across product, security, QA, and marketplace readiness.',
+    businessOutcome: 'Evidence packets can be reviewed without trusting unverified marketing claims.',
+    requiredPages: ['/enterprise/readiness', '/enterprise/accessibility'],
+    requiredApis: ['/api/dsg/marketplace/audit-packet', '/api/dsg/marketplace/readiness-score'],
+    requiredData: ['evidence artifacts', 'missing evidence', 'next actions'],
+    requiredIntegrations: ['artifact storage optional'],
+    readinessGates: ['marketplace-readiness', 'accessibility-qa', 'security-rbac'],
+    riskLevel: 'medium',
+    smokeTests: ['smoke:audit-packet', 'smoke:first-value-flow'],
+    blockedUntil: ['Smoke output attached', 'Deployment proof attached', 'Owner review'],
+  },
+  {
+    id: 'ai-assistant-approval-gate',
+    name: 'AI assistant with approval gate',
+    category: 'ai-workflow',
+    idealCustomer: 'Teams that want AI assistance but require human approval before action.',
+    businessOutcome: 'AI drafts recommendations while execution remains gated by human and policy proof.',
+    requiredPages: ['/assistant', '/assistant/review'],
+    requiredApis: ['/api/assistant/draft', '/api/assistant/approve'],
+    requiredData: ['prompts', 'drafts', 'approvals', 'audit events'],
+    requiredIntegrations: ['model provider', 'identity provider optional'],
+    readinessGates: ['runtime-gate', 'security-rbac', 'audit-log'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:app-builder-flow-proof', 'smoke:security-rbac'],
+    blockedUntil: ['Human approval enforcement proof', 'Prompt/output audit trail', 'Role denial test'],
+  },
+  {
+    id: 'membership-subscription-app',
+    name: 'Membership/subscription app',
+    category: 'commerce',
+    idealCustomer: 'SaaS or community products requiring paid plan access.',
+    businessOutcome: 'Members access features according to plan, seat, quota, and upgrade path.',
+    requiredPages: ['/membership', '/billing', '/account'],
+    requiredApis: ['/api/membership', '/api/billing/entitlement'],
+    requiredData: ['plans', 'members', 'seats', 'quotas', 'entitlements'],
+    requiredIntegrations: ['billing provider', 'marketplace entitlement API optional'],
+    readinessGates: ['entitlement', 'security-rbac', 'legal-support'],
+    riskLevel: 'high',
+    smokeTests: ['smoke:entitlement', 'smoke:first-value-flow'],
+    blockedUntil: ['Billing provider or marketplace entitlement proof', 'Quota exceeded denial test', 'Upgrade path proof'],
+  },
+];
+
+export function getDsgMarketTemplateById(id: string): DsgMarketTemplate | undefined {
+  return DSG_MARKET_TEMPLATES.find((template) => template.id === id);
+}

--- a/lib/dsg/billing/entitlement-contract.ts
+++ b/lib/dsg/billing/entitlement-contract.ts
@@ -1,0 +1,26 @@
+export type DsgEntitlementDecision = {
+  ok: boolean;
+  planId: string | null;
+  feature: string;
+  quotaRemaining: number | null;
+  reason: 'ALLOW' | 'NO_PLAN' | 'FEATURE_DENIED' | 'QUOTA_EXCEEDED' | 'BILLING_REQUIRED' | 'POLICY_MISSING';
+  upgradePath: string | null;
+};
+
+export type DsgEntitlementInput = {
+  planId?: string | null;
+  feature: string;
+  allowedFeatures?: string[];
+  quotaRemaining?: number | null;
+  billingRequired?: boolean;
+  upgradePath?: string | null;
+};
+
+export function decideDsgEntitlement(input: DsgEntitlementInput): DsgEntitlementDecision {
+  if (input.billingRequired && !input.planId) return { ok: false, planId: null, feature: input.feature, quotaRemaining: input.quotaRemaining ?? null, reason: 'BILLING_REQUIRED', upgradePath: input.upgradePath ?? '/enterprise/entitlement' };
+  if (!input.planId) return { ok: false, planId: null, feature: input.feature, quotaRemaining: input.quotaRemaining ?? null, reason: 'NO_PLAN', upgradePath: input.upgradePath ?? '/enterprise/entitlement' };
+  if (!input.allowedFeatures) return { ok: false, planId: input.planId, feature: input.feature, quotaRemaining: input.quotaRemaining ?? null, reason: 'POLICY_MISSING', upgradePath: input.upgradePath ?? '/enterprise/entitlement' };
+  if (!input.allowedFeatures.includes(input.feature)) return { ok: false, planId: input.planId, feature: input.feature, quotaRemaining: input.quotaRemaining ?? null, reason: 'FEATURE_DENIED', upgradePath: input.upgradePath ?? '/enterprise/entitlement' };
+  if (typeof input.quotaRemaining === 'number' && input.quotaRemaining <= 0) return { ok: false, planId: input.planId, feature: input.feature, quotaRemaining: input.quotaRemaining, reason: 'QUOTA_EXCEEDED', upgradePath: input.upgradePath ?? '/enterprise/entitlement' };
+  return { ok: true, planId: input.planId, feature: input.feature, quotaRemaining: input.quotaRemaining ?? null, reason: 'ALLOW', upgradePath: null };
+}

--- a/lib/dsg/market/agent-app-builder-market.ts
+++ b/lib/dsg/market/agent-app-builder-market.ts
@@ -1,0 +1,112 @@
+export type MarketCompetitor = {
+  id: string;
+  name: string;
+  category: 'ai-app-builder' | 'enterprise-low-code' | 'marketplace-saas';
+  positioning: string;
+  strengths: string[];
+  gaps: string[];
+  dsgOpportunity: string;
+  sourceNotes: string[];
+};
+
+export type MarketDirection = {
+  id: string;
+  title: string;
+  customerNeed: string;
+  requiredProductCapability: string;
+  evidenceRequired: string[];
+  status: 'PASS' | 'REVIEW' | 'BLOCKED';
+};
+
+export type AgentAppBuilderMarketReport = {
+  ok: true;
+  generatedAt: string;
+  positioning: string;
+  competitors: MarketCompetitor[];
+  directions: MarketDirection[];
+  noMockPolicy: { enforced: true; rule: string };
+};
+
+export const agentAppBuilderCompetitors: MarketCompetitor[] = [
+  {
+    id: 'v0',
+    name: 'v0',
+    category: 'ai-app-builder',
+    positioning: 'Natural-language app and UI generation tied to the Vercel deployment ecosystem.',
+    strengths: ['Fast prompt-to-UI loop', 'Vercel-native deployment path', 'Useful for landing pages through full-stack app starts'],
+    gaps: ['Marketplace submission evidence is not the primary surface', 'Enterprise enforcement proof still depends on the generated app implementation'],
+    dsgOpportunity: 'Make proof, gates, and missing evidence visible inside the builder rather than only generating code quickly.',
+    sourceNotes: ['v0 product/docs positioning: natural language to UI/app code', 'Vercel deployment docs: production URL, HTTPS/CDN, monitoring ecosystem'],
+  },
+  {
+    id: 'bolt',
+    name: 'Bolt',
+    category: 'ai-app-builder',
+    positioning: 'Prompt, run, edit, and deploy full-stack browser apps with an in-browser development loop.',
+    strengths: ['Browser-native full-stack iteration', 'Integrated filesystem/package/terminal/browser-console style loop', 'Low setup friction for first-time users'],
+    gaps: ['Enterprise governance evidence must still be proven per generated app', 'Billing/RBAC/audit claims need runtime enforcement proof'],
+    dsgOpportunity: 'Compete on first-value speed while adding fail-closed evidence contracts and marketplace packet export.',
+    sourceNotes: ['Bolt/WebContainers positioning: browser full-stack app loop', 'No market-share claim is made in this registry'],
+  },
+  {
+    id: 'enterprise-low-code',
+    name: 'Enterprise low-code platforms',
+    category: 'enterprise-low-code',
+    positioning: 'AI-assisted delivery with integrations, composable architecture, scale, and built-in governance.',
+    strengths: ['Governance vocabulary enterprise buyers expect', 'Integration and delivery management', 'Scalable release controls'],
+    gaps: ['Can be slower to first useful app', 'Generated proof often remains scattered across tools and review docs'],
+    dsgOpportunity: 'Show user outcome, app plan, proof panel, readiness score, and audit packet in one flow.',
+    sourceNotes: ['Gartner-style enterprise low-code themes: AI-assisted tooling, composability, governance, integration demand'],
+  },
+  {
+    id: 'marketplace-saas',
+    name: 'Marketplace SaaS review standard',
+    category: 'marketplace-saas',
+    positioning: 'Marketplace review expects pricing, entitlement, support, data handling, security, audit, and production readiness evidence.',
+    strengths: ['Clear buyer trust requirements', 'Repeatable listing and review artifact expectations'],
+    gaps: ['A builder must gather evidence from many routes/scripts before a reviewer can trust it'],
+    dsgOpportunity: 'Produce an audit packet and dashboard that blocks PASS until real smoke output, enforcement tests, deployment proof, and owner approvals exist.',
+    sourceNotes: ['AWS/Google marketplace SaaS review themes: pricing, entitlement, support, security, data handling, production readiness'],
+  },
+];
+
+export const agentAppBuilderMarketDirections: MarketDirection[] = [
+  {
+    id: 'natural-language-intake',
+    title: 'Outcome-first creation',
+    customerNeed: 'Users want to describe the app and result in plain language before thinking about stack details.',
+    requiredProductCapability: 'Outcome intake that turns goal, users, data, integrations, and risk into a PRD draft and next action.',
+    evidenceRequired: ['POST /api/dsg/app-builder/outcome returns validated JSON', 'Empty goal returns 400', 'UI displays nextAction'],
+    status: 'REVIEW',
+  },
+  {
+    id: 'template-marketplace',
+    title: 'Selectable business templates',
+    customerNeed: 'Teams need a short path from common business outcomes to pages, APIs, data, integrations, and proof needs.',
+    requiredProductCapability: 'Template registry with risk level, readiness gates, smoke tests, and blockedUntil proof gaps.',
+    evidenceRequired: ['Template registry in lib/dsg/app-builder/templates/template-registry.ts', 'UI shows risk and missing proof'],
+    status: 'REVIEW',
+  },
+  {
+    id: 'governed-proof-loop',
+    title: 'Evidence-first governance',
+    customerNeed: 'Enterprise reviewers need proof before production or marketplace claims.',
+    requiredProductCapability: 'Proof panel, readiness score, and audit packet that fail closed when evidence is missing.',
+    evidenceRequired: ['GET /api/dsg/marketplace/audit-packet', 'GET /api/dsg/marketplace/readiness-score', 'smoke scripts attached'],
+    status: 'REVIEW',
+  },
+];
+
+export function getAgentAppBuilderMarketReport(): AgentAppBuilderMarketReport {
+  return {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    positioning: 'DSG is positioned as an evidence-first agent app builder: fast outcome intake plus visible proof gates, not unverified production claims.',
+    competitors: agentAppBuilderCompetitors,
+    directions: agentAppBuilderMarketDirections,
+    noMockPolicy: {
+      enforced: true,
+      rule: 'Market notes may describe positioning and opportunities, but must not claim market share, production readiness, or enforcement without source notes and repo evidence.',
+    },
+  };
+}

--- a/lib/dsg/marketplace/accessibility-checklist.ts
+++ b/lib/dsg/marketplace/accessibility-checklist.ts
@@ -1,0 +1,23 @@
+export type AccessibilityReviewChecklistItem = {
+  section: 'Keyboard' | 'Semantic Structure' | 'Visual' | 'Result';
+  label: string;
+  status: 'REVIEW';
+  nextAction: string;
+};
+
+export const ACCESSIBILITY_REVIEW_CHECKLIST: AccessibilityReviewChecklistItem[] = [
+  { section: 'Keyboard', label: 'Can tab to primary actions', status: 'REVIEW', nextAction: 'Reviewer must tab through primary actions and attach notes.' },
+  { section: 'Keyboard', label: 'No keyboard trap', status: 'REVIEW', nextAction: 'Reviewer must verify escape/continue path for interactive regions.' },
+  { section: 'Keyboard', label: 'Focus order logical', status: 'REVIEW', nextAction: 'Reviewer must record focus order for core pages.' },
+  { section: 'Keyboard', label: 'Focus visible', status: 'REVIEW', nextAction: 'Reviewer must attach focus-visible notes or screenshots.' },
+  { section: 'Semantic Structure', label: 'Page title', status: 'REVIEW', nextAction: 'Reviewer must verify title and route context.' },
+  { section: 'Semantic Structure', label: 'Heading order', status: 'REVIEW', nextAction: 'Reviewer must inspect heading hierarchy.' },
+  { section: 'Semantic Structure', label: 'Landmark', status: 'REVIEW', nextAction: 'Reviewer must inspect landmarks.' },
+  { section: 'Semantic Structure', label: 'Form labels', status: 'REVIEW', nextAction: 'Reviewer must verify visible/programmatic labels.' },
+  { section: 'Semantic Structure', label: 'Status text', status: 'REVIEW', nextAction: 'Reviewer must confirm statuses are readable as text.' },
+  { section: 'Visual', label: 'Contrast checked', status: 'REVIEW', nextAction: 'Reviewer must run contrast check and attach result.' },
+  { section: 'Visual', label: 'Mobile viewport', status: 'REVIEW', nextAction: 'Reviewer must check a mobile viewport.' },
+  { section: 'Visual', label: 'Error/warning readable', status: 'REVIEW', nextAction: 'Reviewer must verify warning/error readability.' },
+  { section: 'Visual', label: 'Status not color-only', status: 'REVIEW', nextAction: 'Reviewer must confirm status text/icons do not rely only on color.' },
+  { section: 'Result', label: 'Verdict: PASS / REVIEW / BLOCKED', status: 'REVIEW', nextAction: 'Reviewer must choose verdict and list missing evidence before any PASS.' },
+];

--- a/lib/dsg/marketplace/audit-packet.ts
+++ b/lib/dsg/marketplace/audit-packet.ts
@@ -1,0 +1,61 @@
+import { createAppBuilderFlowProof } from '@/lib/dsg/app-builder/proof/create-flow-proof';
+import { getAccessibilityQaReport } from './accessibility-qa';
+import { getEntitlementReport } from './entitlement';
+import { getEnterpriseMarketplaceReadinessReport } from './readiness';
+import { createReadinessScore, type ReadinessScore } from './readiness-score';
+import { getSecurityRbacReport } from './security-rbac';
+
+export type DsgAuditPacket = {
+  ok: true;
+  generatedAt: string;
+  product: 'DSG ONE V1';
+  baseUrl: string;
+  readiness: unknown;
+  readinessScore: ReadinessScore;
+  accessibilityQa: unknown;
+  securityRbac: unknown;
+  entitlement: unknown;
+  appBuilderProof: unknown;
+  smokeEvidence: string[];
+  missingEvidence: string[];
+  finalVerdict: 'PASS' | 'REVIEW' | 'BLOCKED';
+};
+
+function combineVerdict(verdicts: Array<'PASS' | 'REVIEW' | 'BLOCKED'>): 'PASS' | 'REVIEW' | 'BLOCKED' {
+  if (verdicts.includes('BLOCKED')) return 'BLOCKED';
+  if (verdicts.includes('REVIEW')) return 'REVIEW';
+  return 'PASS';
+}
+
+export function createDsgAuditPacket(baseUrl: string): DsgAuditPacket {
+  const readiness = getEnterpriseMarketplaceReadinessReport();
+  const accessibilityQa = getAccessibilityQaReport();
+  const securityRbac = getSecurityRbacReport();
+  const entitlement = getEntitlementReport();
+  const appBuilderProof = createAppBuilderFlowProof('Create an evidence-first enterprise app builder audit packet.');
+  const readinessScore = createReadinessScore(readiness);
+  const missingEvidence = [
+    ...readinessScore.missingEvidence,
+    ...securityRbac.checks.flatMap((check) => check.status === 'PASS' ? [] : check.requiredBeforePass.map((item) => `security-rbac:${check.id}: ${item}`)),
+    ...entitlement.checks.flatMap((check) => check.status === 'PASS' ? [] : check.requiredBeforePass.map((item) => `entitlement:${check.id}: ${item}`)),
+    ...accessibilityQa.checks.flatMap((check) => check.status === 'PASS' ? [] : check.requiredBeforePass.map((item) => `accessibility:${check.id}: ${item}`)),
+  ];
+  const smokeEvidence = readiness.gates.flatMap((gate) => gate.verifiedEvidence.filter((item) => /smoke|script/i.test(item)));
+  const combined = combineVerdict([readiness.verdict, accessibilityQa.verdict, securityRbac.verdict, entitlement.verdict, readinessScore.verdict]);
+
+  return {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    product: 'DSG ONE V1',
+    baseUrl,
+    readiness,
+    readinessScore,
+    accessibilityQa,
+    securityRbac,
+    entitlement,
+    appBuilderProof,
+    smokeEvidence,
+    missingEvidence,
+    finalVerdict: combined === 'PASS' && missingEvidence.length > 0 ? 'REVIEW' : combined,
+  };
+}

--- a/lib/dsg/marketplace/readiness-score.ts
+++ b/lib/dsg/marketplace/readiness-score.ts
@@ -1,0 +1,59 @@
+import type { MarketplaceReadinessReport, MarketplaceReadinessStatus } from './readiness';
+
+export type ReadinessScore = {
+  overall: number;
+  verdict: 'PASS' | 'REVIEW' | 'BLOCKED';
+  categories: Array<{
+    id: string;
+    title: string;
+    score: number;
+    status: 'PASS' | 'REVIEW' | 'BLOCKED';
+    blockers: string[];
+    nextAction: string;
+  }>;
+  missingEvidence: string[];
+  caps: string[];
+};
+
+function scoreGate(status: MarketplaceReadinessStatus, hasSmokeEvidence: boolean): number {
+  if (status === 'PASS') return 100;
+  if (status === 'BLOCKED') return 0;
+  return hasSmokeEvidence ? 70 : 50;
+}
+
+export function createReadinessScore(report: MarketplaceReadinessReport): ReadinessScore {
+  const categories = report.gates.map((gate) => {
+    const hasSmokeEvidence = gate.verifiedEvidence.some((item) => item.toLowerCase().includes('smoke'));
+    return {
+      id: gate.id,
+      title: gate.title,
+      score: scoreGate(gate.status, hasSmokeEvidence),
+      status: gate.status,
+      blockers: gate.status === 'PASS' ? [] : gate.requiredEvidence,
+      nextAction: gate.nextAction,
+    };
+  });
+
+  const rawOverall = Math.round(categories.reduce((sum, category) => sum + category.score, 0) / Math.max(categories.length, 1));
+  const hasOwnerApproval = report.gates.some((gate) => gate.verifiedEvidence.some((item) => /owner approval/i.test(item)));
+  const hasEnforcementProof = report.gates.some((gate) => gate.verifiedEvidence.some((item) => /enforcement test|server-side rbac|entitlement denial/i.test(item)));
+  const caps: string[] = [];
+  let overall = rawOverall;
+  if (!hasOwnerApproval && overall > 80) {
+    overall = 80;
+    caps.push('overall capped at 80 until owner approval evidence exists');
+  }
+
+  const hasBlocked = categories.some((category) => category.status === 'BLOCKED');
+  const hasReview = categories.some((category) => category.status === 'REVIEW');
+  const verdict: ReadinessScore['verdict'] = hasBlocked || !hasEnforcementProof ? 'BLOCKED' : hasReview ? 'REVIEW' : 'PASS';
+  if (!hasEnforcementProof) caps.push('overall verdict cannot be PASS until enforcement proof exists');
+
+  return {
+    overall,
+    verdict,
+    categories,
+    missingEvidence: categories.flatMap((category) => category.blockers.map((blocker) => `${category.id}: ${blocker}`)),
+    caps,
+  };
+}

--- a/lib/dsg/security/authorization-contract.ts
+++ b/lib/dsg/security/authorization-contract.ts
@@ -1,0 +1,27 @@
+export type DsgAuthorizationDecision = {
+  ok: boolean;
+  subjectId: string | null;
+  orgId: string | null;
+  action: string;
+  resource: string;
+  reason: 'ALLOW' | 'MISSING_SUBJECT' | 'MISSING_ORG' | 'ROLE_DENIED' | 'ORG_DENIED' | 'POLICY_MISSING';
+  auditRequired: boolean;
+};
+
+export type DsgAuthorizationInput = {
+  subjectId?: string | null;
+  orgId?: string | null;
+  action: string;
+  resource: string;
+  allowedActions?: string[];
+  sameOrg?: boolean;
+};
+
+export function decideDsgAuthorization(input: DsgAuthorizationInput): DsgAuthorizationDecision {
+  if (!input.subjectId) return { ok: false, subjectId: null, orgId: input.orgId ?? null, action: input.action, resource: input.resource, reason: 'MISSING_SUBJECT', auditRequired: true };
+  if (!input.orgId) return { ok: false, subjectId: input.subjectId, orgId: null, action: input.action, resource: input.resource, reason: 'MISSING_ORG', auditRequired: true };
+  if (input.sameOrg === false) return { ok: false, subjectId: input.subjectId, orgId: input.orgId, action: input.action, resource: input.resource, reason: 'ORG_DENIED', auditRequired: true };
+  if (!input.allowedActions) return { ok: false, subjectId: input.subjectId, orgId: input.orgId, action: input.action, resource: input.resource, reason: 'POLICY_MISSING', auditRequired: true };
+  if (!input.allowedActions.includes(input.action)) return { ok: false, subjectId: input.subjectId, orgId: input.orgId, action: input.action, resource: input.resource, reason: 'ROLE_DENIED', auditRequired: true };
+  return { ok: true, subjectId: input.subjectId, orgId: input.orgId, action: input.action, resource: input.resource, reason: 'ALLOW', auditRequired: true };
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "smoke:marketplace-readiness": "node scripts/dsg-marketplace-readiness-check.mjs",
     "smoke:accessibility-qa": "node scripts/dsg-accessibility-qa-check.mjs",
     "smoke:security-rbac": "node scripts/dsg-security-rbac-check.mjs",
-    "smoke:entitlement": "node scripts/dsg-entitlement-check.mjs"
+    "smoke:entitlement": "node scripts/dsg-entitlement-check.mjs",
+    "smoke:audit-packet": "node scripts/dsg-audit-packet-check.mjs",
+    "smoke:first-value-flow": "node scripts/dsg-first-value-flow-smoke.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",

--- a/scripts/dsg-audit-packet-check.mjs
+++ b/scripts/dsg-audit-packet-check.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+function failSummary(failures, extra = {}) {
+  const summary = {
+    ok: false,
+    checkedAt: new Date().toISOString(),
+    failures,
+    ...extra,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  process.exit(1);
+}
+
+function resolveBaseUrl() {
+  const rawBaseUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+  if (!rawBaseUrl) {
+    failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL is required'], {
+      nextAction: 'Set APP_URL="https://dsg-one-v1.vercel.app" or DSG_ONE_V1_PRODUCTION_URL before running this production smoke.',
+    });
+  }
+
+  try {
+    const baseUrl = new URL(rawBaseUrl);
+    if (baseUrl.protocol !== 'https:') {
+      failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL must use https'], {
+        baseUrl: rawBaseUrl,
+        nextAction: 'Use the deployed HTTPS production URL; localhost and http URLs are not accepted for marketplace audit evidence.',
+      });
+    }
+    return baseUrl.origin;
+  } catch (error) {
+    failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL must be a valid URL'], {
+      baseUrl: rawBaseUrl,
+      error: error instanceof Error ? error.message : String(error),
+      nextAction: 'Provide a valid HTTPS production URL.',
+    });
+  }
+}
+
+const baseUrl = resolveBaseUrl();
+const url = new URL('/api/dsg/marketplace/audit-packet', baseUrl);
+
+try {
+  const response = await fetch(url);
+  const json = await response.json().catch(() => null);
+  const failures = [];
+  if (!response.ok) failures.push(`HTTP ${response.status}`);
+  if (!json?.ok) failures.push('ok must be true');
+  if (json?.product !== 'DSG ONE V1') failures.push('product must be DSG ONE V1');
+  if (!['PASS', 'REVIEW', 'BLOCKED'].includes(json?.finalVerdict)) failures.push('finalVerdict must be PASS, REVIEW, or BLOCKED');
+  if (json?.finalVerdict === 'PASS') failures.push('finalVerdict must not be PASS until approvals/enforcement tests are attached');
+  if (!Array.isArray(json?.missingEvidence)) failures.push('missingEvidence must be an array');
+
+  const summary = {
+    ok: failures.length === 0,
+    url: url.toString(),
+    status: response.status,
+    finalVerdict: json?.finalVerdict,
+    missingEvidenceCount: json?.missingEvidence?.length ?? null,
+    failures,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (failures.length) process.exit(1);
+} catch (error) {
+  failSummary(['fetch failed'], {
+    url: url.toString(),
+    error: error instanceof Error ? error.message : String(error),
+    nextAction: 'Verify the HTTPS deployment is reachable, then rerun smoke:audit-packet.',
+  });
+}

--- a/scripts/dsg-first-value-flow-smoke.mjs
+++ b/scripts/dsg-first-value-flow-smoke.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+function failSummary(failures, extra = {}) {
+  const summary = {
+    ok: false,
+    checkedAt: new Date().toISOString(),
+    failures,
+    ...extra,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  process.exit(1);
+}
+
+function resolveBaseUrl() {
+  const rawBaseUrl = process.env.APP_URL || process.env.DSG_ONE_V1_PRODUCTION_URL;
+  if (!rawBaseUrl) {
+    failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL is required'], {
+      nextAction: 'Set APP_URL="https://dsg-one-v1.vercel.app" or DSG_ONE_V1_PRODUCTION_URL before running this production smoke.',
+    });
+  }
+
+  try {
+    const baseUrl = new URL(rawBaseUrl);
+    if (baseUrl.protocol !== 'https:') {
+      failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL must use https'], {
+        baseUrl: rawBaseUrl,
+        nextAction: 'Use the deployed HTTPS production URL; localhost and http URLs are not accepted for first-value marketplace evidence.',
+      });
+    }
+    return baseUrl.origin;
+  } catch (error) {
+    failSummary(['APP_URL or DSG_ONE_V1_PRODUCTION_URL must be a valid URL'], {
+      baseUrl: rawBaseUrl,
+      error: error instanceof Error ? error.message : String(error),
+      nextAction: 'Provide a valid HTTPS production URL.',
+    });
+  }
+}
+
+const baseUrl = resolveBaseUrl();
+const routes = [
+  '/dsg/app-builder',
+  '/enterprise/readiness',
+  '/enterprise/terms',
+  '/enterprise/privacy',
+  '/enterprise/security',
+  '/enterprise/support',
+  '/enterprise/entitlement',
+  '/enterprise/security-rbac',
+  '/enterprise/accessibility',
+  '/enterprise/market',
+  '/api/dsg/market/agent-app-builder',
+  '/api/dsg/marketplace/audit-packet',
+  '/api/dsg/marketplace/readiness-score',
+];
+const results = [];
+
+for (const route of routes) {
+  const url = new URL(route, baseUrl);
+  try {
+    const response = await fetch(url, { redirect: 'manual' });
+    results.push({ route, status: response.status, ok: response.status >= 200 && response.status < 300 });
+  } catch (error) {
+    results.push({ route, status: 0, ok: false, error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+const failures = results.filter((result) => !result.ok);
+console.log(JSON.stringify({ ok: failures.length === 0, baseUrl, checkedAt: new Date().toISOString(), results, failures }, null, 2));
+if (failures.length) process.exit(1);


### PR DESCRIPTION
### Motivation

- Introduce an evidence-first marketplace and app-builder flow that surfaces missing proof and keeps production claims fail-closed.
- Provide programmatic audit artifacts (audit packet, readiness score) and enforcement contracts for authorization and entitlement to enable repeatable smoke checks and reviewer workflows.
- Add UI pieces (outcome intake and proof panel) so users can create outcome plans and see required next actions and missing evidence before claiming production.

### Description

- Added API routes for planner and market artifacts: `POST /api/dsg/app-builder/outcome`, `GET /api/dsg/market/agent-app-builder`, `GET /api/dsg/marketplace/audit-packet`, and `GET /api/dsg/marketplace/readiness-score` that wire into new library modules.
- Implemented outcome intake and plan generation in `lib/dsg/app-builder/outcome-intake.ts` and created UI `OutcomeIntakePanel` (client) to submit intake; added `AppBuilderProofPanel` component and integrated both into the app builder page `app/dsg/app-builder/page.tsx`.
- Added marketplace templates and market registry support in `lib/dsg/app-builder/templates/template-registry.ts` and market/competitor/direction reports in `lib/dsg/market/agent-app-builder-market.ts`.
- Implemented readiness scoring and audit packet composition in `lib/dsg/marketplace/readiness-score.ts` and `lib/dsg/marketplace/audit-packet.ts` using other market checks (accessibility, entitlement, security RBAC).
- Added enforcement contract helpers `lib/dsg/security/authorization-contract.ts` and `lib/dsg/billing/entitlement-contract.ts` plus accessibility checklist and evidence templates under `docs/` and `docs/evidence/`.
- Added enterprise UI pages for `enterprise/readiness`, `enterprise/accessibility`, and `enterprise/market` and wired new components and reports into those pages.
- Added smoke check scripts `scripts/dsg-audit-packet-check.mjs` and `scripts/dsg-first-value-flow-smoke.mjs` and exposed them in `package.json` along with `smoke:audit-packet` and `smoke:first-value-flow` scripts.
- Added `AGENTS.md` with repo rules and guidance for running the smoke and readiness checks.

### Testing

- Ran `npm run dsg:typecheck` and `npm run lint` against the modified codebase (typecheck and lint completed successfully).
- No automated integration smoke tests were executed as part of this rollout because the new smoke scripts require a reachable `APP_URL`/production origin; scripts were added as `scripts/dsg-audit-packet-check.mjs` and `scripts/dsg-first-value-flow-smoke.mjs` for use against a deployed site.
- Recommend running `APP_URL="https://dsg-one-v1.vercel.app" npm run smoke:first-value-flow` and `npm run smoke:audit-packet` against the deployed instance to validate runtime endpoints and audit packet output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a093571083289345e607e46fa8d0)