### PR TITLE
feat: harden template marketplace entitlement

### DIFF
--- a/app/api/dsg/templates/[id]/entitlement/route.ts
+++ b/app/api/dsg/templates/[id]/entitlement/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getDsgSupabaseRpcConfig, callDsgRpc } from '@/lib/dsg/server/supabase-rpc';
+
+type EntitlementRpcRow = {
+  allowed: boolean;
+  reason: string;
+  sale_status: string | null;
+  price_satang: number | null;
+};
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'job:read');
+    const { id } = await params;
+
+    const config = getDsgSupabaseRpcConfig();
+    const rows = await callDsgRpc<EntitlementRpcRow[]>(config, 'can_use_template', {
+      p_actor_id: actor.actorId,
+      p_template_id: id,
+    });
+
+    const decision = rows?.[0] ?? {
+      allowed: false,
+      reason: 'TEMPLATE_NOT_FOUND',
+      sale_status: null,
+      price_satang: null,
+    };
+
+    const status = decision.allowed || decision.reason === 'TEMPLATE_NOT_FOUND' ? 200 : 403;
+
+    return NextResponse.json(
+      {
+        ok: true,
+        data: {
+          templateId: id,
+          actorId: actor.actorId,
+          allowed: decision.allowed,
+          reason: decision.reason,
+          saleStatus: decision.sale_status,
+          priceSatang: decision.price_satang,
+          nextAction: decision.allowed
+            ? 'Allow template use.'
+            : 'Require a CLEARED purchase before granting paid template access.',
+        },
+      },
+      { status },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'TEMPLATE_ENTITLEMENT_FAILED';
+    const status = message === 'DSG_AUTH_REQUIRED' || message === 'DSG_PERMISSION_DENIED' ? 403 : 500;
+    return NextResponse.json({ ok: false, error: { code: message } }, { status });
+  }
+}

--- a/app/api/dsg/templates/submit/route.ts
+++ b/app/api/dsg/templates/submit/route.ts
@@ -27,7 +27,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: { code: 'INVALID_PRICE' } }, { status: 400 });
     }
 
-    // Build a minimal DsgMarketTemplate shape to run the eligibility check
+    // Build a minimal DsgMarketTemplate shape to run the eligibility check.
+    // This does not mark the marketplace PASS; it only blocks unsafe monetization inputs.
     const candidate: Pick<DsgMarketTemplate, 'id' | 'sharingMode' | 'blockedUntil'> & Partial<DsgMarketTemplate> = {
       id: body.slug,
       sharingMode: 'public',
@@ -56,19 +57,17 @@ export async function POST(req: NextRequest) {
     }
 
     const config = getDsgSupabaseRpcConfig();
-    const result = await callDsgRpc<{ id: string }>(config, 'submit_template_for_sale', {
+    const templateId = await callDsgRpc<string>(config, 'submit_template_for_sale', {
+      p_actor_id: actor.actorId,
       p_slug: body.slug,
       p_name: body.name,
       p_description: body.description,
       p_category: body.category,
       p_stack: body.stack ?? [],
       p_price_satang: body.price_satang,
-      p_version: body.version ?? '1.0.0',
-      p_seller_id: actor.actorId,
-      p_sharing_mode: 'public',
     });
 
-    return NextResponse.json({ ok: true, data: result }, { status: 201 });
+    return NextResponse.json({ ok: true, data: { id: templateId } }, { status: 201 });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'TEMPLATE_SUBMIT_FAILED';
     const status = message === 'DSG_AUTH_REQUIRED' || message === 'DSG_PERMISSION_DENIED' ? 403 : 500;

--- a/lib/dsg/marketplace/template-entitlement.ts
+++ b/lib/dsg/marketplace/template-entitlement.ts
@@ -1,0 +1,125 @@
+export type TemplateEntitlementSaleStatus = 'PENDING' | 'CLEARED' | 'REFUNDED';
+
+export type TemplateEntitlementReason =
+  | 'TEMPLATE_NOT_FOUND'
+  | 'SELLER_OWNER'
+  | 'TEMPLATE_NOT_PUBLIC'
+  | 'FREE_TEMPLATE'
+  | 'PAYMENT_REQUIRED'
+  | 'PURCHASE_CLEARED'
+  | 'PURCHASE_PENDING'
+  | 'PURCHASE_REFUNDED'
+  | 'PURCHASE_NOT_CLEARED';
+
+export type TemplateEntitlementInput = {
+  actorId: string;
+  template:
+    | {
+        id: string;
+        sellerId: string | null;
+        priceSatang: number;
+        sharingMode: string | null;
+      }
+    | null;
+  latestSale?: { status: TemplateEntitlementSaleStatus | string } | null;
+};
+
+export type TemplateEntitlementDecision = {
+  allowed: boolean;
+  reason: TemplateEntitlementReason;
+  saleStatus: string | null;
+  priceSatang: number | null;
+  nextAction: string;
+};
+
+export function decideTemplateEntitlement(input: TemplateEntitlementInput): TemplateEntitlementDecision {
+  const { actorId, template, latestSale } = input;
+
+  if (!template) {
+    return {
+      allowed: false,
+      reason: 'TEMPLATE_NOT_FOUND',
+      saleStatus: null,
+      priceSatang: null,
+      nextAction: 'Select an existing marketplace template.',
+    };
+  }
+
+  if (template.sellerId === actorId) {
+    return {
+      allowed: true,
+      reason: 'SELLER_OWNER',
+      saleStatus: null,
+      priceSatang: template.priceSatang,
+      nextAction: 'Allow the creator to use their own template.',
+    };
+  }
+
+  if ((template.sharingMode ?? 'public') !== 'public') {
+    return {
+      allowed: false,
+      reason: 'TEMPLATE_NOT_PUBLIC',
+      saleStatus: null,
+      priceSatang: template.priceSatang,
+      nextAction: 'Publish the template before marketplace use.',
+    };
+  }
+
+  if (template.priceSatang <= 0) {
+    return {
+      allowed: true,
+      reason: 'FREE_TEMPLATE',
+      saleStatus: null,
+      priceSatang: template.priceSatang,
+      nextAction: 'Allow access to the free public template.',
+    };
+  }
+
+  if (!latestSale) {
+    return {
+      allowed: false,
+      reason: 'PAYMENT_REQUIRED',
+      saleStatus: null,
+      priceSatang: template.priceSatang,
+      nextAction: 'Start Stripe Checkout before granting access.',
+    };
+  }
+
+  if (latestSale.status === 'CLEARED') {
+    return {
+      allowed: true,
+      reason: 'PURCHASE_CLEARED',
+      saleStatus: latestSale.status,
+      priceSatang: template.priceSatang,
+      nextAction: 'Allow access to the purchased template.',
+    };
+  }
+
+  if (latestSale.status === 'PENDING') {
+    return {
+      allowed: false,
+      reason: 'PURCHASE_PENDING',
+      saleStatus: latestSale.status,
+      priceSatang: template.priceSatang,
+      nextAction: 'Wait for Stripe webhook confirmation before granting access.',
+    };
+  }
+
+  if (latestSale.status === 'REFUNDED') {
+    return {
+      allowed: false,
+      reason: 'PURCHASE_REFUNDED',
+      saleStatus: latestSale.status,
+      priceSatang: template.priceSatang,
+      nextAction: 'Require a new cleared purchase before granting access.',
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: 'PURCHASE_NOT_CLEARED',
+    saleStatus: latestSale.status,
+    priceSatang: template.priceSatang,
+    nextAction: 'Require a CLEARED marketplace sale before granting access.',
+  };
+}

--- a/supabase/migrations/20260527000002_dsg_template_entitlement.sql
+++ b/supabase/migrations/20260527000002_dsg_template_entitlement.sql
@@ -1,0 +1,80 @@
+-- Template Marketplace entitlement guard
+-- Blocks paid template use until the actor is the seller or has a CLEARED purchase.
+
+create index if not exists dsg_template_sales_buyer_template_status_idx
+  on public.dsg_template_sales(buyer_id, template_id, status, created_at desc);
+
+create or replace function can_use_template(
+  p_actor_id uuid,
+  p_template_id uuid
+) returns table(
+  allowed boolean,
+  reason text,
+  sale_status text,
+  price_satang integer
+)
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  v_template record;
+  v_sale record;
+begin
+  select id, seller_id, price_satang, sharing_mode
+    into v_template
+  from public.dsg_templates
+  where id = p_template_id
+  limit 1;
+
+  if not found then
+    return query select false, 'TEMPLATE_NOT_FOUND'::text, null::text, null::integer;
+    return;
+  end if;
+
+  if v_template.seller_id = p_actor_id then
+    return query select true, 'SELLER_OWNER'::text, null::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  if coalesce(v_template.sharing_mode, 'public') <> 'public' then
+    return query select false, 'TEMPLATE_NOT_PUBLIC'::text, null::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  if coalesce(v_template.price_satang, 0) <= 0 then
+    return query select true, 'FREE_TEMPLATE'::text, null::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  select status
+    into v_sale
+  from public.dsg_template_sales
+  where template_id = p_template_id
+    and buyer_id = p_actor_id
+  order by created_at desc
+  limit 1;
+
+  if not found then
+    return query select false, 'PAYMENT_REQUIRED'::text, null::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  if v_sale.status = 'CLEARED' then
+    return query select true, 'PURCHASE_CLEARED'::text, v_sale.status::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  if v_sale.status = 'PENDING' then
+    return query select false, 'PURCHASE_PENDING'::text, v_sale.status::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  if v_sale.status = 'REFUNDED' then
+    return query select false, 'PURCHASE_REFUNDED'::text, v_sale.status::text, v_template.price_satang::integer;
+    return;
+  end if;
+
+  return query select false, 'PURCHASE_NOT_CLEARED'::text, v_sale.status::text, v_template.price_satang::integer;
+end;
+$$;

--- a/supabase/migrations/20260527000002_dsg_template_entitlement.sql
+++ b/supabase/migrations/20260527000002_dsg_template_entitlement.sql
@@ -21,10 +21,10 @@ declare
   v_template record;
   v_sale record;
 begin
-  select id, seller_id, price_satang, sharing_mode
+  select t.id, t.seller_id, t.price_satang, t.sharing_mode
     into v_template
-  from public.dsg_templates
-  where id = p_template_id
+  from public.dsg_templates as t
+  where t.id = p_template_id
   limit 1;
 
   if not found then
@@ -47,12 +47,12 @@ begin
     return;
   end if;
 
-  select status
+  select s.status
     into v_sale
-  from public.dsg_template_sales
-  where template_id = p_template_id
-    and buyer_id = p_actor_id
-  order by created_at desc
+  from public.dsg_template_sales as s
+  where s.template_id = p_template_id
+    and s.buyer_id = p_actor_id
+  order by s.created_at desc
   limit 1;
 
   if not found then

--- a/tests/dsg/template-entitlement.test.ts
+++ b/tests/dsg/template-entitlement.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { decideTemplateEntitlement } from '../../lib/dsg/marketplace/template-entitlement';
+
+const paidTemplate = {
+  id: 'template-1',
+  sellerId: 'seller-1',
+  priceSatang: 49_000,
+  sharingMode: 'public',
+};
+
+describe('decideTemplateEntitlement', () => {
+  it('allows the seller to use their own template', () => {
+    const decision = decideTemplateEntitlement({ actorId: 'seller-1', template: paidTemplate });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('SELLER_OWNER');
+  });
+
+  it('allows free public templates without a purchase', () => {
+    const decision = decideTemplateEntitlement({
+      actorId: 'buyer-1',
+      template: { ...paidTemplate, sellerId: 'seller-1', priceSatang: 0 },
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('FREE_TEMPLATE');
+  });
+
+  it('blocks paid templates when no purchase exists', () => {
+    const decision = decideTemplateEntitlement({ actorId: 'buyer-1', template: paidTemplate });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('PAYMENT_REQUIRED');
+  });
+
+  it('blocks pending purchases until Stripe webhook clears the sale', () => {
+    const decision = decideTemplateEntitlement({
+      actorId: 'buyer-1',
+      template: paidTemplate,
+      latestSale: { status: 'PENDING' },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('PURCHASE_PENDING');
+    expect(decision.nextAction).toContain('Stripe webhook');
+  });
+
+  it('allows cleared purchases', () => {
+    const decision = decideTemplateEntitlement({
+      actorId: 'buyer-1',
+      template: paidTemplate,
+      latestSale: { status: 'CLEARED' },
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('PURCHASE_CLEARED');
+  });
+
+  it('blocks refunded purchases', () => {
+    const decision = decideTemplateEntitlement({
+      actorId: 'buyer-1',
+      template: paidTemplate,
+      latestSale: { status: 'REFUNDED' },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('PURCHASE_REFUNDED');
+  });
+
+  it('blocks non-public templates for non-sellers', () => {
+    const decision = decideTemplateEntitlement({
+      actorId: 'buyer-1',
+      template: { ...paidTemplate, sharingMode: 'private' },
+      latestSale: { status: 'CLEARED' },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('TEMPLATE_NOT_PUBLIC');
+  });
+
+  it('blocks missing templates', () => {
+    const decision = decideTemplateEntitlement({ actorId: 'buyer-1', template: null });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('TEMPLATE_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
## Summary

- Add production migration `can_use_template(actor_id, template_id)` to enforce paid template access.
- Add `GET /api/dsg/templates/[id]/entitlement` so template use flows can verify entitlement before granting access.
- Add unit-tested entitlement decision helper for seller/free/cleared/pending/refunded/unpaid cases.
- Fix `/api/dsg/templates/submit` RPC arguments to match the actual `submit_template_for_sale(p_actor_id, ...)` migration signature.

## Production DB evidence

Applied migration to Supabase project `zeyguilldygozufpgxms`.

Verified real DB scenarios:

```json
[
  { "scenario": "seller", "allowed": true, "reason": "SELLER_OWNER", "sale_status": null, "price_satang": 49000 },
  { "scenario": "unpaid_buyer", "allowed": false, "reason": "PAYMENT_REQUIRED", "sale_status": null, "price_satang": 49000 }
]
```

## DSG readiness state

REVIEW, not PASS.

This PR adds a real entitlement guard and negative unpaid-buyer denial proof. It does not claim full MARKETPLACE_PASS because the following evidence is still required:

- completed paid purchase proving `PENDING -> CLEARED`
- Stripe webhook delivery 200 from a real checkout event
- buyer can use template after `CLEARED`
- quota denial smoke for MCP API key billing
- payout ledger / owner approval / accessibility evidence

## Validation status

- Read `AGENTS.md` before edits.
- Attempted GraphMap status, but Vercel connector fetch was blocked by tool safety before reaching endpoint; fallback was reading concrete repo files directly.
- Supabase production RPC tested with real rows.
- Unit tests added but not executed in this environment.
