### PR TITLE
feat: marketplace completion — buyer library, creator dashboard, duplicate guard

### DIFF
--- a/app/api/dsg/templates/[id]/purchase/route.ts
+++ b/app/api/dsg/templates/[id]/purchase/route.ts
@@ -9,7 +9,11 @@ import {
 } from '@/lib/dsg/marketplace/template-commission';
 import type { DsgMarketTemplate } from '@/lib/dsg/app-builder/templates/template-registry';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
+  return new Stripe(key);
+}
 
 type TemplateRow = {
   id: string;
@@ -66,6 +70,17 @@ export async function POST(
       return NextResponse.json({ ok: false, error: { code: 'CANNOT_BUY_OWN_TEMPLATE' } }, { status: 422 });
     }
 
+    // Duplicate purchase guard
+    const existing = await readDsgRest<{ sale_id: string }[]>(config, 'dsg_template_sales', {
+      select: 'sale_id',
+      template_id: `eq.${template.id}`,
+      buyer_id: `eq.${actor.actorId}`,
+      status: `neq.REFUNDED`,
+    });
+    if (existing.length > 0) {
+      return NextResponse.json({ ok: false, error: { code: 'ALREADY_PURCHASED' } }, { status: 422 });
+    }
+
     const eligibility = checkTemplateMonetizationEligibility(
       toMarketTemplateShape(template),
       template.price_satang,
@@ -87,7 +102,7 @@ export async function POST(
     });
 
     if (template.price_satang > 0) {
-      const session = await stripe.checkout.sessions.create({
+      const session = await getStripe().checkout.sessions.create({
         mode: 'payment',
         line_items: [
           {

--- a/app/api/dsg/templates/my/purchases/route.ts
+++ b/app/api/dsg/templates/my/purchases/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getDsgSupabaseRpcConfig, readDsgRest } from '@/lib/dsg/server/supabase-rpc';
+
+type SaleRow = {
+  sale_id: string;
+  template_id: string;
+  price_satang: number;
+  created_at: string;
+};
+
+type TemplateRow = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  stack: string[];
+};
+
+export type PurchasedTemplate = {
+  saleId: string;
+  templateId: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  stack: string[];
+  priceSatang: number;
+  priceTHB: number;
+  purchasedAt: string;
+};
+
+export async function GET(req: NextRequest) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'job:read');
+    const config = getDsgSupabaseRpcConfig();
+
+    const sales = await readDsgRest<SaleRow[]>(config, 'dsg_template_sales', {
+      select: 'sale_id,template_id,price_satang,created_at',
+      buyer_id: `eq.${actor.actorId}`,
+      status: 'eq.CLEARED',
+      order: 'created_at.desc',
+    });
+
+    if (sales.length === 0) {
+      return NextResponse.json({ ok: true, data: [] });
+    }
+
+    const templateIds = sales.map((s) => s.template_id).join(',');
+    const templates = await readDsgRest<TemplateRow[]>(config, 'dsg_templates', {
+      select: 'id,slug,name,description,category,stack',
+      id: `in.(${templateIds})`,
+    });
+
+    const templateMap = new Map(templates.map((t) => [t.id, t]));
+
+    const purchases: PurchasedTemplate[] = sales.flatMap((sale) => {
+      const tmpl = templateMap.get(sale.template_id);
+      if (!tmpl) return [];
+      return [
+        {
+          saleId: sale.sale_id,
+          templateId: sale.template_id,
+          slug: tmpl.slug,
+          name: tmpl.name,
+          description: tmpl.description,
+          category: tmpl.category,
+          stack: tmpl.stack ?? [],
+          priceSatang: sale.price_satang,
+          priceTHB: sale.price_satang / 100,
+          purchasedAt: sale.created_at,
+        },
+      ];
+    });
+
+    return NextResponse.json({ ok: true, data: purchases });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'PURCHASES_FETCH_FAILED';
+    const status = message === 'DSG_AUTH_REQUIRED' || message === 'DSG_PERMISSION_DENIED' ? 403 : 500;
+    return NextResponse.json({ ok: false, error: { code: message } }, { status });
+  }
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,7 +1,11 @@
 import Stripe from 'stripe';
 import { getDsgSupabaseRpcConfig, callDsgRpc } from '@/lib/dsg/server/supabase-rpc';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
+  return new Stripe(key);
+}
 
 export async function POST(req: Request) {
   const body = await req.text();
@@ -9,7 +13,7 @@ export async function POST(req: Request) {
 
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+    event = getStripe().webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET ?? '');
   } catch {
     return new Response('Invalid signature', { status: 400 });
   }

--- a/app/dsg/templates/my-payouts/page.tsx
+++ b/app/dsg/templates/my-payouts/page.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import React, { useState, useEffect, useMemo } from 'react';
+import { TrendingUp, Clock, DollarSign, ShoppingBag, Loader2, BarChart2 } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+type Sale = {
+  saleId: string;
+  templateId: string;
+  sellerId: string;
+  buyerId: string;
+  priceSatang: number;
+  commissionRateBps: number;
+  platformFeeSatang: number;
+  creatorPayoutSatang: number;
+  status: string;
+  createdAt: string;
+};
+
+type Summary = {
+  clearedSales: number;
+  pendingSales: number;
+  clearedPayoutSatang: number;
+  pendingPayoutSatang: number;
+  totalRevenueSatang: number;
+  totalPlatformFeeSatang: number;
+  clearedPayoutTHB: number;
+  pendingPayoutTHB: number;
+  totalRevenueTHB: number;
+};
+
+function formatTHB(n: number) {
+  return `฿${n.toLocaleString('th-TH', { minimumFractionDigits: 0 })}`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('th-TH', { day: 'numeric', month: 'short', year: '2-digit' });
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  CLEARED: 'ชำระแล้ว',
+  PENDING: 'รอชำระ',
+  REFUNDED: 'คืนเงิน',
+};
+const STATUS_COLOR: Record<string, string> = {
+  CLEARED: 'text-emerald-400',
+  PENDING: 'text-amber-400',
+  REFUNDED: 'text-red-400',
+};
+
+export default function MyPayoutsPage() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/dsg/templates/my/payouts')
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.ok) {
+          setSummary(res.data.summary);
+          setSales(res.data.recentSales ?? []);
+        } else {
+          setError(res.error?.code ?? 'UNKNOWN_ERROR');
+        }
+      })
+      .catch(() => setError('NETWORK_ERROR'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const chartData = useMemo(() => {
+    const byMonth: Record<string, number> = {};
+    sales
+      .filter((s) => s.status === 'CLEARED')
+      .forEach((s) => {
+        const month = s.createdAt.slice(0, 7);
+        byMonth[month] = (byMonth[month] ?? 0) + s.creatorPayoutSatang / 100;
+      });
+    return Object.entries(byMonth)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, thb]) => ({ month, thb }));
+  }, [sales]);
+
+  if (loading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-400" />
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-400">
+        <p>{error === 'DSG_AUTH_REQUIRED' ? 'กรุณาเข้าสู่ระบบ' : `เกิดข้อผิดพลาด: ${error}`}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 md:px-8">
+      <div className="mx-auto max-w-5xl space-y-8">
+        {/* Header */}
+        <section className="rounded-3xl border border-emerald-500/20 bg-emerald-500/10 p-6 md:p-8">
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-emerald-200">
+            <TrendingUp className="h-3.5 w-3.5" /> Creator Earnings
+          </div>
+          <h1 className="text-3xl font-black tracking-tight md:text-4xl">รายได้ของฉัน</h1>
+          <p className="mt-2 text-sm text-slate-300">ภาพรวมยอดขายและรายได้จาก templates ที่วางขาย</p>
+        </section>
+
+        {/* Stat cards */}
+        {summary && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              {
+                icon: DollarSign,
+                label: 'ยอดโอนแล้ว',
+                value: formatTHB(summary.clearedPayoutTHB),
+                color: 'text-emerald-400',
+                border: 'border-emerald-500/20',
+              },
+              {
+                icon: Clock,
+                label: 'รอโอน',
+                value: formatTHB(summary.pendingPayoutTHB),
+                color: 'text-amber-400',
+                border: 'border-amber-500/20',
+              },
+              {
+                icon: TrendingUp,
+                label: 'ยอดขายรวม',
+                value: formatTHB(summary.totalRevenueTHB),
+                color: 'text-indigo-400',
+                border: 'border-indigo-500/20',
+              },
+              {
+                icon: ShoppingBag,
+                label: 'จำนวนออเดอร์',
+                value: String(summary.clearedSales + summary.pendingSales),
+                color: 'text-violet-400',
+                border: 'border-violet-500/20',
+              },
+            ].map(({ icon: Icon, label, value, color, border }) => (
+              <div key={label} className={`rounded-2xl border ${border} bg-slate-900 p-5`}>
+                <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                  <Icon className={`h-4 w-4 ${color}`} />
+                  {label}
+                </div>
+                <p className={`text-2xl font-black ${color}`}>{value}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Revenue chart */}
+        {chartData.length > 0 && (
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <div className="mb-4 flex items-center gap-2 text-sm font-bold text-slate-300">
+              <BarChart2 className="h-4 w-4 text-emerald-400" /> รายได้รายเดือน (THB)
+            </div>
+            <ResponsiveContainer width="100%" height={180}>
+              <BarChart data={chartData} barSize={28}>
+                <XAxis dataKey="month" tick={{ fill: '#94a3b8', fontSize: 11 }} axisLine={false} tickLine={false} />
+                <YAxis tick={{ fill: '#94a3b8', fontSize: 11 }} axisLine={false} tickLine={false} width={50} />
+                <Tooltip
+                  contentStyle={{ background: '#1e293b', border: '1px solid #334155', borderRadius: 12, color: '#f1f5f9' }}
+                  formatter={(v) => [`฿${Number(v ?? 0).toLocaleString()}`, 'รายได้']}
+                />
+                <Bar dataKey="thb" fill="#34d399" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {/* Recent sales table */}
+        <div className="rounded-2xl border border-slate-800 bg-slate-900 overflow-hidden">
+          <div className="border-b border-slate-800 px-5 py-4">
+            <h2 className="text-sm font-bold text-slate-200">ประวัติการขายล่าสุด</h2>
+          </div>
+          {sales.length === 0 ? (
+            <div className="py-16 text-center text-sm text-slate-500">ยังไม่มียอดขาย</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-800 text-left text-xs font-bold uppercase tracking-wide text-slate-500">
+                    <th className="px-5 py-3">วันที่</th>
+                    <th className="px-5 py-3">ราคา</th>
+                    <th className="px-5 py-3">รายได้ (80%)</th>
+                    <th className="px-5 py-3">สถานะ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sales.map((sale) => (
+                    <tr key={sale.saleId} className="border-b border-slate-800/50 last:border-0 hover:bg-slate-800/30">
+                      <td className="px-5 py-3 text-slate-400">{formatDate(sale.createdAt)}</td>
+                      <td className="px-5 py-3 font-bold text-slate-200">{formatTHB(sale.priceSatang / 100)}</td>
+                      <td className="px-5 py-3 font-bold text-emerald-400">{formatTHB(sale.creatorPayoutSatang / 100)}</td>
+                      <td className={`px-5 py-3 font-bold ${STATUS_COLOR[sale.status] ?? 'text-slate-400'}`}>
+                        {STATUS_LABEL[sale.status] ?? sale.status}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/dsg/templates/my/page.tsx
+++ b/app/dsg/templates/my/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { ArrowRight, BookOpen, Loader2, ShoppingBag } from 'lucide-react';
+
+type PurchasedTemplate = {
+  saleId: string;
+  templateId: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  stack: string[];
+  priceSatang: number;
+  priceTHB: number;
+  purchasedAt: string;
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  SaaS: 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300',
+  Dashboard: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  'AI/Chat': 'border-violet-500/40 bg-violet-500/10 text-violet-300',
+  'E-commerce': 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  'Internal Tools': 'border-slate-500/40 bg-slate-500/10 text-slate-300',
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('th-TH', { day: 'numeric', month: 'short', year: '2-digit' });
+}
+
+function formatPrice(priceSatang: number) {
+  if (priceSatang === 0) return 'ฟรี';
+  return `฿${(priceSatang / 100).toLocaleString('th-TH')}`;
+}
+
+export default function MyTemplatesPage() {
+  const [purchases, setPurchases] = useState<PurchasedTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/dsg/templates/my/purchases')
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.ok) setPurchases(res.data ?? []);
+        else setError(res.error?.code ?? 'UNKNOWN_ERROR');
+      })
+      .catch(() => setError('NETWORK_ERROR'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-400" />
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-400">
+        <p>{error === 'DSG_AUTH_REQUIRED' ? 'กรุณาเข้าสู่ระบบ' : `เกิดข้อผิดพลาด: ${error}`}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 md:px-8">
+      <div className="mx-auto max-w-6xl space-y-8">
+        {/* Header */}
+        <section className="rounded-3xl border border-violet-500/20 bg-violet-500/10 p-6 md:p-8">
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-violet-400/30 bg-violet-400/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-violet-200">
+            <BookOpen className="h-3.5 w-3.5" /> My Library
+          </div>
+          <h1 className="text-3xl font-black tracking-tight md:text-4xl">Templates ของฉัน</h1>
+          <p className="mt-2 text-sm text-slate-300">Templates ที่ซื้อและรับมาทั้งหมด — พร้อมใช้งานใน App Builder</p>
+        </section>
+
+        {/* Count */}
+        {purchases.length > 0 && (
+          <p className="text-sm text-slate-500">{purchases.length} template{purchases.length !== 1 ? 's' : ''}</p>
+        )}
+
+        {/* Empty state */}
+        {purchases.length === 0 && (
+          <div className="flex flex-col items-center justify-center rounded-3xl border border-slate-800 bg-slate-900 py-24 text-center">
+            <ShoppingBag className="mb-4 h-10 w-10 text-slate-600" />
+            <p className="text-lg font-bold text-slate-300">ยังไม่มี templates</p>
+            <p className="mt-1 text-sm text-slate-500">ไปดู templates ที่มีให้เลือก</p>
+            <a
+              href="/dsg/templates"
+              className="mt-6 inline-flex items-center gap-1.5 rounded-2xl bg-indigo-600 px-5 py-3 text-sm font-bold text-white hover:bg-indigo-500"
+            >
+              ดู Templates <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+        )}
+
+        {/* Grid */}
+        {purchases.length > 0 && (
+          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {purchases.map((tmpl) => (
+              <div
+                key={tmpl.saleId}
+                className="flex flex-col rounded-3xl border border-slate-800 bg-slate-900 p-5 transition-colors hover:border-slate-700"
+              >
+                {/* Category badge */}
+                <div className="mb-4 flex items-start justify-between">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-700 bg-slate-800 text-slate-300">
+                    <BookOpen className="h-5 w-5" />
+                  </div>
+                  {tmpl.category && (
+                    <span className={`rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${CATEGORY_COLORS[tmpl.category] ?? 'border-slate-500/40 bg-slate-500/10 text-slate-300'}`}>
+                      {tmpl.category}
+                    </span>
+                  )}
+                </div>
+
+                <h3 className="text-base font-black text-slate-100">{tmpl.name}</h3>
+                <p className="mt-1 flex-1 text-sm leading-6 text-slate-400">{tmpl.description}</p>
+
+                {/* Stack */}
+                <div className="mt-4 flex flex-wrap gap-1.5">
+                  {tmpl.stack.map((tag) => (
+                    <span key={tag} className="rounded-full border border-slate-700 bg-slate-800 px-2.5 py-0.5 text-[11px] text-slate-400">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+
+                {/* Footer */}
+                <div className="mt-5 flex items-center justify-between">
+                  <div className="flex flex-col">
+                    <span className="text-xs text-slate-500">ซื้อเมื่อ {formatDate(tmpl.purchasedAt)}</span>
+                    <span className={`text-xs font-bold ${tmpl.priceSatang === 0 ? 'text-emerald-400' : 'text-slate-400'}`}>
+                      {formatPrice(tmpl.priceSatang)}
+                    </span>
+                  </div>
+                  <a
+                    href={`/dsg/app-builder?template=${tmpl.slug}`}
+                    className="inline-flex items-center gap-1.5 rounded-2xl bg-indigo-600 px-4 py-2 text-xs font-bold text-white hover:bg-indigo-500"
+                  >
+                    Use template <ArrowRight className="h-3.5 w-3.5" />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/dsg/templates/page.tsx
+++ b/app/dsg/templates/page.tsx
@@ -76,7 +76,7 @@ export default function TemplatesPage() {
       const data = await res.json();
       if (data.ok) {
         if (data.data.checkoutRequired && data.data.checkoutUrl) {
-          window.location.href = data.data.checkoutUrl;
+          window.location.assign(data.data.checkoutUrl);
           return;
         } else {
           alert(`ได้รับ template "${template.name}" แล้ว! ไปที่ App Builder เพื่อใช้งาน`);

--- a/supabase/migrations/20260525000003_template_sales_unique_buyer.sql
+++ b/supabase/migrations/20260525000003_template_sales_unique_buyer.sql
@@ -1,0 +1,4 @@
+-- Prevent the same buyer from purchasing the same template more than once
+alter table public.dsg_template_sales
+  add constraint uq_template_sale_buyer_template
+  unique (template_id, buyer_id);


### PR DESCRIPTION
## Goal
ปิดช่องโหว่และเพิ่ม UI ที่ขาดอยู่เพื่อให้ marketplace loop สมบูรณ์: creator เห็นรายได้, buyer เห็น templates ที่ซื้อแล้ว, ป้องกันการซื้อซ้ำ

## Files changed

| File | Reason |
|---|---|
| `supabase/migrations/20260525000003_template_sales_unique_buyer.sql` | UNIQUE(template_id, buyer_id) ป้องกัน duplicate purchase ระดับ DB |
| `app/api/dsg/templates/[id]/purchase/route.ts` | เพิ่ม duplicate check ก่อน buildTemplateSale + lazy-init Stripe |
| `app/api/dsg/templates/my/purchases/route.ts` | ใหม่ — GET buyer's cleared purchases (joins templates by id IN list) |
| `app/dsg/templates/my/page.tsx` | ใหม่ — Buyer Library UI: grid template cards + "Use template" link |
| `app/dsg/templates/my-payouts/page.tsx` | ใหม่ — Creator Dashboard: stat cards, Recharts bar chart, sales table |
| `app/api/webhooks/stripe/route.ts` | Lazy-init Stripe (fix build-time crash) |
| `app/dsg/templates/page.tsx` | window.location.assign() แทน .href (ESLint fix) |

## Commands run
```
npx tsc --noEmit   # 0 errors
npm run lint       # 0 errors
npm run build      # success
```

## Pass/fail
- TypeScript: **PASS**
- ESLint: **PASS**
- Build: **PASS**

## Known limits
- Monthly chart แสดงเฉพาะข้อมูลจาก `recentSales` (max 20 rows) ไม่ใช่ทั้งหมด
- ยังไม่มี refund endpoint (REFUNDED status มีใน DB แต่ไม่มี UI)

## User-visible benefit
- `/dsg/templates/my` — buyer เห็น templates ที่ตัวเองได้รับ/ซื้อ พร้อมปุ่ม "Use template"
- `/dsg/templates/my-payouts` — creator เห็น cleared payout, pending, revenue chart, ตาราง sales
- ซื้อ template เดิมซ้ำไม่ได้แล้ว (return ALREADY_PURCHASED 422)

## Next step
Apply migration `20260525000003` บน Supabase production DB

https://claude.ai/code/session_01Ee4thXGvXVe7nfLhZb62Hx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee4thXGvXVe7nfLhZb62Hx)_