### PR TITLE
docs(skillgate): promote lastVerified from local → CI-verified

### DIFF
--- a/docs/skillgate-evidence.json
+++ b/docs/skillgate-evidence.json
@@ -148,11 +148,12 @@
     "npm test -- tests/dsg/agent-skills-pipeline.test.ts",
     "npm run build"
   ],
-  "lastVerified": "2026-05-23T04:07:00Z",
-  "lastVerifiedBy": "local — branch claude/test-coverage-analysis-qbAC3",
-  "lastVerifiedLog": "docs/TEST_EXECUTION_SUMMARY.md",
+  "lastVerified": "2026-05-23T04:15:11Z",
+  "lastVerifiedBy": "GitHub Actions — skillgate-ci.yml — run 26323185657",
+  "lastVerifiedLog": "https://github.com/tdealer01-crypto/dsg-one-v1/actions/runs/26323185657/job/77495915449",
+  "localVerifiedLog": "docs/TEST_EXECUTION_SUMMARY.md",
   "notes": [
-    "lastVerified reflects local run. Replace with CI run date once GitHub Actions are wired.",
+    "lastVerified reflects CI run on main after PR #93 merged.",
     "Lock tests use real temp directories — no fs mocking. Failures reflect actual filesystem behavior.",
     "Run gate tests assert that blocked/needs_review/needs_approval paths never call prepareGovernedToolRequest.",
     "Pipeline test is fully offline — no GitHub API calls made."


### PR DESCRIPTION
## Goal

Update `docs/skillgate-evidence.json` to reflect that SkillGate is now CI-verified, not just locally verified.

## Files changed

| File | Reason |
|---|---|
| `docs/skillgate-evidence.json` | `lastVerified` → CI run timestamp; `lastVerifiedBy` → GitHub Actions job ID; `lastVerifiedLog` → Actions URL |

## Commands run

No code changes. Evidence-only update.

## Pass / fail

| Check | Status |
|---|---|
| SkillGate CI (job 77495915449) | ✓ SUCCESS |
| Public main file visibility | ✓ CONFIRMED — all 5 agent-skills test files visible |
| Other pre-existing CI failures | unchanged (Verify DSG App Builder, Typecheck+Lint, verify) |

## Known limits

Pre-existing failures in other workflows are not addressed in this PR — they were present before PR #93 and are unrelated to SkillGate.

## User-visible benefit

`docs/skillgate-evidence.json` now carries a CI-backed `lastVerified` timestamp and a direct link to the Actions run — anyone auditing the repo sees verifiable evidence, not a self-reported local run.

## Next step

Production smoke: hit `/api/agent-skills/search?q=github+auditor` with a valid workspace token to confirm the route is live.

https://claude.ai/code/session_015u49U1E3TsJjFH7uAniShm

---
_Generated by [Claude Code](https://claude.ai/code/session_015u49U1E3TsJjFH7uAniShm)_