### PR TITLE
fix: resolve Stripe Invoice.parent TypeScript cast error in webhook

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -53,8 +53,10 @@ export async function POST(req: Request) {
 
   if (event.type === 'invoice.paid') {
     const invoice = event.data.object as Stripe.Invoice;
-    const parent = invoice.parent as { type?: string; subscription_details?: { subscription?: string } } | null;
-    const subscriptionId = parent?.subscription_details?.subscription ?? null;
+    const subRaw = invoice.parent?.subscription_details?.subscription;
+    const subscriptionId = subRaw
+      ? (typeof subRaw === 'string' ? subRaw : subRaw.id)
+      : null;
 
     if (subscriptionId && invoice.period_start && invoice.period_end) {
       await callDsgRpc(config, 'renew_mcp_subscription_period', {


### PR DESCRIPTION
## Root cause\n\nStripe SDK 22.x types `Invoice.parent` as `Stripe.Invoice.Parent | null`, where `Parent.subscription_details.subscription` is `string | Stripe.Subscription`. The previous code cast `invoice.parent` to a custom struct, which fails `tsc --noEmit` because neither type sufficiently overlaps with the other:\n\n```\nConversion of type 'Stripe.Invoice.Parent | null' to type '{ ... }' may be a mistake\nbecause neither type sufficiently overlaps with the other.\n```\n\nThis is the root cause of the pre-existing `Typecheck + Lint + DSG checks` failure since PR #110.\n\n## Fix\n\nAccess `invoice.parent` via the proper Stripe-typed path and use a `typeof` guard to extract the subscription ID from either `string` or `Stripe.Subscription`:\n\n```ts\nconst subRaw = invoice.parent?.subscription_details?.subscription;\nconst subscriptionId = subRaw\n  ? (typeof subRaw === 'string' ? subRaw : subRaw.id)\n  : null;\n```\n\nNo logic change — same runtime behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGL2yBPbUg9WrjvvTDCP3v)_