### PR TITLE
fix: restore @vitest/coverage-v8 for npm run test:coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "9.39.1",
     "eslint-config-next": "16.0.8",
     "firebase-tools": "^15.0.0",


### PR DESCRIPTION
## Summary
- Re-adds `@vitest/coverage-v8: ^3.2.4` to devDependencies

## Root cause
`vitest.config.ts` specifies `coverage.provider: 'v8'`, which requires `@vitest/coverage-v8` at runtime. The package was accidentally removed during the previous session's revert of the Stryker/mutation-testing changes. Without it, `npm run test:coverage` fails immediately and the `Emit CCVS unit evidence envelope` CI job fails.

## What this fixes
- `Emit CCVS unit evidence envelope` job in `ccvs-evidence.yml`

## What is NOT fixed here (pre-existing, unrelated to CCVS work)
- `Typecheck + Lint + DSG checks` — failing since PR #110 (MCP billing, 2026-05-26)
- `verify` — same root cause

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGL2yBPbUg9WrjvvTDCP3v)_